### PR TITLE
validation: prefetch blocks while connecting

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -731,6 +731,9 @@ and its `cs_KeyStore` lock for example).
 - [CCheckQueue::Loop (`b-scriptch.xx`)](https://doxygen.bitcoincore.org/class_c_check_queue.html#checkqueue)
   : Parallel script validation threads for transactions in blocks.
 
+- [Block read-ahead (`b-blockread.xx`)](https://doxygen.bitcoincore.org/classnode_1_1_block_fetcher.html)
+  : Reads blocks from disk while validation connects earlier blocks.
+
 - [ThreadHTTP (`b-http`)](https://doxygen.bitcoincore.org/httpserver_8cpp.html#http)
   : Thread to listen for RPC and REST connections.
 

--- a/doc/release-notes-36000.md
+++ b/doc/release-notes-36000.md
@@ -1,0 +1,6 @@
+Performance Improvements
+------------------------
+
+- A background thread can now prefetch later blocks from disk while another
+  block is being connected, speeding up reindexing and initial block download.
+  (#36000)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   net_processing.cpp
   netgroup.cpp
   node/abort.cpp
+  node/blockfetcher.cpp
   node/blockmanager_args.cpp
   node/blockstorage.cpp
   node/caches.cpp

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(bitcoinkernel
   ../flatfile.cpp
   ../hash.cpp
   ../logging.cpp
+  ../node/blockfetcher.cpp
   ../node/blockstorage.cpp
   ../node/chainstate.cpp
   ../node/utxo_snapshot.cpp

--- a/src/node/blockfetcher.cpp
+++ b/src/node/blockfetcher.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <node/blockfetcher.h>
+
+#include <chain.h>
+#include <kernel/cs_main.h>
+#include <primitives/block.h>
+#include <sync.h>
+#include <uint256.h>
+
+#include <memory>
+#include <utility>
+
+namespace node {
+bool BlockFetcher::ShouldEnqueue(const CBlockIndex* index) { return index && (index->nStatus & BLOCK_HAVE_DATA); }
+
+bool BlockFetcher::Enqueue(const CBlockIndex& index)
+{
+    auto block{std::make_shared<CBlock>()};
+    if (!m_read_block(*block, index.GetBlockPos(), index.GetBlockHash())) return false;
+    m_followup = std::move(block);
+    return true;
+}
+
+std::shared_ptr<const CBlock> BlockFetcher::Load(const uint256& hash)
+{
+    auto block{std::move(m_followup)};
+    return block && block->GetHash() == hash ? block : nullptr;
+}
+
+void BlockFetcher::FillQueue(const CBlockIndex& last_index, int next_height)
+{
+    AssertLockHeld(::cs_main);
+    if (m_followup) return;
+    if (auto* next{last_index.GetAncestor(next_height)}; ShouldEnqueue(next)) Enqueue(*next);
+}
+} // namespace node

--- a/src/node/blockfetcher.cpp
+++ b/src/node/blockfetcher.cpp
@@ -13,35 +13,44 @@
 #include <util/expected.h>
 #include <util/threadpool.h>
 
+#include <cstddef>
 #include <memory>
 #include <utility>
 
 namespace node {
 bool BlockFetcher::ShouldEnqueue(const CBlockIndex* index) { return index && (index->nStatus & BLOCK_HAVE_DATA); }
 
+std::shared_ptr<const CBlock> BlockFetcher::PopFollowup()
+{
+    if (m_followups.empty()) return nullptr;
+    auto followup{std::move(m_followups[0])};
+    m_followups.pop_front();
+    return followup.get();
+}
+
 bool BlockFetcher::Enqueue(const CBlockIndex& index)
 {
-    if (m_pool.WorkersCount() == 0) m_pool.Start(WORKER_COUNT);
     auto followup{m_pool.Submit([&read_block = m_read_block, hash = index.GetBlockHash(), pos = index.GetBlockPos()]() -> std::shared_ptr<const CBlock> {
         auto block{std::make_shared<CBlock>()};
         if (!read_block(*block, pos, hash)) return nullptr;
         return block;
     })};
-    if (followup) m_followup = std::move(*followup);
+    if (followup) m_followups.emplace_back(std::move(*followup));
     return !!followup;
 }
 
 std::shared_ptr<const CBlock> BlockFetcher::Load(const uint256& hash)
 {
-    if (!m_followup.valid()) return nullptr;
-    auto block{m_followup.get()};
-    return block && block->GetHash() == hash ? block : nullptr;
+    if (auto block{PopFollowup()}; block && block->GetHash() == hash) return block;
+    return nullptr;
 }
 
 void BlockFetcher::FillQueue(const CBlockIndex& last_index, int next_height)
 {
     AssertLockHeld(::cs_main);
-    if (m_followup.valid()) return;
-    if (auto* next{last_index.GetAncestor(next_height)}; ShouldEnqueue(next)) Enqueue(*next);
+    for (size_t i{m_followups.size()}; i < m_queue_size; ++i) {
+        const auto* next{last_index.GetAncestor(next_height + i)};
+        if (!ShouldEnqueue(next) || !Enqueue(*next)) break;
+    }
 }
 } // namespace node

--- a/src/node/blockfetcher.cpp
+++ b/src/node/blockfetcher.cpp
@@ -5,10 +5,13 @@
 #include <node/blockfetcher.h>
 
 #include <chain.h>
+#include <flatfile.h>
 #include <kernel/cs_main.h>
 #include <primitives/block.h>
 #include <sync.h>
 #include <uint256.h>
+#include <util/expected.h>
+#include <util/threadpool.h>
 
 #include <memory>
 #include <utility>
@@ -18,22 +21,27 @@ bool BlockFetcher::ShouldEnqueue(const CBlockIndex* index) { return index && (in
 
 bool BlockFetcher::Enqueue(const CBlockIndex& index)
 {
-    auto block{std::make_shared<CBlock>()};
-    if (!m_read_block(*block, index.GetBlockPos(), index.GetBlockHash())) return false;
-    m_followup = std::move(block);
-    return true;
+    if (m_pool.WorkersCount() == 0) m_pool.Start(WORKER_COUNT);
+    auto followup{m_pool.Submit([&read_block = m_read_block, hash = index.GetBlockHash(), pos = index.GetBlockPos()]() -> std::shared_ptr<const CBlock> {
+        auto block{std::make_shared<CBlock>()};
+        if (!read_block(*block, pos, hash)) return nullptr;
+        return block;
+    })};
+    if (followup) m_followup = std::move(*followup);
+    return !!followup;
 }
 
 std::shared_ptr<const CBlock> BlockFetcher::Load(const uint256& hash)
 {
-    auto block{std::move(m_followup)};
+    if (!m_followup.valid()) return nullptr;
+    auto block{m_followup.get()};
     return block && block->GetHash() == hash ? block : nullptr;
 }
 
 void BlockFetcher::FillQueue(const CBlockIndex& last_index, int next_height)
 {
     AssertLockHeld(::cs_main);
-    if (m_followup) return;
+    if (m_followup.valid()) return;
     if (auto* next{last_index.GetAncestor(next_height)}; ShouldEnqueue(next)) Enqueue(*next);
 }
 } // namespace node

--- a/src/node/blockfetcher.cpp
+++ b/src/node/blockfetcher.cpp
@@ -39,9 +39,12 @@ bool BlockFetcher::Enqueue(const CBlockIndex& index)
     return !!followup;
 }
 
+void BlockFetcher::Clear() { m_followups.clear(); }
+
 std::shared_ptr<const CBlock> BlockFetcher::Load(const uint256& hash)
 {
     if (auto block{PopFollowup()}; block && block->GetHash() == hash) return block;
+    Clear();
     return nullptr;
 }
 

--- a/src/node/blockfetcher.h
+++ b/src/node/blockfetcher.h
@@ -1,0 +1,40 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_BLOCKFETCHER_H
+#define BITCOIN_NODE_BLOCKFETCHER_H
+
+#include <kernel/cs_main.h>
+#include <sync.h>
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+class CBlock;
+class CBlockIndex;
+struct FlatFilePos;
+class uint256;
+
+namespace node {
+/** Supplies blocks to validation. */
+class BlockFetcher
+{
+    using ReadBlockFn = std::function<bool(CBlock&, const FlatFilePos&, const uint256&)>;
+
+    const ReadBlockFn m_read_block;
+    std::shared_ptr<const CBlock> m_followup GUARDED_BY(::cs_main);
+
+    static bool ShouldEnqueue(const CBlockIndex* index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool Enqueue(const CBlockIndex& index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+public:
+    explicit BlockFetcher(ReadBlockFn read_block) : m_read_block{std::move(read_block)} {}
+
+    std::shared_ptr<const CBlock> Load(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void FillQueue(const CBlockIndex& last_index, int next_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+};
+} // namespace node
+
+#endif // BITCOIN_NODE_BLOCKFETCHER_H

--- a/src/node/blockfetcher.h
+++ b/src/node/blockfetcher.h
@@ -10,6 +10,7 @@
 #include <util/threadpool.h>
 
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <future>
 #include <memory>
@@ -27,17 +28,20 @@ class BlockFetcher
 {
     using ReadBlockFn = std::function<bool(CBlock&, const FlatFilePos&, const uint256&)>;
 
-    static constexpr uint32_t WORKER_COUNT{1};
-
     const ReadBlockFn m_read_block;
     ThreadPool m_pool{"blockread"};
-    std::future<std::shared_ptr<const CBlock>> m_followup GUARDED_BY(::cs_main);
+    const uint32_t m_queue_size;
+    std::deque<std::future<std::shared_ptr<const CBlock>>> m_followups GUARDED_BY(::cs_main);
 
     static bool ShouldEnqueue(const CBlockIndex* index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    std::shared_ptr<const CBlock> PopFollowup() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool Enqueue(const CBlockIndex& index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 public:
-    explicit BlockFetcher(ReadBlockFn read_block) : m_read_block{std::move(read_block)} {}
+    explicit BlockFetcher(ReadBlockFn read_block, int worker_count = 2, uint32_t queue_size = 4) : m_read_block{std::move(read_block)}, m_queue_size{queue_size}
+    {
+        m_pool.Start(worker_count);
+    }
 
     std::shared_ptr<const CBlock> Load(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void FillQueue(const CBlockIndex& last_index, int next_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/node/blockfetcher.h
+++ b/src/node/blockfetcher.h
@@ -43,6 +43,7 @@ public:
         m_pool.Start(worker_count);
     }
 
+    void Clear() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     std::shared_ptr<const CBlock> Load(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void FillQueue(const CBlockIndex& last_index, int next_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };

--- a/src/node/blockfetcher.h
+++ b/src/node/blockfetcher.h
@@ -7,9 +7,13 @@
 
 #include <kernel/cs_main.h>
 #include <sync.h>
+#include <util/threadpool.h>
 
+#include <cstdint>
 #include <functional>
+#include <future>
 #include <memory>
+#include <string>
 #include <utility>
 
 class CBlock;
@@ -18,13 +22,16 @@ struct FlatFilePos;
 class uint256;
 
 namespace node {
-/** Supplies blocks to validation. */
+/** Supplies blocks to validation. Destruction waits for any queued reads. */
 class BlockFetcher
 {
     using ReadBlockFn = std::function<bool(CBlock&, const FlatFilePos&, const uint256&)>;
 
+    static constexpr uint32_t WORKER_COUNT{1};
+
     const ReadBlockFn m_read_block;
-    std::shared_ptr<const CBlock> m_followup GUARDED_BY(::cs_main);
+    ThreadPool m_pool{"blockread"};
+    std::future<std::shared_ptr<const CBlock>> m_followup GUARDED_BY(::cs_main);
 
     static bool ShouldEnqueue(const CBlockIndex* index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool Enqueue(const CBlockIndex& index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3210,6 +3210,10 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
     const CBlockIndex* pindexOldTip = m_chain.Tip();
     const CBlockIndex* pindexFork = m_chain.FindFork(index_most_work);
     const CBlockIndex* read_ahead_tip{provided_block ? index_most_work.pprev : &index_most_work}; // Avoid rereading the provided block
+    if (pindexFork && pindexFork != pindexOldTip) {
+        m_block_fetcher->Clear();
+        if (read_ahead_tip) m_block_fetcher->FillQueue(*read_ahead_tip, pindexFork->nHeight + 1);
+    }
 
     // Disconnect active blocks which are no longer in the best chain.
     bool fBlocksDisconnected = false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3241,7 +3241,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
 
         // Connect new blocks.
         for (CBlockIndex* pindexConnect : vpindexToConnect | std::views::reverse) {
-            if (!ConnectTip(state, pindexConnect, pindexConnect == &index_most_work ? pblock : std::shared_ptr<const CBlock>(), connected_blocks, disconnectpool)) {
+            auto block_to_connect{pindexConnect == &index_most_work ? pblock : std::shared_ptr<const CBlock>()};
+            if (!ConnectTip(state, pindexConnect, std::move(block_to_connect), connected_blocks, disconnectpool)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
@@ -3387,11 +3388,12 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
 
                 bool fInvalidFound = false;
                 std::shared_ptr<const CBlock> nullBlockPtr;
+                auto block_to_connect{pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr};
                 // BlockConnected signals must be sent for the original role;
                 // in case snapshot validation is completed during ActivateBestChainStep, the
                 // result of GetRole() changes from BACKGROUND to NORMAL.
                const ChainstateRole chainstate_role{this->GetRole()};
-                if (!ActivateBestChainStep(state, *pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connected_blocks)) {
+                if (!ActivateBestChainStep(state, *pindexMostWork, block_to_connect, fInvalidFound, connected_blocks)) {
                     // A system error occurred
                     return false;
                 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -29,6 +29,7 @@
 #include <kernel/types.h>
 #include <kernel/warning.h>
 #include <logging/timer.h>
+#include <node/blockfetcher.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
 #include <policy/ephemeral_policy.h>
@@ -1864,11 +1865,16 @@ Chainstate::Chainstate(
     BlockManager& blockman,
     ChainstateManager& chainman,
     std::optional<uint256> from_snapshot_blockhash)
-    : m_mempool(mempool),
+    : m_block_fetcher{std::make_unique<node::BlockFetcher>([blockman = &blockman](CBlock& block, const FlatFilePos& pos, const uint256& hash) {
+          return blockman->ReadBlock(block, pos, hash);
+      })},
+      m_mempool(mempool),
       m_blockman(blockman),
       m_chainman(chainman),
       m_assumeutxo(from_snapshot_blockhash ? Assumeutxo::UNVALIDATED : Assumeutxo::VALIDATED),
       m_from_snapshot_blockhash(from_snapshot_blockhash) {}
+
+Chainstate::~Chainstate() = default;
 
 fs::path Chainstate::StoragePath() const
 {
@@ -3192,17 +3198,18 @@ void Chainstate::PruneBlockIndexCandidates() {
 
 /**
  * Try to make some progress towards making index_most_work the active block.
- * pblock is either nullptr or a pointer to a CBlock corresponding to index_most_work.
+ * provided_block is either nullptr or points to the CBlock corresponding to index_most_work.
  *
  * @returns true unless a system error occurred
  */
-bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks)
+bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& provided_block, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks)
 {
     AssertLockHeld(cs_main);
     if (m_mempool) AssertLockHeld(m_mempool->cs);
 
     const CBlockIndex* pindexOldTip = m_chain.Tip();
     const CBlockIndex* pindexFork = m_chain.FindFork(index_most_work);
+    const CBlockIndex* read_ahead_tip{provided_block ? index_most_work.pprev : &index_most_work}; // Avoid rereading the provided block
 
     // Disconnect active blocks which are no longer in the best chain.
     bool fBlocksDisconnected = false;
@@ -3241,7 +3248,8 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex&
 
         // Connect new blocks.
         for (CBlockIndex* pindexConnect : vpindexToConnect | std::views::reverse) {
-            auto block_to_connect{pindexConnect == &index_most_work ? pblock : std::shared_ptr<const CBlock>()};
+            auto block_to_connect{provided_block && pindexConnect == &index_most_work ? provided_block : m_block_fetcher->Load(pindexConnect->GetBlockHash())};
+            if (read_ahead_tip) m_block_fetcher->FillQueue(*read_ahead_tip, pindexConnect->nHeight + 1);
             if (!ConnectTip(state, pindexConnect, std::move(block_to_connect), connected_blocks, disconnectpool)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.

--- a/src/validation.h
+++ b/src/validation.h
@@ -63,6 +63,7 @@ namespace kernel {
 struct ChainstateRole;
 } // namespace kernel
 namespace node {
+class BlockFetcher;
 class SnapshotMetadata;
 } // namespace node
 namespace Consensus {
@@ -556,6 +557,9 @@ protected:
      */
     Mutex m_chainstate_mutex;
 
+    //! Reads blocks ahead during chain activation.
+    std::unique_ptr<node::BlockFetcher> m_block_fetcher;
+
     //! Optional mempool that is kept in sync with the chain.
     //! Only the active chainstate has a mempool.
     CTxMemPool* m_mempool;
@@ -586,6 +590,7 @@ public:
         node::BlockManager& blockman,
         ChainstateManager& chainman,
         std::optional<uint256> from_snapshot_blockhash = std::nullopt);
+    ~Chainstate();
 
     //! Return path to chainstate leveldb directory.
     fs::path StoragePath() const;
@@ -851,7 +856,7 @@ public:
     std::pair<int, int> GetPruneRange(int last_height_can_prune) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 protected:
-    bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& provided_block, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     bool ConnectTip(
         BlockValidationState& state,
         CBlockIndex* pindexNew,

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -18,6 +18,11 @@ from test_framework.util import (
 )
 
 
+def blockread_msgs(count):
+    """Startup lines logged by the block read-ahead workers, one per worker thread."""
+    return [f"blockread.{worker:02d} thread start" for worker in range(count)]
+
+
 class ReindexTest(BitcoinTestFramework):
     def set_test_params(self):
         self.rpc_timeout *= 2  # To avoid timeout when generating the reindex chain
@@ -25,11 +30,19 @@ class ReindexTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def reindex(self, justchainstate=False):
-        self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
+        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=blockread_msgs(1)):
+            self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
         extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
-        self.start_nodes(extra_args)
+        # Reindex connects multiple blocks in one ActivateBestChain() call, exercising read-ahead.
+        log_start = self.nodes[0].debug_log_size(encoding='utf-8')
+        read_ahead_msgs = ["Using cached block"]
+        with self.nodes[0].assert_debug_log(expected_msgs=read_ahead_msgs, unexpected_msgs=blockread_msgs(1)):
+            self.start_nodes(extra_args)
+        with open(self.nodes[0].debug_log_path, encoding='utf-8', errors='replace') as debug_log:
+            debug_log.seek(log_start)
+            assert_equal(debug_log.read().count('Using cached block'), blockcount if justchainstate else blockcount - 1)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")
 

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -37,12 +37,16 @@ class ReindexTest(BitcoinTestFramework):
         extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
         # Reindex connects multiple blocks in one ActivateBestChain() call, exercising read-ahead.
         log_start = self.nodes[0].debug_log_size(encoding='utf-8')
-        read_ahead_msgs = ["Using cached block"]
-        with self.nodes[0].assert_debug_log(expected_msgs=read_ahead_msgs, unexpected_msgs=blockread_msgs(1)):
+        read_ahead_msgs = blockread_msgs(1) + ["Using cached block"]
+        with self.nodes[0].assert_debug_log(expected_msgs=read_ahead_msgs, unexpected_msgs=[]):
             self.start_nodes(extra_args)
         with open(self.nodes[0].debug_log_path, encoding='utf-8', errors='replace') as debug_log:
             debug_log.seek(log_start)
             assert_equal(debug_log.read().count('Using cached block'), blockcount if justchainstate else blockcount - 1)
+        block_hash = self.nodes[0].getblockhash(1)  # Reconnect in a second activation to check worker reuse.
+        self.nodes[0].invalidateblock(block_hash)
+        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=blockread_msgs(1)):
+            self.nodes[0].reconsiderblock(block_hash)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")
 

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -30,14 +30,14 @@ class ReindexTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def reindex(self, justchainstate=False):
-        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=blockread_msgs(1)):
+        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=blockread_msgs(2)):
             self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
         extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
         # Reindex connects multiple blocks in one ActivateBestChain() call, exercising read-ahead.
         log_start = self.nodes[0].debug_log_size(encoding='utf-8')
-        read_ahead_msgs = blockread_msgs(1) + ["Using cached block"]
+        read_ahead_msgs = blockread_msgs(2) + ["Using cached block"]
         with self.nodes[0].assert_debug_log(expected_msgs=read_ahead_msgs, unexpected_msgs=[]):
             self.start_nodes(extra_args)
         with open(self.nodes[0].debug_log_path, encoding='utf-8', errors='replace') as debug_log:
@@ -45,7 +45,7 @@ class ReindexTest(BitcoinTestFramework):
             assert_equal(debug_log.read().count('Using cached block'), blockcount if justchainstate else blockcount - 1)
         block_hash = self.nodes[0].getblockhash(1)  # Reconnect in a second activation to check worker reuse.
         self.nodes[0].invalidateblock(block_hash)
-        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=blockread_msgs(1)):
+        with self.nodes[0].assert_debug_log(expected_msgs=[], unexpected_msgs=blockread_msgs(2)):
             self.nodes[0].reconsiderblock(block_hash)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -8,10 +8,12 @@
 - Stop the node and restart it with -reindex. Verify that the node has reindexed up to block 3.
 - Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
 - Verify that out-of-order blocks are correctly processed, see LoadExternalBlockFile()
+- Verify that the first block on a competing fork is prefetched during a reorg.
 """
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import create_block
 from test_framework.messages import MAGIC_BYTES
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     util_xor,
@@ -115,6 +117,27 @@ class ReindexTest(BitcoinTestFramework):
             node.wait_for_rpc_connection(wait_for_import=False)
         node.stop_node()
 
+    def reorg(self):
+        self.log.info("Test block read-ahead during a reorg")
+        node = self.nodes[0]
+        height = node.getblockcount()
+        fork_hash = node.getblockhash(height - 1)
+        block_time = node.getblock(fork_hash)['time'] + 1
+        fork_block = create_block(int(fork_hash, 16), height=height, ntime=block_time)
+        fork_block.solve()
+        assert_equal(node.submitblock(fork_block.serialize().hex()), 'inconclusive')
+        assert_equal(node.getblockcount(), height)
+
+        fork_tip = create_block(fork_block.hash_int, height=height + 1, ntime=block_time + 1)
+        fork_tip.solve()
+        log_start = node.debug_log_size(encoding='utf-8')
+        assert_equal(node.submitblock(fork_tip.serialize().hex()), None)
+        with open(node.debug_log_path, encoding='utf-8', errors='replace') as debug_log:
+            debug_log.seek(log_start)
+            # The tip is caller-provided, so the other cached block is the prefetched sibling.
+            assert_equal(debug_log.read().count('Using cached block'), 2)
+        assert_equal(node.getbestblockhash(), fork_tip.hash_hex)
+
     def run_test(self):
         self.reindex(False)
         self.reindex(True)
@@ -122,6 +145,7 @@ class ReindexTest(BitcoinTestFramework):
         self.reindex(True)
 
         self.out_of_order()
+        self.reorg()
         self.continue_reindex_after_shutdown()
 
 


### PR DESCRIPTION
**Problem:** Block reading and deserialization happen immediately before block connection, so their mostly I/O-bound work does not overlap CPU-bound validation.

This is a follow-up to [#35295](https://github.com/bitcoin/bitcoin/pull/35295), which parallelized input prevout fetching during block connection.

**Fix:** Add a `Chainstate`-owned block fetcher that reads later blocks from disk while the current block is connected. Start with synchronous 1-block read-ahead, then move reads to an eagerly started 2-worker pool that persists across activations. Keep blocks provided by the caller on the existing direct path and maintain a sliding queue of up to 4 disk reads. During reorgs, start reading the first sibling while disconnecting the old tip.

This PR deliberately uses 2 readers and a fixed queue size of 4. Current measurements favor 2 readers with queue sizes of 4 or 8, so this uses the smaller queue. The worker count and queue size can be made configurable later if further measurements justify tuning them.

**Credit:** The idea comes from [bitcoindev1337](https://bitcoin-irc.chaincode.com/bitcoin-core-dev/2026-08-11#1245429), who had already implemented a similar design and reported comparable results.
<details><summary>Benchmark results</summary>

```python
1d6656c6b0 refactor: prepare block fetcher wiring
3547915bfb doc: add block read-ahead release note

2026-09-02 | reindex-chainstate | 964469 blocks | dbcache 2000 | i7-hdd | x86_64 | Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz | 8 threads | 62Gi RAM | HDD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
  Time (abs ≡):        30017.350 s               [User: 44516.820 s, System: 1392.820 s]

Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
  Time (abs ≡):        19609.006 s               [User: 46710.915 s, System: 1466.050 s]

Relative speed comparison
        1.53          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
```

```python
2026-09-02 | reindex-chainstate | 964469 blocks | dbcache 2000 | i9-ssd | x86_64 | Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz | 16 threads | 62Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
  Time (mean ± σ):     14954.582 s ± 47.740 s    [User: 41200.553 s, System: 1293.087 s]
  Range (min … max):   14920.825 s … 14988.339 s    2 runs
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
  Time (mean ± σ):     9499.382 s ± 26.187 s    [User: 42840.137 s, System: 1291.391 s]
  Range (min … max):   9480.865 s … 9517.899 s    2 runs
 
Relative speed comparison
        1.57 ±  0.01  COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
```

```python
2026-09-02 | reindex-chainstate | 964469 blocks | dbcache 2000 | rpi5-16-2 | aarch64 | Cortex-A76 | 4 threads | 15Gi RAM | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
  Time (abs ≡):        37266.870 s               [User: 77596.462 s, System: 5504.890 s]
 
Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
  Time (abs ≡):        31224.887 s               [User: 76833.950 s, System: 5281.869 s]
 
Relative speed comparison
        1.19          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -reindex-chainstate -assumevalid=00000000000000000000ccebd6d74d9194d8dcdc1d177c478e094bfad51ba5ac -blocksonly -disablewallet -connect=0 -listen=0 -dnsseed=0 -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
```

```python
2026-09-02 | IBD | 964469 blocks | dbcache 2000 | ssd-ryzen | x86_64 | AMD Ryzen 7 3700X 8-Core Processor | 16 threads | 62Gi RAM | ext4 | SSD

Benchmark 1: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -blocksonly -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
  Time (mean ± σ):     18325.931 s ± 713.652 s    [User: 40928.980 s, System: 4110.338 s]
  Range (min … max):   17821.303 s … 18830.559 s    2 runs

Benchmark 2: COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -blocksonly -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
  Time (mean ± σ):     16192.131 s ± 232.698 s    [User: 40349.710 s, System: 2982.493 s]
  Range (min … max):   16027.589 s … 16356.674 s    2 runs

Relative speed comparison
        1.13 ±  0.05  COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -blocksonly -printtoconsole=0 (COMMIT = 1d6656c6b024578db910f45f4a131f18d75a2ed0)
        1.00          COMPILER=gcc ./build/bin/bitcoind -datadir=/mnt/my_storage/BitcoinData -stopatheight=964469 -dbcache=2000 -blocksonly -printtoconsole=0 (COMMIT = 3547915bfb240f280188954c7c5b60ec90145ac5)
```

</details>
