### PR TITLE
Primitives: Combine assignments

### DIFF
--- a/contrib/devtools/bitcoin-tidy/CMakeLists.txt
+++ b/contrib/devtools/bitcoin-tidy/CMakeLists.txt
@@ -25,8 +25,14 @@ find_program(CLANG_TIDY_EXE REQUIRED NAMES "clang-tidy-${LLVM_VERSION_MAJOR}" "c
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
 
-add_library(bitcoin-tidy MODULE bitcoin-tidy.cpp nontrivial-threadlocal.cpp)
+add_library(bitcoin-tidy MODULE)
 target_include_directories(bitcoin-tidy SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
+
+target_sources(bitcoin-tidy PRIVATE
+    bitcoin-tidy.cpp
+    combine-assignments.cpp
+    nontrivial-threadlocal.cpp
+)
 
 # Disable RTTI and exceptions as necessary
 if (MSVC)

--- a/contrib/devtools/bitcoin-tidy/bitcoin-tidy.cpp
+++ b/contrib/devtools/bitcoin-tidy/bitcoin-tidy.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "combine-assignments.h"
 #include "nontrivial-threadlocal.h"
 
 #include <clang-tidy/ClangTidyModule.h>
@@ -11,6 +12,7 @@ class BitcoinModule final : public clang::tidy::ClangTidyModule
 public:
     void addCheckFactories(clang::tidy::ClangTidyCheckFactories& CheckFactories) override
     {
+        CheckFactories.registerCheck<CombineAssignments>("bitcoin-combine-assignments");
         CheckFactories.registerCheck<bitcoin::NonTrivialThreadLocal>("bitcoin-nontrivial-threadlocal");
     }
 };

--- a/contrib/devtools/bitcoin-tidy/combine-assignments.cpp
+++ b/contrib/devtools/bitcoin-tidy/combine-assignments.cpp
@@ -1,0 +1,183 @@
+#include "combine-assignments.h"
+
+#include <clang/AST/ExprObjC.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Lex/Lexer.h>
+
+#include <cstddef>
+#include <optional>
+
+namespace {
+
+using namespace clang;
+using namespace clang::ast_matchers;
+
+struct AnnotationInfo {
+  unsigned Index;
+  unsigned Total;
+};
+
+std::optional<AnnotationInfo> GetAnnotationInfo(FieldDecl const *FD) {
+  auto const *Attr = FD->getAttr<AnnotateAttr>();
+  if (!Attr)
+    return std::nullopt;
+
+  StringRef Annotation = Attr->getAnnotation();
+  if (!Annotation.consume_front("constructor-argument:"))
+    return std::nullopt;
+
+  auto [IdxStr, TotalStr] = Annotation.split('/');
+
+  unsigned Idx, Total;
+  if (IdxStr.getAsInteger(10, Idx) || TotalStr.getAsInteger(10, Total))
+    return std::nullopt; // parse error
+
+  if (Idx == 0 || Idx > Total)
+    return std::nullopt; // 1-based index out of range
+
+  return AnnotationInfo{Idx - 1, Total}; // convert to 0-based
+}
+
+struct AssignmentInfo {
+  MemberExpr const *ME = nullptr;
+  Expr const *Base = nullptr;
+  Expr const *RHS = nullptr;
+  unsigned Index = 0;
+  unsigned Total = 0;
+};
+
+// Given an assignment's LHS and RHS expressions, returns the annotated
+// field assignment info if LHS is base.member with an annotated field.
+std::optional<AssignmentInfo> ExtractAssignment(Expr const *LHS,
+                                                Expr const *RHS) {
+  auto *ME = dyn_cast<MemberExpr>(LHS->IgnoreParenImpCasts());
+  if (!ME)
+    return std::nullopt;
+
+  auto *FD = dyn_cast<FieldDecl>(ME->getMemberDecl());
+  if (!FD)
+    return std::nullopt;
+
+  auto Info = GetAnnotationInfo(FD);
+  if (!Info)
+    return std::nullopt;
+
+  return AssignmentInfo{ME, ME->getBase()->IgnoreParenImpCasts(), RHS,
+                        Info->Index, Info->Total};
+}
+
+std::optional<AssignmentInfo> GetAssignment(Stmt const *S) {
+  // Built-in assignment: base.member = rhs
+  if (auto *BO = dyn_cast<BinaryOperator>(S))
+    if (BO->isAssignmentOp())
+      return ExtractAssignment(BO->getLHS(), BO->getRHS());
+
+  // Strip a surrounding expression statement.
+  if (auto *E = dyn_cast<ExprWithCleanups>(S))
+    S = E->getSubExpr();
+
+  // Overloaded operator=: base.member = rhs
+  if (auto *Op = dyn_cast<CXXOperatorCallExpr>(S))
+    if (Op->getOperator() == OO_Equal)
+      return ExtractAssignment(Op->getArg(0), Op->getArg(1));
+
+  return std::nullopt;
+}
+
+/// Convenience: get the source text of an expression.
+std::string GetText(Expr const *E, SourceManager const &SM,
+                    LangOptions const &LO) {
+  CharSourceRange Range = CharSourceRange::getTokenRange(E->getSourceRange());
+  return Lexer::getSourceText(Range, SM, LO).str();
+}
+
+/// Infer the constructor name (class name) from the base expression's type.
+/// Returns an empty string if the type is not a CXXRecordDecl.
+std::string GetClassName(Expr const *Base) {
+  auto const *Record = Base->getType().getCanonicalType()->getAsCXXRecordDecl();
+  return Record ? Record->getName().str() : std::string{};
+}
+
+} // namespace
+
+void CombineAssignments::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(compoundStmt().bind("body"), this);
+}
+
+void CombineAssignments::check(MatchFinder::MatchResult const &Result) {
+  auto const *Body = Result.Nodes.getNodeAs<CompoundStmt>("body");
+  if (!Body)
+    return;
+
+  auto &SM = *Result.SourceManager;
+  auto const &LO = Result.Context->getLangOpts();
+  llvm::SmallVector<Stmt const *, 16> Stmts(Body->body());
+
+  for (size_t i = 0; i < Stmts.size(); ++i) {
+    std::vector<std::optional<AssignmentInfo>> Members;
+    auto AddMember = [&](AssignmentInfo Info) {
+      if (Members.size() < Info.Total)
+        Members.resize(Info.Total);
+      Members[Info.Index] = Info;
+    };
+
+    auto First = GetAssignment(Stmts[i]);
+    if (!First)
+      continue;
+
+    std::string BaseText = GetText(First->Base, SM, LO);
+
+    AddMember(*First);
+
+    size_t LastStmt = i;
+
+    for (size_t j = i + 1; j < Stmts.size(); ++j) {
+      auto A = GetAssignment(Stmts[j]);
+      if (!A)
+        break;
+
+      if (GetText(A->Base, SM, LO) != BaseText)
+        break;
+
+      AddMember(*A);
+      LastStmt = j;
+    }
+
+    auto IsComplete = [&]() {
+      if (Members.size() < 2)
+        return false;
+      for (unsigned k = 0; k < Members.size(); ++k) {
+        if (!Members[k])
+          return false;
+        if (Members.size() < Members[k]->Total)
+          return false;
+      }
+      return true;
+    };
+
+    if (!IsComplete())
+      continue;
+
+    std::string ClassName = GetClassName(First->Base);
+    if (ClassName.empty())
+      continue;
+
+    std::string Args;
+    for (unsigned k = 0; k < Members.size(); ++k) {
+      if (k > 0)
+        Args += ", ";
+      Args += GetText(Members[k]->RHS, SM, LO);
+    }
+
+    std::string Replacement = BaseText + " = " + ClassName + "(" + Args + ")";
+
+    CharSourceRange ReplaceRange = CharSourceRange::getTokenRange(
+        SourceRange(Stmts[i]->getBeginLoc(), Stmts[LastStmt]->getEndLoc()));
+
+    diag(Stmts[i]->getBeginLoc(),
+         "replace separate member assignments to %0 with a constructor call")
+        << ClassName << FixItHint::CreateReplacement(ReplaceRange, Replacement);
+
+    i = LastStmt;
+  }
+}

--- a/contrib/devtools/bitcoin-tidy/combine-assignments.h
+++ b/contrib/devtools/bitcoin-tidy/combine-assignments.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <clang-tidy/ClangTidyCheck.h>
+
+class CombineAssignments : public clang::tidy::ClangTidyCheck {
+public:
+  using ClangTidyCheck::ClangTidyCheck;
+
+private:
+  void registerMatchers(clang::ast_matchers::MatchFinder *Finder) override;
+  void check(clang::ast_matchers::MatchFinder::MatchResult const &Res) override;
+};

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -24,4 +24,13 @@
 #  error No known always_inline attribute for this platform.
 #endif
 
+#if defined(__clang__)
+#  if __has_attribute(annotate)
+#    define CONSTRUCTOR_ARGUMENT(INDEX, TOTAL) [[clang::annotate("constructor-argument:" #INDEX "/" #TOTAL)]]
+#  endif
+#endif
+#ifndef CONSTRUCTOR_ARGUMENT
+#  define CONSTRUCTOR_ARGUMENT(INDEX, TOTAL)
+#endif
+
 #endif // BITCOIN_ATTRIBUTES_H

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -34,14 +34,11 @@ static void CCoinsCaching(benchmark::Bench& bench)
 
     CMutableTransaction t1;
     t1.vin.resize(3);
-    t1.vin[0].prevout.hash = dummyTransactions[0].GetHash();
-    t1.vin[0].prevout.n = 1;
+    t1.vin[0].prevout = COutPoint(dummyTransactions[0].GetHash(), 1);
     t1.vin[0].scriptSig << std::vector<unsigned char>(65, 0);
-    t1.vin[1].prevout.hash = dummyTransactions[1].GetHash();
-    t1.vin[1].prevout.n = 0;
+    t1.vin[1].prevout = COutPoint(dummyTransactions[1].GetHash(), 0);
     t1.vin[1].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
-    t1.vin[2].prevout.hash = dummyTransactions[1].GetHash();
-    t1.vin[2].prevout.n = 1;
+    t1.vin[2].prevout = COutPoint(dummyTransactions[1].GetHash(), 1);
     t1.vin[2].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
     t1.vout.resize(2);
     t1.vout[0].nValue = 90 * COIN;

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -49,14 +49,12 @@ static void DuplicateInputs(benchmark::Bench& bench)
     coinbaseTx.vin.resize(1);
     coinbaseTx.vin[0].prevout.SetNull();
     coinbaseTx.vout.resize(1);
-    coinbaseTx.vout[0].scriptPubKey = SCRIPT_PUB;
-    coinbaseTx.vout[0].nValue = GetBlockSubsidy(nHeight, chainparams.GetConsensus());
+    coinbaseTx.vout[0] = CTxOut(GetBlockSubsidy(nHeight, chainparams.GetConsensus()), SCRIPT_PUB);
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
 
 
     naughtyTx.vout.resize(1);
-    naughtyTx.vout[0].nValue = 0;
-    naughtyTx.vout[0].scriptPubKey = SCRIPT_PUB;
+    naughtyTx.vout[0] = CTxOut(0, SCRIPT_PUB);
 
     uint64_t n_inputs = (((MAX_BLOCK_SERIALIZED_SIZE / WITNESS_SCALE_FACTOR) - (CTransaction(coinbaseTx).ComputeTotalSize() + CTransaction(naughtyTx).ComputeTotalSize())) / 41) - 100;
     for (uint64_t x = 0; x < (n_inputs - 1); ++x) {

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -44,16 +44,14 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx1.vin[0].scriptSig = CScript() << OP_1;
     tx1.vin[0].scriptWitness.stack.push_back({1});
     tx1.vout.resize(1);
-    tx1.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
-    tx1.vout[0].nValue = 10 * COIN;
+    tx1.vout[0] = CTxOut(10 * COIN, CScript() << OP_1 << OP_EQUAL);
 
     CMutableTransaction tx2 = CMutableTransaction();
     tx2.vin.resize(1);
     tx2.vin[0].scriptSig = CScript() << OP_2;
     tx2.vin[0].scriptWitness.stack.push_back({2});
     tx2.vout.resize(1);
-    tx2.vout[0].scriptPubKey = CScript() << OP_2 << OP_EQUAL;
-    tx2.vout[0].nValue = 10 * COIN;
+    tx2.vout[0] = CTxOut(10 * COIN, CScript() << OP_2 << OP_EQUAL);
 
     CMutableTransaction tx3 = CMutableTransaction();
     tx3.vin.resize(1);
@@ -61,8 +59,7 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx3.vin[0].scriptSig = CScript() << OP_2;
     tx3.vin[0].scriptWitness.stack.push_back({3});
     tx3.vout.resize(1);
-    tx3.vout[0].scriptPubKey = CScript() << OP_3 << OP_EQUAL;
-    tx3.vout[0].nValue = 10 * COIN;
+    tx3.vout[0] = CTxOut(10 * COIN, CScript() << OP_3 << OP_EQUAL);
 
     CMutableTransaction tx4 = CMutableTransaction();
     tx4.vin.resize(2);
@@ -73,10 +70,8 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx4.vin[1].scriptSig = CScript() << OP_4;
     tx4.vin[1].scriptWitness.stack.push_back({4});
     tx4.vout.resize(2);
-    tx4.vout[0].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
-    tx4.vout[0].nValue = 10 * COIN;
-    tx4.vout[1].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
-    tx4.vout[1].nValue = 10 * COIN;
+    tx4.vout[0] = CTxOut(10 * COIN, CScript() << OP_4 << OP_EQUAL);
+    tx4.vout[1] = CTxOut(10 * COIN, CScript() << OP_4 << OP_EQUAL);
 
     CMutableTransaction tx5 = CMutableTransaction();
     tx5.vin.resize(2);
@@ -87,10 +82,8 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx5.vin[1].scriptSig = CScript() << OP_5;
     tx5.vin[1].scriptWitness.stack.push_back({5});
     tx5.vout.resize(2);
-    tx5.vout[0].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
-    tx5.vout[0].nValue = 10 * COIN;
-    tx5.vout[1].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
-    tx5.vout[1].nValue = 10 * COIN;
+    tx5.vout[0] = CTxOut(10 * COIN, CScript() << OP_5 << OP_EQUAL);
+    tx5.vout[1] = CTxOut(10 * COIN, CScript() << OP_5 << OP_EQUAL);
 
     CMutableTransaction tx6 = CMutableTransaction();
     tx6.vin.resize(2);
@@ -101,10 +94,8 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx6.vin[1].scriptSig = CScript() << OP_6;
     tx6.vin[1].scriptWitness.stack.push_back({6});
     tx6.vout.resize(2);
-    tx6.vout[0].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
-    tx6.vout[0].nValue = 10 * COIN;
-    tx6.vout[1].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
-    tx6.vout[1].nValue = 10 * COIN;
+    tx6.vout[0] = CTxOut(10 * COIN, CScript() << OP_6 << OP_EQUAL);
+    tx6.vout[1] = CTxOut(10 * COIN, CScript() << OP_6 << OP_EQUAL);
 
     CMutableTransaction tx7 = CMutableTransaction();
     tx7.vin.resize(2);
@@ -115,10 +106,8 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx7.vin[1].scriptSig = CScript() << OP_6;
     tx7.vin[1].scriptWitness.stack.push_back({6});
     tx7.vout.resize(2);
-    tx7.vout[0].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
-    tx7.vout[0].nValue = 10 * COIN;
-    tx7.vout[1].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
-    tx7.vout[1].nValue = 10 * COIN;
+    tx7.vout[0] = CTxOut(10 * COIN, CScript() << OP_7 << OP_EQUAL);
+    tx7.vout[1] = CTxOut(10 * COIN, CScript() << OP_7 << OP_EQUAL);
 
     CTxMemPool& pool = *Assert(testing_setup->m_node.mempool);
     LOCK2(cs_main, pool.cs);

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -54,8 +54,7 @@ static std::vector<CTransactionRef> CreateCoinCluster(FastRandomContext& det_ran
         tx.vin[0].scriptWitness.stack.push_back(CScriptNum(x).getvch());
         tx.vout.resize(det_rand.randrange(10)+2);
         for (auto& out : tx.vout) {
-            out.scriptPubKey = CScript() << CScriptNum(tx_counter) << OP_EQUAL;
-            out.nValue = 10 * COIN;
+            out = CTxOut(10 * COIN, CScript() << CScriptNum(tx_counter) << OP_EQUAL);
         }
         ordered_coins.emplace_back(MakeTransactionRef(tx));
         available_coins.emplace_back(ordered_coins.back(), tx_counter++);
@@ -83,8 +82,7 @@ static std::vector<CTransactionRef> CreateCoinCluster(FastRandomContext& det_ran
             }
             tx.vout.resize(det_rand.randrange(10)+2);
             for (auto& out : tx.vout) {
-                out.scriptPubKey = CScript() << CScriptNum(tx_counter) << OP_EQUAL;
-                out.nValue = 10 * COIN;
+                out = CTxOut(10 * COIN, CScript() << CScriptNum(tx_counter) << OP_EQUAL);
             }
         }
         ordered_coins.emplace_back(MakeTransactionRef(tx));

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -37,8 +37,7 @@ static void RpcMempool(benchmark::Bench& bench)
         tx.vin[0].scriptSig = CScript() << OP_1;
         tx.vin[0].scriptWitness.stack.push_back({1});
         tx.vout.resize(1);
-        tx.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
-        tx.vout[0].nValue = i;
+        tx.vout[0] = CTxOut(i, CScript() << OP_1 << OP_EQUAL);
         const CTransactionRef tx_r{MakeTransactionRef(tx)};
         AddTx(tx_r, /*fee=*/i, pool);
     }

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -75,11 +75,9 @@ void generateFakeBlock(const CChainParams& params,
     coinbase_tx.vin.resize(1);
     coinbase_tx.vin[0].prevout.SetNull();
     coinbase_tx.vout.resize(2);
-    coinbase_tx.vout[0].scriptPubKey = coinbase_out_script;
-    coinbase_tx.vout[0].nValue = 48 * COIN;
+    coinbase_tx.vout[0] = CTxOut(48 * COIN, coinbase_out_script);
     coinbase_tx.vin[0].scriptSig = CScript() << ++tip.tip_height << OP_0;
-    coinbase_tx.vout[1].scriptPubKey = coinbase_out_script; // extra output
-    coinbase_tx.vout[1].nValue = 1 * COIN;
+    coinbase_tx.vout[1] = CTxOut(1 * COIN, coinbase_out_script);
 
     // Fill the coinbase with outputs that don't belong to the wallet in order to benchmark
     // AvailableCoins' behavior with unnecessary TXOs

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -643,8 +643,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
                     throw std::runtime_error(err);
                 }
                 Coin newcoin;
-                newcoin.out.scriptPubKey = scriptPubKey;
-                newcoin.out.nValue = MAX_MONEY;
+                newcoin.out = CTxOut(MAX_MONEY, scriptPubKey);
                 if (prevOut.exists("amount")) {
                     newcoin.out.nValue = AmountFromValue(prevOut["amount"]);
                 }

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -41,8 +41,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     txNew.vin.resize(1);
     txNew.vout.resize(1);
     txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
-    txNew.vout[0].nValue = genesisReward;
-    txNew.vout[0].scriptPubKey = genesisOutputScript;
+    txNew.vout[0] = CTxOut(genesisReward, genesisOutputScript);
 
     CBlock genesis;
     genesis.nTime    = nTime;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -28,8 +28,8 @@
 class COutPoint
 {
 public:
-    Txid hash;
-    uint32_t n;
+    CONSTRUCTOR_ARGUMENT(1, 2) Txid hash;
+    CONSTRUCTOR_ARGUMENT(2, 2) uint32_t n;
 
     static constexpr uint32_t NULL_INDEX = std::numeric_limits<uint32_t>::max();
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -61,9 +61,9 @@ public:
 class CTxIn
 {
 public:
-    COutPoint prevout;
-    CScript scriptSig;
-    uint32_t nSequence;
+    CONSTRUCTOR_ARGUMENT(1, 3) COutPoint prevout;
+    CONSTRUCTOR_ARGUMENT(2, 3) CScript scriptSig;
+    CONSTRUCTOR_ARGUMENT(3, 3) uint32_t nSequence;
     CScriptWitness scriptWitness; //!< Only serialized through CTransaction
 
     /**

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -139,8 +139,8 @@ public:
 class CTxOut
 {
 public:
-    CAmount nValue;
-    CScript scriptPubKey;
+    CONSTRUCTOR_ARGUMENT(1, 2) CAmount nValue;
+    CONSTRUCTOR_ARGUMENT(2, 2) CScript scriptPubKey;
 
     CTxOut()
     {

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -138,8 +138,7 @@ std::optional<CMutableTransaction> PartiallySignedTransaction::GetUnsignedTx() c
     }
     for (const PSBTOutput& output : outputs) {
         CTxOut txout;
-        txout.nValue = output.amount;
-        txout.scriptPubKey = output.script;
+        txout = CTxOut(output.amount, output.script);
         mtx.vout.push_back(txout);
     }
     return mtx;

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -132,8 +132,7 @@ std::optional<CMutableTransaction> PartiallySignedTransaction::GetUnsignedTx() c
     uint32_t max_sequence = CTxIn::SEQUENCE_FINAL;
     for (const PSBTInput& input : inputs) {
         CTxIn txin;
-        txin.prevout.hash = input.prev_txid;
-        txin.prevout.n = input.prev_out;
+        txin.prevout = COutPoint(input.prev_txid, input.prev_out);
         txin.nSequence = input.sequence.value_or(max_sequence);
         mtx.vin.push_back(txin);
     }

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -227,8 +227,7 @@ void ParsePrevouts(const UniValue& prevTxsUnival, FlatSigningProvider* keystore,
                     throw JSONRPCError(RPC_DESERIALIZATION_ERROR, err);
                 }
                 Coin newcoin;
-                newcoin.out.scriptPubKey = scriptPubKey;
-                newcoin.out.nValue = MAX_MONEY;
+                newcoin.out = CTxOut(MAX_MONEY, scriptPubKey);
                 if (prevOut.exists("amount")) {
                     newcoin.out.nValue = AmountFromValue(prevOut.find_value("amount"));
                 }

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -38,14 +38,12 @@ static CBlock BuildBlockTestCase(FastRandomContext& ctx) {
     block.hashPrevBlock = ctx.rand256();
     block.nBits = 0x207fffff;
 
-    tx.vin[0].prevout.hash = Txid::FromUint256(ctx.rand256());
-    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout = COutPoint(Txid::FromUint256(ctx.rand256()), 0);
     block.vtx[1] = MakeTransactionRef(tx);
 
     tx.vin.resize(10);
     for (size_t i = 0; i < tx.vin.size(); i++) {
-        tx.vin[i].prevout.hash = Txid::FromUint256(ctx.rand256());
-        tx.vin[i].prevout.n = 0;
+        tx.vin[i].prevout = COutPoint(Txid::FromUint256(ctx.rand256()), 0);
     }
     block.vtx[2] = MakeTransactionRef(tx);
 
@@ -321,8 +319,7 @@ BOOST_AUTO_TEST_CASE(ReceiveWithExtraTransactions) {
     auto rand_ctx(FastRandomContext(uint256{42}));
 
     CMutableTransaction mtx = BuildTransactionTestCase();
-    mtx.vin[0].prevout.hash = Txid::FromUint256(rand_ctx.rand256());
-    mtx.vin[0].prevout.n = 0;
+    mtx.vin[0].prevout = COutPoint(Txid::FromUint256(rand_ctx.rand256()), 0);
     const CTransactionRef non_block_tx = MakeTransactionRef(std::move(mtx));
 
     CBlock block(BuildBlockTestCase(rand_ctx));

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -208,9 +208,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
         const auto script_wit_stack = std::vector<std::vector<uint8_t>>{WITNESS_STACK_ELEM_OP_TRUE};
 
         CTxIn in;
-        in.prevout = outpoint;
-        in.nSequence = sequence;
-        in.scriptSig = script_sig;
+        in = CTxIn(outpoint, script_sig, sequence);
         in.scriptWitness.stack = script_wit_stack;
         tx_mut.vin.push_back(in);
 

--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -252,8 +252,7 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
         coinbase_tx.vin[0].prevout.SetNull();
         coinbase_tx.vin[0].scriptSig = CScript() << height << OP_0;
         coinbase_tx.vout.resize(1);
-        coinbase_tx.vout[0].scriptPubKey = CScript() << OP_TRUE;
-        coinbase_tx.vout[0].nValue = COIN;
+        coinbase_tx.vout[0] = CTxOut(COIN, CScript() << OP_TRUE);
         block->vtx.push_back(MakeTransactionRef(coinbase_tx));
 
         const auto mempool_size = mempool.size();

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -57,8 +57,7 @@ struct PrecomputedData
             const uint8_t ser[4] = {uint8_t(idx), uint8_t(idx >> 8), uint8_t(idx >> 16), uint8_t(idx >> 24)};
             uint256 txid;
             CSHA256().Write(PREFIX_O, 1).Write(ser, sizeof(ser)).Finalize(txid.begin());
-            outpoints[i].hash = Txid::FromUint256(txid);
-            outpoints[i].n = i;
+            outpoints[i] = COutPoint(Txid::FromUint256(txid), i);
             tx.vin.emplace_back(outpoints[i]);
         }
         block.vtx.push_back(MakeTransactionRef(tx));

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -433,9 +433,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
                     const auto script_wit_stack = fuzzed_data_provider.ConsumeBool() ? P2WSH_EMPTY_TRUE_STACK : P2WSH_EMPTY_TWO_STACK;
 
                     CTxIn in;
-                    in.prevout = outpoint;
-                    in.nSequence = sequence;
-                    in.scriptSig = script_sig;
+                    in = CTxIn(outpoint, script_sig, sequence);
                     in.scriptWitness.stack = script_wit_stack;
 
                     tx_mut.vin.push_back(in);

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -354,9 +354,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
                 const auto script_sig = CScript{};
                 const auto script_wit_stack = std::vector<std::vector<uint8_t>>{WITNESS_STACK_ELEM_OP_TRUE};
                 CTxIn in;
-                in.prevout = outpoint;
-                in.nSequence = sequence;
-                in.scriptSig = script_sig;
+                in = CTxIn(outpoint, script_sig, sequence);
                 in.scriptWitness.stack = script_wit_stack;
 
                 tx_mut.vin.push_back(in);

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -63,9 +63,7 @@ CMutableTransaction ConsumeTransaction(FuzzedDataProvider& fuzzed_data_provider,
             script_wit = ConsumeScriptWitness(fuzzed_data_provider);
         }
         CTxIn in;
-        in.prevout = COutPoint{txid_prev, index_out};
-        in.nSequence = sequence;
-        in.scriptSig = script_sig;
+        in = CTxIn(COutPoint{txid_prev, index_out}, script_sig, sequence);
         in.scriptWitness = script_wit;
 
         tx_mut.vin.push_back(in);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -71,8 +71,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     {
         txChild[i].vin.resize(1);
         txChild[i].vin[0].scriptSig = CScript() << OP_11;
-        txChild[i].vin[0].prevout.hash = txParent.GetHash();
-        txChild[i].vin[0].prevout.n = i;
+        txChild[i].vin[0].prevout = COutPoint(txParent.GetHash(), i);
         txChild[i].vout.resize(1);
         txChild[i].vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
         txChild[i].vout[0].nValue = 11000LL;
@@ -82,8 +81,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     {
         txGrandChild[i].vin.resize(1);
         txGrandChild[i].vin[0].scriptSig = CScript() << OP_11;
-        txGrandChild[i].vin[0].prevout.hash = txChild[i].GetHash();
-        txGrandChild[i].vin[0].prevout.n = 0;
+        txGrandChild[i].vin[0].prevout = COutPoint(txChild[i].GetHash(), 0);
         txGrandChild[i].vout.resize(1);
         txGrandChild[i].vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
         txGrandChild[i].vout[0].nValue = 11000LL;
@@ -311,8 +309,7 @@ inline CTransactionRef make_tx(std::vector<CAmount>&& output_values, std::vector
     tx.vin.resize(inputs.size());
     tx.vout.resize(output_values.size());
     for (size_t i = 0; i < inputs.size(); ++i) {
-        tx.vin[i].prevout.hash = inputs[i]->GetHash();
-        tx.vin[i].prevout.n = input_indices.size() > i ? input_indices[i] : 0;
+        tx.vin[i].prevout = COutPoint(inputs[i]->GetHash(), input_indices.size() > i ? input_indices[i] : 0);
     }
     for (size_t i = 0; i < output_values.size(); ++i) {
         tx.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -34,8 +34,7 @@ BOOST_AUTO_TEST_CASE(MempoolLookupTest)
     tx.vin.resize(1);
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vout.resize(1);
-    tx.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
-    tx.vout[0].nValue = 10 * COIN;
+    tx.vout[0] = CTxOut(10 * COIN, CScript() << OP_1 << OP_EQUAL);
 
     // Not in the mempool, so can't find it by txid or wtxid
     BOOST_CHECK(!pool.get(tx.GetHash()));
@@ -63,8 +62,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     txParent.vout.resize(3);
     for (int i = 0; i < 3; i++)
     {
-        txParent.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        txParent.vout[i].nValue = 33000LL;
+        txParent.vout[i] = CTxOut(33000LL, CScript() << OP_11 << OP_EQUAL);
     }
     CMutableTransaction txChild[3];
     for (int i = 0; i < 3; i++)
@@ -73,8 +71,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
         txChild[i].vin[0].scriptSig = CScript() << OP_11;
         txChild[i].vin[0].prevout = COutPoint(txParent.GetHash(), i);
         txChild[i].vout.resize(1);
-        txChild[i].vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        txChild[i].vout[0].nValue = 11000LL;
+        txChild[i].vout[0] = CTxOut(11000LL, CScript() << OP_11 << OP_EQUAL);
     }
     CMutableTransaction txGrandChild[3];
     for (int i = 0; i < 3; i++)
@@ -83,8 +80,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
         txGrandChild[i].vin[0].scriptSig = CScript() << OP_11;
         txGrandChild[i].vin[0].prevout = COutPoint(txChild[i].GetHash(), 0);
         txGrandChild[i].vout.resize(1);
-        txGrandChild[i].vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        txGrandChild[i].vout[0].nValue = 11000LL;
+        txGrandChild[i].vout[0] = CTxOut(11000LL, CScript() << OP_11 << OP_EQUAL);
     }
 
 
@@ -150,16 +146,14 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx1.vin.resize(1);
     tx1.vin[0].scriptSig = CScript() << OP_1;
     tx1.vout.resize(1);
-    tx1.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
-    tx1.vout[0].nValue = 10 * COIN;
+    tx1.vout[0] = CTxOut(10 * COIN, CScript() << OP_1 << OP_EQUAL);
     TryAddToMempool(pool, entry.Fee(1000LL).FromTx(tx1));
 
     CMutableTransaction tx2 = CMutableTransaction();
     tx2.vin.resize(1);
     tx2.vin[0].scriptSig = CScript() << OP_2;
     tx2.vout.resize(1);
-    tx2.vout[0].scriptPubKey = CScript() << OP_2 << OP_EQUAL;
-    tx2.vout[0].nValue = 10 * COIN;
+    tx2.vout[0] = CTxOut(10 * COIN, CScript() << OP_2 << OP_EQUAL);
     TryAddToMempool(pool, entry.Fee(500LL).FromTx(tx2));
 
     pool.TrimToSize(pool.DynamicMemoryUsage()); // should do nothing
@@ -176,8 +170,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx3.vin[0].prevout = COutPoint(tx2.GetHash(), 0);
     tx3.vin[0].scriptSig = CScript() << OP_2;
     tx3.vout.resize(1);
-    tx3.vout[0].scriptPubKey = CScript() << OP_3 << OP_EQUAL;
-    tx3.vout[0].nValue = 10 * COIN;
+    tx3.vout[0] = CTxOut(10 * COIN, CScript() << OP_3 << OP_EQUAL);
     TryAddToMempool(pool, entry.Fee(2000LL).FromTx(tx3));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // tx3 should pay for tx2 (CPFP)
@@ -200,10 +193,8 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx4.vin[1].prevout.SetNull();
     tx4.vin[1].scriptSig = CScript() << OP_4;
     tx4.vout.resize(2);
-    tx4.vout[0].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
-    tx4.vout[0].nValue = 10 * COIN;
-    tx4.vout[1].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
-    tx4.vout[1].nValue = 10 * COIN;
+    tx4.vout[0] = CTxOut(10 * COIN, CScript() << OP_4 << OP_EQUAL);
+    tx4.vout[1] = CTxOut(10 * COIN, CScript() << OP_4 << OP_EQUAL);
 
     CMutableTransaction tx5 = CMutableTransaction();
     tx5.vin.resize(2);
@@ -212,10 +203,8 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx5.vin[1].prevout.SetNull();
     tx5.vin[1].scriptSig = CScript() << OP_5;
     tx5.vout.resize(2);
-    tx5.vout[0].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
-    tx5.vout[0].nValue = 10 * COIN;
-    tx5.vout[1].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
-    tx5.vout[1].nValue = 10 * COIN;
+    tx5.vout[0] = CTxOut(10 * COIN, CScript() << OP_5 << OP_EQUAL);
+    tx5.vout[1] = CTxOut(10 * COIN, CScript() << OP_5 << OP_EQUAL);
 
     CMutableTransaction tx6 = CMutableTransaction();
     tx6.vin.resize(2);
@@ -224,10 +213,8 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx6.vin[1].prevout.SetNull();
     tx6.vin[1].scriptSig = CScript() << OP_6;
     tx6.vout.resize(2);
-    tx6.vout[0].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
-    tx6.vout[0].nValue = 10 * COIN;
-    tx6.vout[1].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
-    tx6.vout[1].nValue = 10 * COIN;
+    tx6.vout[0] = CTxOut(10 * COIN, CScript() << OP_6 << OP_EQUAL);
+    tx6.vout[1] = CTxOut(10 * COIN, CScript() << OP_6 << OP_EQUAL);
 
     CMutableTransaction tx7 = CMutableTransaction();
     tx7.vin.resize(2);
@@ -236,10 +223,8 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx7.vin[1].prevout = COutPoint(tx6.GetHash(), 0);
     tx7.vin[1].scriptSig = CScript() << OP_6;
     tx7.vout.resize(2);
-    tx7.vout[0].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
-    tx7.vout[0].nValue = 10 * COIN;
-    tx7.vout[1].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
-    tx7.vout[1].nValue = 10 * COIN;
+    tx7.vout[0] = CTxOut(10 * COIN, CScript() << OP_7 << OP_EQUAL);
+    tx7.vout[1] = CTxOut(10 * COIN, CScript() << OP_7 << OP_EQUAL);
 
     TryAddToMempool(pool, entry.Fee(700LL).FromTx(tx4));
     auto usage_with_tx4_only = pool.DynamicMemoryUsage();
@@ -312,8 +297,7 @@ inline CTransactionRef make_tx(std::vector<CAmount>&& output_values, std::vector
         tx.vin[i].prevout = COutPoint(inputs[i]->GetHash(), input_indices.size() > i ? input_indices[i] : 0);
     }
     for (size_t i = 0; i < output_values.size(); ++i) {
-        tx.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        tx.vout[i].nValue = output_values[i];
+        tx.vout[i] = CTxOut(output_values[i], CScript() << OP_11 << OP_EQUAL);
     }
     return MakeTransactionRef(tx);
 }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -162,8 +162,7 @@ void MinerTestingSetup::TestPackageSelection(const CScript& scriptPubKey, const 
     CMutableTransaction tx;
     tx.vin.resize(1);
     tx.vin[0].scriptSig = CScript() << OP_1;
-    tx.vin[0].prevout.hash = txFirst[0]->GetHash();
-    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout = COutPoint(txFirst[0]->GetHash(), 0);
     tx.vout.resize(1);
     tx.vout[0].nValue = 5000000000LL - 1000;
     // This tx has a low fee: 1000 satoshis
@@ -329,8 +328,7 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
     tx.vin.resize(1);
     // NOTE: OP_NOP is used to force 20 SigOps for the CHECKMULTISIG
     tx.vin[0].scriptSig = CScript() << OP_0 << OP_0 << OP_CHECKSIG << OP_1;
-    tx.vin[0].prevout.hash = first_tx->GetHash();
-    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout = COutPoint(first_tx->GetHash(), 0);
     tx.vout.resize(50);
     for (auto &out : tx.vout) {
         out.nValue = first_tx->vout[0].nValue / 50;
@@ -348,8 +346,7 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
     for (unsigned int i = 0; i < 50; ++i) {
         auto tx2 = tx;
         tx2.vin.resize(1);
-        tx2.vin[0].prevout.hash = parent_tx->GetHash();
-        tx2.vin[0].prevout.n = i;
+        tx2.vin[0].prevout = COutPoint(parent_tx->GetHash(), i);
         tx2.vin[0].scriptSig = CScript() << OP_1;
         tx2.vout.resize(20);
         tx2.vout[0].nValue = parent_tx->vout[i].nValue - CENT;
@@ -450,8 +447,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
         }
         tx.vin[0].scriptSig << OP_1;
         tx.vout[0].scriptPubKey << OP_1;
-        tx.vin[0].prevout.hash = txFirst[0]->GetHash();
-        tx.vin[0].prevout.n = 0;
+        tx.vin[0].prevout = COutPoint(txFirst[0]->GetHash(), 0);
         tx.vout[0].nValue = BLOCKSUBSIDY;
         for (unsigned int i = 0; i < 63; ++i) {
             tx.vout[0].nValue -= LOWFEE;
@@ -487,8 +483,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
         tx.vin[0].prevout.hash = hash;
         tx.vin.resize(2);
         tx.vin[1].scriptSig = CScript() << OP_1;
-        tx.vin[1].prevout.hash = txFirst[0]->GetHash();
-        tx.vin[1].prevout.n = 0;
+        tx.vin[1].prevout = COutPoint(txFirst[0]->GetHash(), 0);
         tx.vout[0].nValue = tx.vout[0].nValue + BLOCKSUBSIDY - HIGHERFEE; // First txn output + fresh coinbase - new txn fee
         hash = tx.GetHash();
         TryAddToMempool(tx_mempool, entry.Fee(HIGHERFEE).Time(Now<NodeSeconds>()).SpendsCoinbase(true).FromTx(tx));
@@ -560,8 +555,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
         BOOST_REQUIRE(mining->createNewBlock(options, /*cooldown=*/false));
 
         // invalid p2sh txn in tx_mempool, template creation fails
-        tx.vin[0].prevout.hash = txFirst[0]->GetHash();
-        tx.vin[0].prevout.n = 0;
+        tx.vin[0].prevout = COutPoint(txFirst[0]->GetHash(), 0);
         tx.vin[0].scriptSig = CScript() << OP_1;
         tx.vout[0].nValue = BLOCKSUBSIDY - LOWFEE;
         CScript script = CScript() << OP_0;
@@ -598,8 +592,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
     tx.version = 2;
     tx.vin.resize(1);
     prevheights.resize(1);
-    tx.vin[0].prevout.hash = txFirst[0]->GetHash(); // only 1 transaction
-    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout = COutPoint(txFirst[0]->GetHash(), 0);
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vin[0].nSequence = m_node.chainman->ActiveChain().Tip()->nHeight + 1; // txFirst[0] is the 2nd block
     prevheights[0] = baseheight + 1;
@@ -719,8 +712,7 @@ void MinerTestingSetup::TestPrioritisedMining(const CScript& scriptPubKey, const
     // Test that a tx below min fee but prioritised is included
     CMutableTransaction tx;
     tx.vin.resize(1);
-    tx.vin[0].prevout.hash = txFirst[0]->GetHash();
-    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout = COutPoint(txFirst[0]->GetHash(), 0);
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vout.resize(1);
     tx.vout[0].nValue = 5000000000LL; // 0 fee
@@ -728,8 +720,7 @@ void MinerTestingSetup::TestPrioritisedMining(const CScript& scriptPubKey, const
     TryAddToMempool(tx_mempool, entry.Fee(0).Time(Now<NodeSeconds>()).SpendsCoinbase(true).FromTx(tx));
     tx_mempool.PrioritiseTransaction(hashFreePrioritisedTx, 5 * COIN);
 
-    tx.vin[0].prevout.hash = txFirst[1]->GetHash();
-    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout = COutPoint(txFirst[1]->GetHash(), 0);
     tx.vout[0].nValue = 5000000000LL - 1000;
     // This tx has a low fee: 1000 satoshis
     Txid hashParentTx = tx.GetHash(); // save this txid for later use

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -589,9 +589,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
     tx.version = 2;
     tx.vin.resize(1);
     prevheights.resize(1);
-    tx.vin[0].prevout = COutPoint(txFirst[0]->GetHash(), 0);
-    tx.vin[0].scriptSig = CScript() << OP_1;
-    tx.vin[0].nSequence = m_node.chainman->ActiveChain().Tip()->nHeight + 1; // txFirst[0] is the 2nd block
+    tx.vin[0] = CTxIn(COutPoint(txFirst[0]->GetHash(), 0), CScript() << OP_1, m_node.chainman->ActiveChain().Tip()->nHeight + 1); // txFirst[0] is the 2nd block
     prevheights[0] = baseheight + 1;
     tx.vout.resize(1);
     tx.vout[0] = CTxOut(BLOCKSUBSIDY-HIGHFEE, CScript() << OP_1);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -331,8 +331,7 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
     tx.vin[0].prevout = COutPoint(first_tx->GetHash(), 0);
     tx.vout.resize(50);
     for (auto &out : tx.vout) {
-        out.nValue = first_tx->vout[0].nValue / 50;
-        out.scriptPubKey = CScript() << OP_1;
+        out = CTxOut(first_tx->vout[0].nValue / 50, CScript() << OP_1);
     }
 
     tx.vout[0].nValue -= CENT;
@@ -351,8 +350,7 @@ std::vector<CTransactionRef> CreateBigSigOpsCluster(const CTransactionRef& first
         tx2.vout.resize(20);
         tx2.vout[0].nValue = parent_tx->vout[i].nValue - CENT;
         for (auto &out : tx2.vout) {
-            out.nValue = 0;
-            out.scriptPubKey = CScript() << OP_0 << OP_0 << OP_0 << OP_NOP << OP_CHECKMULTISIG << OP_1;
+            out = CTxOut(0, CScript() << OP_0 << OP_0 << OP_0 << OP_NOP << OP_CHECKMULTISIG << OP_1);
         }
         ret.push_back(MakeTransactionRef(tx2));
     }
@@ -513,8 +511,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
         // double spend txn pair in tx_mempool, template creation fails
         tx.vin[0].prevout.hash = txFirst[0]->GetHash();
         tx.vin[0].scriptSig = CScript() << OP_1;
-        tx.vout[0].nValue = BLOCKSUBSIDY - HIGHFEE;
-        tx.vout[0].scriptPubKey = CScript() << OP_1;
+        tx.vout[0] = CTxOut(BLOCKSUBSIDY - HIGHFEE, CScript() << OP_1);
         hash = tx.GetHash();
         TryAddToMempool(tx_mempool, entry.Fee(HIGHFEE).Time(Now<NodeSeconds>()).SpendsCoinbase(true).FromTx(tx));
         tx.vout[0].scriptPubKey = CScript() << OP_2;
@@ -597,8 +594,7 @@ void MinerTestingSetup::TestBasicMining(const CScript& scriptPubKey, const std::
     tx.vin[0].nSequence = m_node.chainman->ActiveChain().Tip()->nHeight + 1; // txFirst[0] is the 2nd block
     prevheights[0] = baseheight + 1;
     tx.vout.resize(1);
-    tx.vout[0].nValue = BLOCKSUBSIDY-HIGHFEE;
-    tx.vout[0].scriptPubKey = CScript() << OP_1;
+    tx.vout[0] = CTxOut(BLOCKSUBSIDY-HIGHFEE, CScript() << OP_1);
     tx.nLockTime = 0;
     hash = tx.GetHash();
     TryAddToMempool(tx_mempool, entry.Fee(HIGHFEE).Time(Now<NodeSeconds>()).SpendsCoinbase(true).FromTx(tx));

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -29,10 +29,7 @@ static inline CTransactionRef make_tx(const std::vector<COutPoint>& inputs, size
         tx.vin[i].prevout = inputs[i];
     }
     for (size_t i = 0; i < num_outputs; ++i) {
-        tx.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        // The actual input and output values of these transactions don't really
-        // matter, since all accounting will use the entries' cached fees.
-        tx.vout[i].nValue = COIN;
+        tx.vout[i] = CTxOut(COIN, CScript() << OP_11 << OP_EQUAL);
     }
     return MakeTransactionRef(tx);
 }

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -67,8 +67,7 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     {
         txTo[i].vin.resize(1);
         txTo[i].vout.resize(1);
-        txTo[i].vin[0].prevout.n = i;
-        txTo[i].vin[0].prevout.hash = txFrom.GetHash();
+        txTo[i].vin[0].prevout = COutPoint(txFrom.GetHash(), i);
         txTo[i].vout[0].nValue = 1;
     }
 
@@ -212,8 +211,7 @@ BOOST_AUTO_TEST_CASE(multisig_Sign)
     {
         txTo[i].vin.resize(1);
         txTo[i].vout.resize(1);
-        txTo[i].vin[0].prevout.n = i;
-        txTo[i].vin[0].prevout.hash = txFrom.GetHash();
+        txTo[i].vin[0].prevout = COutPoint(txFrom.GetHash(), i);
         txTo[i].vout[0].nValue = 1;
     }
 

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -441,8 +441,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     {
         CMutableTransaction tx;
         tx.vin.resize(1);
-        tx.vin[0].prevout.n = 0;
-        tx.vin[0].prevout.hash = Txid::FromUint256(m_rng.rand256());
+        tx.vin[0].prevout = COutPoint(Txid::FromUint256(m_rng.rand256()), 0);
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = i*CENT;
@@ -460,8 +459,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
 
         CMutableTransaction tx;
         tx.vin.resize(1);
-        tx.vin[0].prevout.n = 0;
-        tx.vin[0].prevout.hash = txPrev->GetHash();
+        tx.vin[0].prevout = COutPoint(txPrev->GetHash(), 0);
         tx.vout.resize(1);
         tx.vout[0].nValue = i*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
@@ -485,8 +483,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin.resize(2777);
         for (unsigned int j = 0; j < tx.vin.size(); j++)
         {
-            tx.vin[j].prevout.n = j;
-            tx.vin[j].prevout.hash = txPrev->GetHash();
+            tx.vin[j].prevout = COutPoint(txPrev->GetHash(), j);
         }
         SignatureData empty;
         BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL, empty));

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -48,10 +48,8 @@ static CTransactionRef MakeTransactionSpending(const std::vector<COutPoint>& out
     // Ensure txid != wtxid
     tx.vin[0].scriptWitness.stack.push_back({1});
     tx.vout.resize(2);
-    tx.vout[0].nValue = CENT;
-    tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
-    tx.vout[1].nValue = 3 * CENT;
-    tx.vout[1].scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(key.GetPubKey()));
+    tx.vout[0] = CTxOut(CENT, GetScriptForDestination(PKHash(key.GetPubKey())));
+    tx.vout[1] = CTxOut(3 * CENT, GetScriptForDestination(WitnessV0KeyHash(key.GetPubKey())));
     return MakeTransactionRef(tx);
 }
 
@@ -444,8 +442,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin[0].prevout = COutPoint(Txid::FromUint256(m_rng.rand256()), 0);
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
-        tx.vout[0].nValue = i*CENT;
-        tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
+        tx.vout[0] = CTxOut(i*CENT, GetScriptForDestination(PKHash(key.GetPubKey())));
 
         auto ptx = MakeTransactionRef(tx);
         orphanage->AddTx(ptx, i);
@@ -461,8 +458,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin.resize(1);
         tx.vin[0].prevout = COutPoint(txPrev->GetHash(), 0);
         tx.vout.resize(1);
-        tx.vout[0].nValue = i*CENT;
-        tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
+        tx.vout[0] = CTxOut(i*CENT, GetScriptForDestination(PKHash(key.GetPubKey())));
         SignatureData empty;
         BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL, empty));
 
@@ -478,8 +474,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
 
         CMutableTransaction tx;
         tx.vout.resize(1);
-        tx.vout[0].nValue = 1*CENT;
-        tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
+        tx.vout[0] = CTxOut(1*CENT, GetScriptForDestination(PKHash(key.GetPubKey())));
         tx.vin.resize(2777);
         for (unsigned int j = 0; j < tx.vin.size(); j++)
         {

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -23,8 +23,7 @@ static inline CTransactionRef make_tx(const std::vector<CTransactionRef>& inputs
     tx.vin.resize(inputs.size());
     tx.vout.resize(output_values.size());
     for (size_t i = 0; i < inputs.size(); ++i) {
-        tx.vin[i].prevout.hash = inputs[i]->GetHash();
-        tx.vin[i].prevout.n = 0;
+        tx.vin[i].prevout = COutPoint(inputs[i]->GetHash(), 0);
         // Add a witness so wtxid != txid
         CScriptWitness witness;
         witness.stack.emplace_back(i + 10);

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -30,8 +30,7 @@ static inline CTransactionRef make_tx(const std::vector<CTransactionRef>& inputs
         tx.vin[i].scriptWitness = witness;
     }
     for (size_t i = 0; i < output_values.size(); ++i) {
-        tx.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        tx.vout[i].nValue = output_values[i];
+        tx.vout[i] = CTxOut(output_values[i], CScript() << OP_11 << OP_EQUAL);
     }
     return MakeTransactionRef(tx);
 }

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -90,10 +90,8 @@ BOOST_AUTO_TEST_CASE(sign)
     txFrom.vout.resize(8);
     for (int i = 0; i < 4; i++)
     {
-        txFrom.vout[i].scriptPubKey = evalScripts[i];
-        txFrom.vout[i].nValue = COIN;
-        txFrom.vout[i+4].scriptPubKey = standardScripts[i];
-        txFrom.vout[i+4].nValue = COIN;
+        txFrom.vout[i] = CTxOut(COIN, evalScripts[i]);
+        txFrom.vout[i+4] = CTxOut(COIN, standardScripts[i]);
     }
     BOOST_CHECK(IsStandardTx(CTransaction(txFrom), reason));
 
@@ -188,8 +186,7 @@ BOOST_AUTO_TEST_CASE(set)
     txFrom.vout.resize(4);
     for (int i = 0; i < 4; i++)
     {
-        txFrom.vout[i].scriptPubKey = outer[i];
-        txFrom.vout[i].nValue = CENT;
+        txFrom.vout[i] = CTxOut(CENT, outer[i]);
     }
     BOOST_CHECK(IsStandardTx(CTransaction(txFrom), reason));
 
@@ -199,8 +196,7 @@ BOOST_AUTO_TEST_CASE(set)
         txTo[i].vin.resize(1);
         txTo[i].vout.resize(1);
         txTo[i].vin[0].prevout = COutPoint(txFrom.GetHash(), i);
-        txTo[i].vout[0].nValue = 1*CENT;
-        txTo[i].vout[0].scriptPubKey = inner[i];
+        txTo[i].vout[0] = CTxOut(1*CENT, inner[i]);
     }
     for (int i = 0; i < 4; i++)
     {
@@ -295,12 +291,9 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     BOOST_CHECK(keystore.AddCScript(pay1));
     CScript pay1of3 = GetScriptForMultisig(1, keys);
 
-    txFrom.vout[0].scriptPubKey = GetScriptForDestination(ScriptHash(pay1)); // P2SH (OP_CHECKSIG)
-    txFrom.vout[0].nValue = 1000;
-    txFrom.vout[1].scriptPubKey = pay1; // ordinary OP_CHECKSIG
-    txFrom.vout[1].nValue = 2000;
-    txFrom.vout[2].scriptPubKey = pay1of3; // ordinary OP_CHECKMULTISIG
-    txFrom.vout[2].nValue = 3000;
+    txFrom.vout[0] = CTxOut(1000, GetScriptForDestination(ScriptHash(pay1)));
+    txFrom.vout[1] = CTxOut(2000, pay1);
+    txFrom.vout[2] = CTxOut(3000, pay1of3);
 
     // vout[3] is complicated 1-of-3 AND 2-of-3
     // ... that is OK if wrapped in P2SH:
@@ -310,8 +303,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     oneAndTwo << OP_2 << ToByteVector(key[3].GetPubKey()) << ToByteVector(key[4].GetPubKey()) << ToByteVector(key[5].GetPubKey());
     oneAndTwo << OP_3 << OP_CHECKMULTISIG;
     BOOST_CHECK(keystore.AddCScript(oneAndTwo));
-    txFrom.vout[3].scriptPubKey = GetScriptForDestination(ScriptHash(oneAndTwo));
-    txFrom.vout[3].nValue = 4000;
+    txFrom.vout[3] = CTxOut(4000, GetScriptForDestination(ScriptHash(oneAndTwo)));
 
     // vout[4] is max sigops:
     CScript fifteenSigops; fifteenSigops << OP_1;
@@ -319,35 +311,29 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         fifteenSigops << ToByteVector(key[i%3].GetPubKey());
     fifteenSigops << OP_15 << OP_CHECKMULTISIG;
     BOOST_CHECK(keystore.AddCScript(fifteenSigops));
-    txFrom.vout[4].scriptPubKey = GetScriptForDestination(ScriptHash(fifteenSigops));
-    txFrom.vout[4].nValue = 5000;
+    txFrom.vout[4] = CTxOut(5000, GetScriptForDestination(ScriptHash(fifteenSigops)));
 
     // vout[5/6] are non-standard because they exceed MAX_P2SH_SIGOPS
     CScript sixteenSigops; sixteenSigops << OP_16 << OP_CHECKMULTISIG;
     BOOST_CHECK(keystore.AddCScript(sixteenSigops));
-    txFrom.vout[5].scriptPubKey = GetScriptForDestination(ScriptHash(sixteenSigops));
-    txFrom.vout[5].nValue = 5000;
+    txFrom.vout[5] = CTxOut(5000, GetScriptForDestination(ScriptHash(sixteenSigops)));
     CScript twentySigops; twentySigops << OP_CHECKMULTISIG;
     BOOST_CHECK(keystore.AddCScript(twentySigops));
-    txFrom.vout[6].scriptPubKey = GetScriptForDestination(ScriptHash(twentySigops));
-    txFrom.vout[6].nValue = 3000;
+    txFrom.vout[6] = CTxOut(3000, GetScriptForDestination(ScriptHash(twentySigops)));
 
     // vout[7] is non-standard because it lacks sigops
     CScript no_sigops;
-    txFrom.vout[7].scriptPubKey = no_sigops;
-    txFrom.vout[7].nValue = 1000;
+    txFrom.vout[7] = CTxOut(1000, no_sigops);
 
     // vout [8] is non-standard because it contains OP_RETURN in its redeemScript.
     static const unsigned char op_return[] = {OP_RETURN};
     const auto op_return_script = CScript(op_return, op_return + sizeof(op_return));
-    txFrom.vout[8].scriptPubKey = GetScriptForDestination(ScriptHash(op_return_script));
-    txFrom.vout[8].nValue = 1000;
+    txFrom.vout[8] = CTxOut(1000, GetScriptForDestination(ScriptHash(op_return_script)));
 
     // vout[9] is non-standard because its witness is unknown
     CScript witnessUnknown;
     witnessUnknown << OP_16 << ToByteVector(uint256::ONE);
-    txFrom.vout[9].scriptPubKey = witnessUnknown;
-    txFrom.vout[9].nValue = 1000;
+    txFrom.vout[9] = CTxOut(1000, witnessUnknown);
 
     AddCoins(coins, CTransaction(txFrom), 0);
 
@@ -390,8 +376,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     {
         CMutableTransaction txToNonStd1;
         txToNonStd1.vout.resize(1);
-        txToNonStd1.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
-        txToNonStd1.vout[0].nValue = 1000;
+        txToNonStd1.vout[0] = CTxOut(1000, GetScriptForDestination(PKHash(key[1].GetPubKey())));
         txToNonStd1.vin.resize(1);
         txToNonStd1.vin[0].prevout = COutPoint(txFrom.GetHash(), 5);
         txToNonStd1.vin[0].scriptSig << std::vector<unsigned char>(sixteenSigops.begin(), sixteenSigops.end());
@@ -407,8 +392,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     {
         CMutableTransaction txToNonStd2;
         txToNonStd2.vout.resize(1);
-        txToNonStd2.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
-        txToNonStd2.vout[0].nValue = 1000;
+        txToNonStd2.vout[0] = CTxOut(1000, GetScriptForDestination(PKHash(key[1].GetPubKey())));
         txToNonStd2.vin.resize(1);
         txToNonStd2.vin[0].prevout = COutPoint(txFrom.GetHash(), 6);
         txToNonStd2.vin[0].scriptSig << std::vector<unsigned char>(twentySigops.begin(), twentySigops.end());
@@ -423,8 +407,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     {
         CMutableTransaction txToNonStd2_no_scriptSig;
         txToNonStd2_no_scriptSig.vout.resize(1);
-        txToNonStd2_no_scriptSig.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
-        txToNonStd2_no_scriptSig.vout[0].nValue = 1000;
+        txToNonStd2_no_scriptSig.vout[0] = CTxOut(1000, GetScriptForDestination(PKHash(key[1].GetPubKey())));
         txToNonStd2_no_scriptSig.vin.resize(1);
         txToNonStd2_no_scriptSig.vin[0].prevout = COutPoint(txFrom.GetHash(), 6);
 
@@ -439,8 +422,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     {
         CMutableTransaction txToNonStd3;
         txToNonStd3.vout.resize(1);
-        txToNonStd3.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
-        txToNonStd3.vout[0].nValue = 1000;
+        txToNonStd3.vout[0] = CTxOut(1000, GetScriptForDestination(PKHash(key[1].GetPubKey())));
         txToNonStd3.vin.resize(1);
         txToNonStd3.vin[0].prevout = COutPoint(txFrom.GetHash(), 7);
 
@@ -454,8 +436,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     {
         CMutableTransaction txToNonStd4;
         txToNonStd4.vout.resize(1);
-        txToNonStd4.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
-        txToNonStd4.vout[0].nValue = 1000;
+        txToNonStd4.vout[0] = CTxOut(1000, GetScriptForDestination(PKHash(key[1].GetPubKey())));
         txToNonStd4.vin.resize(1);
         txToNonStd4.vin[0].prevout = COutPoint(txFrom.GetHash(), 8);
         txToNonStd4.vin[0].scriptSig = op_return_script;
@@ -470,8 +451,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
     {
         CMutableTransaction txWitnessUnknown;
         txWitnessUnknown.vout.resize(1);
-        txWitnessUnknown.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
-        txWitnessUnknown.vout[0].nValue = 1000;
+        txWitnessUnknown.vout[0] = CTxOut(1000, GetScriptForDestination(PKHash(key[1].GetPubKey())));
         txWitnessUnknown.vin.resize(1);
         txWitnessUnknown.vin[0].prevout = COutPoint(txFrom.GetHash(), 9);
         const auto txWitnessUnknown_res = ::ValidateInputsStandardness(CTransaction(txWitnessUnknown), coins);

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -46,8 +46,7 @@ static bool Verify(const CScript& scriptSig, const CScript& scriptPubKey, bool f
     CMutableTransaction txTo;
     txTo.vin.resize(1);
     txTo.vout.resize(1);
-    txTo.vin[0].prevout.n = 0;
-    txTo.vin[0].prevout.hash = txFrom.GetHash();
+    txTo.vin[0].prevout = COutPoint(txFrom.GetHash(), 0);
     txTo.vin[0].scriptSig = scriptSig;
     txTo.vout[0].nValue = 1;
 
@@ -103,8 +102,7 @@ BOOST_AUTO_TEST_CASE(sign)
     {
         txTo[i].vin.resize(1);
         txTo[i].vout.resize(1);
-        txTo[i].vin[0].prevout.n = i;
-        txTo[i].vin[0].prevout.hash = txFrom.GetHash();
+        txTo[i].vin[0].prevout = COutPoint(txFrom.GetHash(), i);
         txTo[i].vout[0].nValue = 1;
     }
     for (int i = 0; i < 8; i++)
@@ -200,8 +198,7 @@ BOOST_AUTO_TEST_CASE(set)
     {
         txTo[i].vin.resize(1);
         txTo[i].vout.resize(1);
-        txTo[i].vin[0].prevout.n = i;
-        txTo[i].vin[0].prevout.hash = txFrom.GetHash();
+        txTo[i].vin[0].prevout = COutPoint(txFrom.GetHash(), i);
         txTo[i].vout[0].nValue = 1*CENT;
         txTo[i].vout[0].scriptPubKey = inner[i];
     }
@@ -362,8 +359,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         txTo.vin.resize(5);
         for (int i = 0; i < 5; i++)
         {
-            txTo.vin[i].prevout.n = i;
-            txTo.vin[i].prevout.hash = txFrom.GetHash();
+            txTo.vin[i].prevout = COutPoint(txFrom.GetHash(), i);
         }
         SignatureData empty;
         BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL, empty));
@@ -397,8 +393,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         txToNonStd1.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
         txToNonStd1.vout[0].nValue = 1000;
         txToNonStd1.vin.resize(1);
-        txToNonStd1.vin[0].prevout.n = 5;
-        txToNonStd1.vin[0].prevout.hash = txFrom.GetHash();
+        txToNonStd1.vin[0].prevout = COutPoint(txFrom.GetHash(), 5);
         txToNonStd1.vin[0].scriptSig << std::vector<unsigned char>(sixteenSigops.begin(), sixteenSigops.end());
 
         const auto txToNonStd1_res = ::ValidateInputsStandardness(CTransaction(txToNonStd1), coins);
@@ -415,8 +410,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         txToNonStd2.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
         txToNonStd2.vout[0].nValue = 1000;
         txToNonStd2.vin.resize(1);
-        txToNonStd2.vin[0].prevout.n = 6;
-        txToNonStd2.vin[0].prevout.hash = txFrom.GetHash();
+        txToNonStd2.vin[0].prevout = COutPoint(txFrom.GetHash(), 6);
         txToNonStd2.vin[0].scriptSig << std::vector<unsigned char>(twentySigops.begin(), twentySigops.end());
 
         const auto txToNonStd2_res = ::ValidateInputsStandardness(CTransaction(txToNonStd2), coins);
@@ -432,8 +426,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         txToNonStd2_no_scriptSig.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
         txToNonStd2_no_scriptSig.vout[0].nValue = 1000;
         txToNonStd2_no_scriptSig.vin.resize(1);
-        txToNonStd2_no_scriptSig.vin[0].prevout.n = 6;
-        txToNonStd2_no_scriptSig.vin[0].prevout.hash = txFrom.GetHash();
+        txToNonStd2_no_scriptSig.vin[0].prevout = COutPoint(txFrom.GetHash(), 6);
 
         const auto txToNonStd2_no_scriptSig_res = ::ValidateInputsStandardness(CTransaction(txToNonStd2_no_scriptSig), coins);
         BOOST_CHECK(txToNonStd2_no_scriptSig_res.IsInvalid());
@@ -449,8 +442,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         txToNonStd3.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
         txToNonStd3.vout[0].nValue = 1000;
         txToNonStd3.vin.resize(1);
-        txToNonStd3.vin[0].prevout.n = 7;
-        txToNonStd3.vin[0].prevout.hash = txFrom.GetHash();
+        txToNonStd3.vin[0].prevout = COutPoint(txFrom.GetHash(), 7);
 
         const auto txToNonStd3_res = ::ValidateInputsStandardness(CTransaction(txToNonStd3), coins);
         BOOST_CHECK(txToNonStd3_res.IsInvalid());
@@ -465,8 +457,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         txToNonStd4.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
         txToNonStd4.vout[0].nValue = 1000;
         txToNonStd4.vin.resize(1);
-        txToNonStd4.vin[0].prevout.n = 8;
-        txToNonStd4.vin[0].prevout.hash = txFrom.GetHash();
+        txToNonStd4.vin[0].prevout = COutPoint(txFrom.GetHash(), 8);
         txToNonStd4.vin[0].scriptSig = op_return_script;
 
         const auto txToNonStd4_res = ::ValidateInputsStandardness(CTransaction(txToNonStd4), coins);
@@ -482,8 +473,7 @@ BOOST_AUTO_TEST_CASE(ValidateInputsStandardness)
         txWitnessUnknown.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
         txWitnessUnknown.vout[0].nValue = 1000;
         txWitnessUnknown.vin.resize(1);
-        txWitnessUnknown.vin[0].prevout.n = 9;
-        txWitnessUnknown.vin[0].prevout.hash = txFrom.GetHash();
+        txWitnessUnknown.vin[0].prevout = COutPoint(txFrom.GetHash(), 9);
         const auto txWitnessUnknown_res = ::ValidateInputsStandardness(CTransaction(txWitnessUnknown), coins);
         BOOST_CHECK(txWitnessUnknown_res.IsInvalid());
         BOOST_CHECK_EQUAL(txWitnessUnknown_res.GetRejectReason(), "bad-txns-nonstandard-inputs");

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -103,8 +103,7 @@ void RandomTransaction(CMutableTransaction& tx, bool fSingle)
     for (int in = 0; in < ins; in++) {
         tx.vin.emplace_back();
         CTxIn &txin = tx.vin.back();
-        txin.prevout.hash = Txid::FromUint256(m_rng.rand256());
-        txin.prevout.n = m_rng.randbits(2);
+        txin.prevout = COutPoint(Txid::FromUint256(m_rng.rand256()), m_rng.randbits(2));
         RandomScript(txin.scriptSig);
         txin.nSequence = (m_rng.randbool()) ? m_rng.rand32() : std::numeric_limits<uint32_t>::max();
     }

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -96,8 +96,7 @@ static void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins, CM
 
     spendingTx.version = 1;
     spendingTx.vin.resize(1);
-    spendingTx.vin[0].prevout.hash = creationTx.GetHash();
-    spendingTx.vin[0].prevout.n = 0;
+    spendingTx.vin[0].prevout = COutPoint(creationTx.GetHash(), 0);
     spendingTx.vin[0].scriptSig = scriptSig;
     spendingTx.vin[0].scriptWitness = witness;
     spendingTx.vout.resize(1);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -91,8 +91,7 @@ static void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins, CM
     creationTx.vin[0].prevout.SetNull();
     creationTx.vin[0].scriptSig = CScript();
     creationTx.vout.resize(1);
-    creationTx.vout[0].nValue = 1;
-    creationTx.vout[0].scriptPubKey = scriptPubKey;
+    creationTx.vout[0] = CTxOut(1, scriptPubKey);
 
     spendingTx.version = 1;
     spendingTx.vin.resize(1);
@@ -100,8 +99,7 @@ static void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins, CM
     spendingTx.vin[0].scriptSig = scriptSig;
     spendingTx.vin[0].scriptWitness = witness;
     spendingTx.vout.resize(1);
-    spendingTx.vout[0].nValue = 1;
-    spendingTx.vout[0].scriptPubKey = CScript();
+    spendingTx.vout[0] = CTxOut(1, CScript());
 
     AddCoins(coins, CTransaction(creationTx), 0);
 }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -399,14 +399,11 @@ BOOST_AUTO_TEST_CASE(test_Get)
 
     CMutableTransaction t1;
     t1.vin.resize(3);
-    t1.vin[0].prevout.hash = dummyTransactions[0].GetHash();
-    t1.vin[0].prevout.n = 1;
+    t1.vin[0].prevout = COutPoint(dummyTransactions[0].GetHash(), 1);
     t1.vin[0].scriptSig << std::vector<unsigned char>(65, 0);
-    t1.vin[1].prevout.hash = dummyTransactions[1].GetHash();
-    t1.vin[1].prevout.n = 0;
+    t1.vin[1].prevout = COutPoint(dummyTransactions[1].GetHash(), 0);
     t1.vin[1].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
-    t1.vin[2].prevout.hash = dummyTransactions[1].GetHash();
-    t1.vin[2].prevout.n = 1;
+    t1.vin[2].prevout = COutPoint(dummyTransactions[1].GetHash(), 1);
     t1.vin[2].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
     t1.vout.resize(2);
     t1.vout[0].nValue = 90*CENT;
@@ -436,8 +433,7 @@ static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const 
     CMutableTransaction inputm;
     inputm.version = 1;
     inputm.vin.resize(1);
-    inputm.vin[0].prevout.hash = output->GetHash();
-    inputm.vin[0].prevout.n = 0;
+    inputm.vin[0].prevout = COutPoint(output->GetHash(), 0);
     inputm.vout.resize(1);
     inputm.vout[0].nValue = 1;
     inputm.vout[0].scriptPubKey = CScript();
@@ -755,8 +751,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     CMutableTransaction t;
     t.vin.resize(1);
-    t.vin[0].prevout.hash = dummyTransactions[0].GetHash();
-    t.vin[0].prevout.n = 1;
+    t.vin[0].prevout = COutPoint(dummyTransactions[0].GetHash(), 1);
     t.vin[0].scriptSig << std::vector<unsigned char>(65, 0);
     t.vout.resize(1);
     t.vout[0].nValue = 90*CENT;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -420,8 +420,7 @@ static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const 
     outputm.vin[0].prevout.SetNull();
     outputm.vin[0].scriptSig = CScript();
     outputm.vout.resize(1);
-    outputm.vout[0].nValue = 1;
-    outputm.vout[0].scriptPubKey = outscript;
+    outputm.vout[0] = CTxOut(1, outscript);
     DataStream ssout;
     ssout << TX_WITH_WITNESS(outputm);
     ssout >> TX_WITH_WITNESS(output);
@@ -435,8 +434,7 @@ static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const 
     inputm.vin.resize(1);
     inputm.vin[0].prevout = COutPoint(output->GetHash(), 0);
     inputm.vout.resize(1);
-    inputm.vout[0].nValue = 1;
-    inputm.vout[0].scriptPubKey = CScript();
+    inputm.vout[0] = CTxOut(1, CScript());
     SignatureData empty;
     bool ret = SignSignature(keystore, *output, inputm, 0, SIGHASH_ALL, empty);
     assert(ret == success);
@@ -513,8 +511,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
         mtx.vin[i].scriptSig = CScript();
 
         mtx.vout.resize(mtx.vout.size() + 1);
-        mtx.vout[i].nValue = 1000;
-        mtx.vout[i].scriptPubKey = CScript() << OP_1;
+        mtx.vout[i] = CTxOut(1000, CScript() << OP_1);
     }
 
     // sign all inputs
@@ -538,8 +535,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
         Coin coin;
         coin.nHeight = 1;
         coin.fCoinBase = false;
-        coin.out.nValue = 1000;
-        coin.out.scriptPubKey = scriptPubKey;
+        coin.out = CTxOut(1000, scriptPubKey);
         coins.emplace_back(std::move(coin));
     }
 
@@ -849,10 +845,8 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Multiple TxoutType::NULL_DATA are permitted
     t.vout.resize(2);
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
-    t.vout[0].nValue = 0;
-    t.vout[1].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
-    t.vout[1].nValue = 0;
+    t.vout[0] = CTxOut(0, CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex);
+    t.vout[1] = CTxOut(0, CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex);
     CheckIsStandard(t);
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38"_hex;
@@ -872,8 +866,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Check large scriptSig (non-standard if size is >1650 bytes)
     t.vout.resize(1);
-    t.vout[0].nValue = MAX_MONEY;
-    t.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
+    t.vout[0] = CTxOut(MAX_MONEY, GetScriptForDestination(PKHash(key.GetPubKey())));
     // OP_PUSHDATA2 with len (3 bytes) + data (1647 bytes) = 1650 bytes
     t.vin[0].scriptSig = CScript() << std::vector<unsigned char>(1647, 0); // 1650
     CheckIsStandard(t);
@@ -947,58 +940,50 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout.insert(t.vout.end(), MAX_DUST_OUTPUTS_PER_TX, {0, t.vout[0].scriptPubKey});
 
     // Check compressed P2PK outputs dust threshold (must have leading 02 or 03)
-    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG;
-    t.vout[0].nValue = 576;
+    t.vout[0] = CTxOut(576, CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG);
     CheckIsStandard(t);
     t.vout[0].nValue = 575;
     CheckIsNotStandard(t, "dust");
 
     // Check uncompressed P2PK outputs dust threshold (must have leading 04/06/07)
-    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(65, 0x04) << OP_CHECKSIG;
-    t.vout[0].nValue = 672;
+    t.vout[0] = CTxOut(672, CScript() << std::vector<unsigned char>(65, 0x04) << OP_CHECKSIG);
     CheckIsStandard(t);
     t.vout[0].nValue = 671;
     CheckIsNotStandard(t, "dust");
 
     // Check P2PKH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUALVERIFY << OP_CHECKSIG;
-    t.vout[0].nValue = 546;
+    t.vout[0] = CTxOut(546, CScript() << OP_DUP << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUALVERIFY << OP_CHECKSIG);
     CheckIsStandard(t);
     t.vout[0].nValue = 545;
     CheckIsNotStandard(t, "dust");
 
     // Check P2SH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUAL;
-    t.vout[0].nValue = 540;
+    t.vout[0] = CTxOut(540, CScript() << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUAL);
     CheckIsStandard(t);
     t.vout[0].nValue = 539;
     CheckIsNotStandard(t, "dust");
 
     // Check P2WPKH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(20, 0);
-    t.vout[0].nValue = 294;
+    t.vout[0] = CTxOut(294, CScript() << OP_0 << std::vector<unsigned char>(20, 0));
     CheckIsStandard(t);
     t.vout[0].nValue = 293;
     CheckIsNotStandard(t, "dust");
 
     // Check P2WSH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(32, 0);
-    t.vout[0].nValue = 330;
+    t.vout[0] = CTxOut(330, CScript() << OP_0 << std::vector<unsigned char>(32, 0));
     CheckIsStandard(t);
     t.vout[0].nValue = 329;
     CheckIsNotStandard(t, "dust");
 
     // Check P2TR outputs dust threshold (Invalid xonly key ok!)
-    t.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
-    t.vout[0].nValue = 330;
+    t.vout[0] = CTxOut(330, CScript() << OP_1 << std::vector<unsigned char>(32, 0));
     CheckIsStandard(t);
     t.vout[0].nValue = 329;
     CheckIsNotStandard(t, "dust");
 
     // Check future Witness Program versions dust threshold (non-32-byte pushes are undefined for version 1)
     for (int op = OP_1; op <= OP_16; op += 1) {
-        t.vout[0].scriptPubKey = CScript() << (opcodetype)op << std::vector<unsigned char>(2, 0);
-        t.vout[0].nValue = 240;
+        t.vout[0] = CTxOut(240, CScript() << (opcodetype)op << std::vector<unsigned char>(2, 0));
         CheckIsStandard(t);
 
         t.vout[0].nValue = 239;

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -29,8 +29,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
         // Spending tx
         spender[i].version = 1;
         spender[i].vin.resize(1);
-        spender[i].vin[0].prevout.hash = spent[i].hash;
-        spender[i].vin[0].prevout.n = spent[i].n;
+        spender[i].vin[0].prevout = COutPoint(spent[i].hash, spent[i].n);
         spender[i].vout.resize(1);
         spender[i].vout[0].nValue = coinbase_tx->GetValueOut();
         spender[i].vout[0].scriptPubKey = coinbase_script;

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -31,8 +31,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
         spender[i].vin.resize(1);
         spender[i].vin[0].prevout = COutPoint(spent[i].hash, spent[i].n);
         spender[i].vout.resize(1);
-        spender[i].vout[0].nValue = coinbase_tx->GetValueOut();
-        spender[i].vout[0].scriptPubKey = coinbase_script;
+        spender[i].vout[0] = CTxOut(coinbase_tx->GetValueOut(), coinbase_script);
 
         // Sign
         std::vector<unsigned char> vchSig;

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -36,8 +36,7 @@ inline CTransactionRef create_placeholder_tx(size_t num_inputs, size_t num_outpu
     mtx.vout.resize(num_outputs);
     auto random_script = CScript() << ToByteVector(m_rng.rand256()) << ToByteVector(m_rng.rand256());
     for (size_t i{0}; i < num_inputs; ++i) {
-        mtx.vin[i].prevout.hash = Txid::FromUint256(m_rng.rand256());
-        mtx.vin[i].prevout.n = 0;
+        mtx.vin[i].prevout = COutPoint(Txid::FromUint256(m_rng.rand256()), 0);
         mtx.vin[i].scriptSig = random_script;
     }
     for (size_t o{0}; o < num_outputs; ++o) {
@@ -662,8 +661,7 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     CMutableTransaction mtx_child1;
     mtx_child1.version = 1;
     mtx_child1.vin.resize(1);
-    mtx_child1.vin[0].prevout.hash = ptx_parent->GetHash();
-    mtx_child1.vin[0].prevout.n = 0;
+    mtx_child1.vin[0].prevout = COutPoint(ptx_parent->GetHash(), 0);
     mtx_child1.vin[0].scriptSig = CScript();
     mtx_child1.vin[0].scriptWitness = witness1;
     mtx_child1.vout.resize(1);
@@ -790,8 +788,7 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     CMutableTransaction mtx_parent2_v1;
     mtx_parent2_v1.version = 1;
     mtx_parent2_v1.vin.resize(1);
-    mtx_parent2_v1.vin[0].prevout.hash = ptx_grandparent2->GetHash();
-    mtx_parent2_v1.vin[0].prevout.n = 0;
+    mtx_parent2_v1.vin[0].prevout = COutPoint(ptx_grandparent2->GetHash(), 0);
     mtx_parent2_v1.vin[0].scriptSig = CScript();
     mtx_parent2_v1.vin[0].scriptWitness = parent2_witness1;
     mtx_parent2_v1.vout.resize(1);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -40,8 +40,7 @@ inline CTransactionRef create_placeholder_tx(size_t num_inputs, size_t num_outpu
         mtx.vin[i].scriptSig = random_script;
     }
     for (size_t o{0}; o < num_outputs; ++o) {
-        mtx.vout[o].nValue = 1 * CENT;
-        mtx.vout[o].scriptPubKey = random_script;
+        mtx.vout[o] = CTxOut(1 * CENT, random_script);
     }
     return MakeTransactionRef(mtx);
 }
@@ -665,8 +664,7 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     mtx_child1.vin[0].scriptSig = CScript();
     mtx_child1.vin[0].scriptWitness = witness1;
     mtx_child1.vout.resize(1);
-    mtx_child1.vout[0].nValue = CAmount(48 * COIN);
-    mtx_child1.vout[0].scriptPubKey = child_locking_script;
+    mtx_child1.vout[0] = CTxOut(CAmount(48 * COIN), child_locking_script);
 
     CMutableTransaction mtx_child2{mtx_child1};
     mtx_child2.vin[0].scriptWitness = witness2;
@@ -792,8 +790,7 @@ BOOST_AUTO_TEST_CASE(package_witness_swap_tests)
     mtx_parent2_v1.vin[0].scriptSig = CScript();
     mtx_parent2_v1.vin[0].scriptWitness = parent2_witness1;
     mtx_parent2_v1.vout.resize(1);
-    mtx_parent2_v1.vout[0].nValue = CAmount(48 * COIN);
-    mtx_parent2_v1.vout[0].scriptPubKey = acs_spk;
+    mtx_parent2_v1.vout[0] = CTxOut(CAmount(48 * COIN), acs_spk);
 
     CMutableTransaction mtx_parent2_v2{mtx_parent2_v1};
     mtx_parent2_v2.vin[0].scriptWitness = parent2_witness2;

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -33,8 +33,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     coinbaseTx.vin.resize(1);
     coinbaseTx.vout.resize(1);
     coinbaseTx.vin[0].scriptSig = CScript() << OP_11 << OP_EQUAL;
-    coinbaseTx.vout[0].nValue = 1 * CENT;
-    coinbaseTx.vout[0].scriptPubKey = scriptPubKey;
+    coinbaseTx.vout[0] = CTxOut(1 * CENT, scriptPubKey);
 
     BOOST_CHECK(CTransaction(coinbaseTx).IsCoinBase());
 
@@ -85,8 +84,7 @@ static inline CTransactionRef make_tx(const std::vector<COutPoint>& inputs, int3
         mtx.vin[i].prevout = inputs[i];
     }
     for (auto i{0}; i < 25; ++i) {
-        mtx.vout[i].scriptPubKey = CScript() << OP_TRUE;
-        mtx.vout[i].nValue = 10000;
+        mtx.vout[i] = CTxOut(10000, CScript() << OP_TRUE);
     }
     return MakeTransactionRef(mtx);
 }
@@ -105,8 +103,7 @@ static inline CTransactionRef make_ephemeral_tx(const std::vector<COutPoint>& in
     }
     mtx.vout.resize(NUM_EPHEMERAL_TX_OUTPUTS);
     for (auto i{0}; i < NUM_EPHEMERAL_TX_OUTPUTS; ++i) {
-        mtx.vout[i].scriptPubKey = CScript() << OP_TRUE;
-        mtx.vout[i].nValue = (i == EPHEMERAL_DUST_INDEX) ? 0 : 10000;
+        mtx.vout[i] = CTxOut((i == EPHEMERAL_DUST_INDEX) ? 0 : 10000, CScript() << OP_TRUE);
     }
     return MakeTransactionRef(mtx);
 }
@@ -471,8 +468,7 @@ BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
             mtx_many_sigops.vin.back().scriptWitness.stack.emplace_back(script_multisig.begin(), script_multisig.end());
         }
         mtx_many_sigops.vout.resize(1);
-        mtx_many_sigops.vout.back().scriptPubKey = CScript() << OP_TRUE;
-        mtx_many_sigops.vout.back().nValue = 10000;
+        mtx_many_sigops.vout.back() = CTxOut(10000, CScript() << OP_TRUE);
         auto tx_many_sigops{MakeTransactionRef(mtx_many_sigops)};
 
         auto parents{pool.GetParents(entry.FromTx(tx_many_sigops))};

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -50,8 +50,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     {
         spends[i].version = 1;
         spends[i].vin.resize(1);
-        spends[i].vin[0].prevout.hash = m_coinbase_txns[0]->GetHash();
-        spends[i].vin[0].prevout.n = 0;
+        spends[i].vin[0].prevout = COutPoint(m_coinbase_txns[0]->GetHash(), 0);
         spends[i].vout.resize(1);
         spends[i].vout[0].nValue = 11*CENT;
         spends[i].vout[0].scriptPubKey = scriptPubKey;
@@ -185,8 +184,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
 
     spend_tx.version = 1;
     spend_tx.vin.resize(1);
-    spend_tx.vin[0].prevout.hash = m_coinbase_txns[0]->GetHash();
-    spend_tx.vin[0].prevout.n = 0;
+    spend_tx.vin[0].prevout = COutPoint(m_coinbase_txns[0]->GetHash(), 0);
     spend_tx.vout.resize(4);
     spend_tx.vout[0].nValue = 11*CENT;
     spend_tx.vout[0].scriptPubKey = p2sh_scriptPubKey;
@@ -247,8 +245,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         CMutableTransaction invalid_under_p2sh_tx;
         invalid_under_p2sh_tx.version = 1;
         invalid_under_p2sh_tx.vin.resize(1);
-        invalid_under_p2sh_tx.vin[0].prevout.hash = spend_tx.GetHash();
-        invalid_under_p2sh_tx.vin[0].prevout.n = 0;
+        invalid_under_p2sh_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 0);
         invalid_under_p2sh_tx.vout.resize(1);
         invalid_under_p2sh_tx.vout[0].nValue = 11*CENT;
         invalid_under_p2sh_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
@@ -264,8 +261,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_cltv_tx.version = 1;
         invalid_with_cltv_tx.nLockTime = 100;
         invalid_with_cltv_tx.vin.resize(1);
-        invalid_with_cltv_tx.vin[0].prevout.hash = spend_tx.GetHash();
-        invalid_with_cltv_tx.vin[0].prevout.n = 2;
+        invalid_with_cltv_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 2);
         invalid_with_cltv_tx.vin[0].nSequence = 0;
         invalid_with_cltv_tx.vout.resize(1);
         invalid_with_cltv_tx.vout[0].nValue = 11*CENT;
@@ -292,8 +288,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         CMutableTransaction invalid_with_csv_tx;
         invalid_with_csv_tx.version = 2;
         invalid_with_csv_tx.vin.resize(1);
-        invalid_with_csv_tx.vin[0].prevout.hash = spend_tx.GetHash();
-        invalid_with_csv_tx.vin[0].prevout.n = 3;
+        invalid_with_csv_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 3);
         invalid_with_csv_tx.vin[0].nSequence = 100;
         invalid_with_csv_tx.vout.resize(1);
         invalid_with_csv_tx.vout[0].nValue = 11*CENT;
@@ -323,8 +318,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         CMutableTransaction valid_with_witness_tx;
         valid_with_witness_tx.version = 1;
         valid_with_witness_tx.vin.resize(1);
-        valid_with_witness_tx.vin[0].prevout.hash = spend_tx.GetHash();
-        valid_with_witness_tx.vin[0].prevout.n = 1;
+        valid_with_witness_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 1);
         valid_with_witness_tx.vout.resize(1);
         valid_with_witness_tx.vout[0].nValue = 11*CENT;
         valid_with_witness_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
@@ -348,10 +342,8 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
 
         tx.version = 1;
         tx.vin.resize(2);
-        tx.vin[0].prevout.hash = spend_tx.GetHash();
-        tx.vin[0].prevout.n = 0;
-        tx.vin[1].prevout.hash = spend_tx.GetHash();
-        tx.vin[1].prevout.n = 1;
+        tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 0);
+        tx.vin[1].prevout = COutPoint(spend_tx.GetHash(), 1);
         tx.vout.resize(1);
         tx.vout[0].nValue = 22*CENT;
         tx.vout[0].scriptPubKey = p2pk_scriptPubKey;

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -52,8 +52,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
         spends[i].vin.resize(1);
         spends[i].vin[0].prevout = COutPoint(m_coinbase_txns[0]->GetHash(), 0);
         spends[i].vout.resize(1);
-        spends[i].vout[0].nValue = 11*CENT;
-        spends[i].vout[0].scriptPubKey = scriptPubKey;
+        spends[i].vout[0] = CTxOut(11*CENT, scriptPubKey);
 
         // Sign:
         std::vector<unsigned char> vchSig;
@@ -186,14 +185,10 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
     spend_tx.vin.resize(1);
     spend_tx.vin[0].prevout = COutPoint(m_coinbase_txns[0]->GetHash(), 0);
     spend_tx.vout.resize(4);
-    spend_tx.vout[0].nValue = 11*CENT;
-    spend_tx.vout[0].scriptPubKey = p2sh_scriptPubKey;
-    spend_tx.vout[1].nValue = 11*CENT;
-    spend_tx.vout[1].scriptPubKey = p2wpkh_scriptPubKey;
-    spend_tx.vout[2].nValue = 11*CENT;
-    spend_tx.vout[2].scriptPubKey = CScript() << OP_CHECKLOCKTIMEVERIFY << OP_DROP << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
-    spend_tx.vout[3].nValue = 11*CENT;
-    spend_tx.vout[3].scriptPubKey = CScript() << OP_CHECKSEQUENCEVERIFY << OP_DROP << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    spend_tx.vout[0] = CTxOut(11*CENT, p2sh_scriptPubKey);
+    spend_tx.vout[1] = CTxOut(11*CENT, p2wpkh_scriptPubKey);
+    spend_tx.vout[2] = CTxOut(11*CENT, CScript() << OP_CHECKLOCKTIMEVERIFY << OP_DROP << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG);
+    spend_tx.vout[3] = CTxOut(11*CENT, CScript() << OP_CHECKSEQUENCEVERIFY << OP_DROP << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG);
 
     // Sign, with a non-DER signature
     {
@@ -247,8 +242,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_under_p2sh_tx.vin.resize(1);
         invalid_under_p2sh_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 0);
         invalid_under_p2sh_tx.vout.resize(1);
-        invalid_under_p2sh_tx.vout[0].nValue = 11*CENT;
-        invalid_under_p2sh_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+        invalid_under_p2sh_tx.vout[0] = CTxOut(11*CENT, p2pk_scriptPubKey);
         std::vector<unsigned char> vchSig2(p2pk_scriptPubKey.begin(), p2pk_scriptPubKey.end());
         invalid_under_p2sh_tx.vin[0].scriptSig << vchSig2;
 
@@ -264,8 +258,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_cltv_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 2);
         invalid_with_cltv_tx.vin[0].nSequence = 0;
         invalid_with_cltv_tx.vout.resize(1);
-        invalid_with_cltv_tx.vout[0].nValue = 11*CENT;
-        invalid_with_cltv_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+        invalid_with_cltv_tx.vout[0] = CTxOut(11*CENT, p2pk_scriptPubKey);
 
         // Sign
         std::vector<unsigned char> vchSig;
@@ -291,8 +284,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         invalid_with_csv_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 3);
         invalid_with_csv_tx.vin[0].nSequence = 100;
         invalid_with_csv_tx.vout.resize(1);
-        invalid_with_csv_tx.vout[0].nValue = 11*CENT;
-        invalid_with_csv_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+        invalid_with_csv_tx.vout[0] = CTxOut(11*CENT, p2pk_scriptPubKey);
 
         // Sign
         std::vector<unsigned char> vchSig;
@@ -320,8 +312,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         valid_with_witness_tx.vin.resize(1);
         valid_with_witness_tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 1);
         valid_with_witness_tx.vout.resize(1);
-        valid_with_witness_tx.vout[0].nValue = 11*CENT;
-        valid_with_witness_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+        valid_with_witness_tx.vout[0] = CTxOut(11*CENT, p2pk_scriptPubKey);
 
         // Sign
         SignatureData sigdata;
@@ -345,8 +336,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, Dersig100Setup)
         tx.vin[0].prevout = COutPoint(spend_tx.GetHash(), 0);
         tx.vin[1].prevout = COutPoint(spend_tx.GetHash(), 1);
         tx.vout.resize(1);
-        tx.vout[0].nValue = 22*CENT;
-        tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+        tx.vout[0] = CTxOut(22*CENT, p2pk_scriptPubKey);
 
         // Sign
         for (int i = 0; i < 2; ++i) {

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -54,8 +54,7 @@ std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const
         coinbase_tx.vin[0].prevout.SetNull();
         coinbase_tx.vin[0].nSequence = CTxIn::MAX_SEQUENCE_NONFINAL; // Make sure timelock is enforced.
         coinbase_tx.vout.resize(1);
-        coinbase_tx.vout[0].scriptPubKey = P2WSH_OP_TRUE;
-        coinbase_tx.vout[0].nValue = GetBlockSubsidy(height + 1, params.GetConsensus());
+        coinbase_tx.vout[0] = CTxOut(GetBlockSubsidy(height + 1, params.GetConsensus()), P2WSH_OP_TRUE);
         // Always include OP_0 as a dummy extraNonce.
         coinbase_tx.vin[0].scriptSig = CScript() << (height + 1) << OP_0;
         block.vtx = {MakeTransactionRef(std::move(coinbase_tx))};

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -31,8 +31,7 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
     txSpend.vin.resize(1);
     txSpend.vout.resize(1);
     txSpend.vin[0].scriptWitness = scriptWitness;
-    txSpend.vin[0].prevout.hash = txCredit.GetHash();
-    txSpend.vin[0].prevout.n = 0;
+    txSpend.vin[0].prevout = COutPoint(txCredit.GetHash(), 0);
     txSpend.vin[0].scriptSig = scriptSig;
     txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
     txSpend.vout[0].scriptPubKey = CScript();

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -30,9 +30,7 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
     txSpend.vin.resize(1);
     txSpend.vout.resize(1);
     txSpend.vin[0].scriptWitness = scriptWitness;
-    txSpend.vin[0].prevout = COutPoint(txCredit.GetHash(), 0);
-    txSpend.vin[0].scriptSig = scriptSig;
-    txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txSpend.vin[0] = CTxIn(COutPoint(txCredit.GetHash(), 0), scriptSig, CTxIn::SEQUENCE_FINAL);
     txSpend.vout[0] = CTxOut(txCredit.vout[0].nValue, CScript());
 
     return txSpend;

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -17,8 +17,7 @@ CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, CAmou
     txCredit.vin[0].prevout.SetNull();
     txCredit.vin[0].scriptSig = CScript() << CScriptNum(0) << CScriptNum(0);
     txCredit.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
-    txCredit.vout[0].scriptPubKey = scriptPubKey;
-    txCredit.vout[0].nValue = nValue;
+    txCredit.vout[0] = CTxOut(nValue, scriptPubKey);
 
     return txCredit;
 }
@@ -34,8 +33,7 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
     txSpend.vin[0].prevout = COutPoint(txCredit.GetHash(), 0);
     txSpend.vin[0].scriptSig = scriptSig;
     txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
-    txSpend.vout[0].scriptPubKey = CScript();
-    txSpend.vout[0].nValue = txCredit.vout[0].nValue;
+    txSpend.vout[0] = CTxOut(txCredit.vout[0].nValue, CScript());
 
     return txSpend;
 }
@@ -61,10 +59,8 @@ std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keyst
     AddCoins(coinsRet, CTransaction(dummyTransactions[0]), 0);
 
     dummyTransactions[1].vout.resize(2);
-    dummyTransactions[1].vout[0].nValue = nValues[2];
-    dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[2].GetPubKey()));
-    dummyTransactions[1].vout[1].nValue = nValues[3];
-    dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(PKHash(key[3].GetPubKey()));
+    dummyTransactions[1].vout[0] = CTxOut(nValues[2], GetScriptForDestination(PKHash(key[2].GetPubKey())));
+    dummyTransactions[1].vout[1] = CTxOut(nValues[3], GetScriptForDestination(PKHash(key[3].GetPubKey())));
     AddCoins(coinsRet, CTransaction(dummyTransactions[1]), 0);
 
     return dummyTransactions;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -94,8 +94,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     // Another one that has the coinbase reward in a P2WSH with OP_TRUE as witness program to make it easy to spend
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
     txCoinbase.vout.resize(2);
-    txCoinbase.vout[1].scriptPubKey = P2WSH_OP_TRUE;
-    txCoinbase.vout[1].nValue = txCoinbase.vout[0].nValue;
+    txCoinbase.vout[1] = CTxOut(txCoinbase.vout[0].nValue, P2WSH_OP_TRUE);
     txCoinbase.vout[0].nValue = 0;
     txCoinbase.vin[0].scriptWitness.SetNull();
     // Always pad with OP_0 as dummy extraNonce (also avoids bad-cb-length error for block <=16)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5837,8 +5837,7 @@ util::Result<void> ChainstateManager::PopulateAndValidateSnapshot(
             for (size_t i = 0; i < coins_per_txid; i++) {
                 COutPoint outpoint;
                 Coin coin;
-                outpoint.n = static_cast<uint32_t>(ReadCompactSize(coins_file));
-                outpoint.hash = txid;
+                outpoint = COutPoint(txid, static_cast<uint32_t>(ReadCompactSize(coins_file)));
                 coins_file >> coin;
                 if (coin.nHeight > base_height ||
                     outpoint.n >= std::numeric_limits<decltype(outpoint.n)>::max() // Avoid integer wrap-around in coinstats.cpp:ApplyHash

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -66,8 +66,7 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
         CAmount n_value{ConsumeMoney(fuzzed_data_provider)};
         all_values += n_value;
         if (all_values > MAX_MONEY) return;
-        tx.vout[0].nValue = n_value;
-        tx.vout[0].scriptPubKey = GetScriptForDestination(fuzzed_wallet.GetDestination(fuzzed_data_provider));
+        tx.vout[0] = CTxOut(n_value, GetScriptForDestination(fuzzed_wallet.GetDestination(fuzzed_data_provider)));
         LOCK(fuzzed_wallet.wallet->cs_wallet);
         auto txid{tx.GetHash()};
         auto ret{fuzzed_wallet.wallet->mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateConfirmed{chainstate.m_chain.Tip()->GetBlockHash(), chainstate.m_chain.Height(), /*index=*/0}))};

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -36,8 +36,7 @@ static void addCoin(CoinsResult& coins,
     CMutableTransaction tx;
     tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
     tx.vout.resize(1);
-    tx.vout[0].nValue = nValue;
-    tx.vout[0].scriptPubKey = GetScriptForDestination(dest);
+    tx.vout[0] = CTxOut(nValue, GetScriptForDestination(dest));
 
     const auto txid{tx.GetHash()};
     LOCK(wallet.cs_wallet);


### PR DESCRIPTION
#35904 mentions that validation code does not require the data members of `COutPoint`, `CTxOut`, and `CTxIn` to be individually mutable. This requirement instead comes from test code being written in a procedural rather than declarative style.

This PR presents a `bitcoin-tidy` check that identifies consecutive assignments to annotated data members of the same object and suggests rewriting them with a constructor invocation. This allows a mechanical refactoring of the majority of mutations and it paves the road for making the types fully immutable.