### PR TITLE
doc: fix outdated URL in hash_tests.cpp

### DIFF
--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(murmurhash3)
    ...
    in = 00 01 02 ... 3e (63 bytes)
 
-   from: https://131002.net/siphash/siphash24.c
+   from: https://github.com/veorq/SipHash/blob/master/vectors.h
 */
 uint64_t siphash_4_2_testvec[] = {
     0x726fdb47dd0e0e31, 0x74f839c593dc67fd, 0x0d6c8009d9a94f5a, 0x85676696d7fb7e2d,


### PR DESCRIPTION
The old URL still 301-redirects, but to the site root, not to the file — and the file itself is gone: the same path on the new domain returns 404. The author's page at https://www.aumasson.jp/siphash/ says that the SipHash page and documentation have moved to github.com/veorq/SipHash.

The vectors now live in vectors.h in that repository. All 64 values match the array below.