### PR TITLE
test: validate JSON in RPC help examples

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -540,7 +540,7 @@ static RPCMethod getblockfrompeer()
         RPCResult{RPCResult::Type::OBJ, "", /*optional=*/false, "", {}},
         RPCExamples{
             HelpExampleCli("getblockfrompeer", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 0")
-            + HelpExampleRpc("getblockfrompeer", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 0")
+            + HelpExampleRpc("getblockfrompeer", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\", 0")
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -869,7 +869,7 @@ static RPCMethod getmempoolcluster()
             RPCResult::Type::OBJ, "", "", ClusterDescription()},
         RPCExamples{
             HelpExampleCli("getmempoolcluster", "txid")
-            + HelpExampleRpc("getmempoolcluster", "txid")
+            + HelpExampleRpc("getmempoolcluster", "\"txid\"")
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -1166,7 +1166,7 @@ static RPCMethod importmempool()
              RPCArgOptions{.oneline_description = "options"}},
         },
         RPCResult{RPCResult::Type::OBJ, "", "", std::vector<RPCResult>{}},
-        RPCExamples{HelpExampleCli("importmempool", "/path/to/mempool.dat") + HelpExampleRpc("importmempool", "/path/to/mempool.dat")},
+        RPCExamples{HelpExampleCli("importmempool", "/path/to/mempool.dat") + HelpExampleRpc("importmempool", "\"/path/to/mempool.dat\"")},
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue {
             const NodeContext& node{EnsureAnyNodeContext(request.context)};
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -335,7 +335,7 @@ static RPCMethod addnode()
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{
                     HelpExampleCli("addnode", "\"192.168.0.6:8333\" \"onetry\" true")
-            + HelpExampleRpc("addnode", "\"192.168.0.6:8333\", \"onetry\" true")
+            + HelpExampleRpc("addnode", "\"192.168.0.6:8333\", \"onetry\", true")
                 },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -410,7 +410,7 @@ static RPCMethod addconnection()
             }},
         RPCExamples{
             HelpExampleCli("addconnection", "\"192.168.0.6:8333\" \"outbound-full-relay\" true")
-            + HelpExampleRpc("addconnection", "\"192.168.0.6:8333\" \"outbound-full-relay\" true")
+            + HelpExampleRpc("addconnection", "\"192.168.0.6:8333\", \"outbound-full-relay\", true")
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -1083,7 +1083,7 @@ static RPCMethod sendmsgtopeer()
         },
         RPCResult{RPCResult::Type::OBJ, "", "", std::vector<RPCResult>{}},
         RPCExamples{
-            HelpExampleCli("sendmsgtopeer", "0 \"addr\" \"ffffff\"") + HelpExampleRpc("sendmsgtopeer", "0 \"addr\" \"ffffff\"")},
+            HelpExampleCli("sendmsgtopeer", "0 \"addr\" \"ffffff\"") + HelpExampleRpc("sendmsgtopeer", "0, \"addr\", \"ffffff\"")},
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue {
             const NodeId peer_id{request.params[0].getInt<int64_t>()};
             const auto msg_type{self.Arg<std::string_view>("msg_type")};

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -378,7 +378,7 @@ static RPCMethod getindexinfo()
                     HelpExampleCli("getindexinfo", "")
                   + HelpExampleRpc("getindexinfo", "")
                   + HelpExampleCli("getindexinfo", "txindex")
-                  + HelpExampleRpc("getindexinfo", "txindex")
+                  + HelpExampleRpc("getindexinfo", "\"txindex\"")
                 },
                 [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -642,7 +642,7 @@ RPCMethod listlabels()
             "\nList labels that have sending addresses\n"
             + HelpExampleCli("listlabels", "send") +
             "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("listlabels", "receive")
+            + HelpExampleRpc("listlabels", "\"receive\"")
                 },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -618,7 +618,7 @@ RPCMethod restorewallet()
         },
         RPCExamples{
             HelpExampleCli("restorewallet", "\"testwallet\" \"home\\backups\\backup-file.bak\"")
-            + HelpExampleRpc("restorewallet", "\"testwallet\" \"home\\backups\\backup-file.bak\"")
+            + HelpExampleRpc("restorewallet", "\"testwallet\", \"home\\\\backups\\\\backup-file.bak\"")
             + HelpExampleCliNamed("restorewallet", {{"wallet_name", "testwallet"}, {"backup_file", "home\\backups\\backup-file.bak\""}, {"load_on_startup", true}})
             + HelpExampleRpcNamed("restorewallet", {{"wallet_name", "testwallet"}, {"backup_file", "home\\backups\\backup-file.bak\""}, {"load_on_startup", true}})
         },

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -514,7 +514,7 @@ RPCMethod listunspent()
                 RPCExamples{
                     HelpExampleCli("listunspent", "")
             + HelpExampleCli("listunspent", "6 9999999 \"[\\\"" + EXAMPLE_ADDRESS[0] + "\\\",\\\"" + EXAMPLE_ADDRESS[1] + "\\\"]\"")
-            + HelpExampleRpc("listunspent", "6, 9999999 \"[\\\"" + EXAMPLE_ADDRESS[0] + "\\\",\\\"" + EXAMPLE_ADDRESS[1] + "\\\"]\"")
+            + HelpExampleRpc("listunspent", "6, 9999999, [\"" + EXAMPLE_ADDRESS[0] + "\",\"" + EXAMPLE_ADDRESS[1] + "\"]")
             + HelpExampleCli("listunspent", "6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'")
             + HelpExampleRpc("listunspent", "6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ")
                 },

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -249,7 +249,7 @@ static RPCMethod loadwallet()
                     + HelpExampleRpc("loadwallet", "\"/path/to/walletname/\"")
                     + "\nLoad wallet using absolute path (Windows):\n"
                     + HelpExampleCli("loadwallet", "\"DriveLetter:\\path\\to\\walletname\\\"")
-                    + HelpExampleRpc("loadwallet", "\"DriveLetter:\\path\\to\\walletname\\\"")
+                    + HelpExampleRpc("loadwallet", "\"DriveLetter:\\\\path\\\\to\\\\walletname\\\\\"")
                 },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -457,7 +457,7 @@ static RPCMethod unloadwallet()
                 }},
                 RPCExamples{
                     HelpExampleCli("unloadwallet", "wallet_name")
-            + HelpExampleRpc("unloadwallet", "wallet_name")
+            + HelpExampleRpc("unloadwallet", "\"wallet_name\"")
                 },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -761,7 +761,7 @@ static RPCMethod createwalletdescriptor()
         },
         RPCExamples{
             HelpExampleCli("createwalletdescriptor", "bech32m")
-            + HelpExampleRpc("createwalletdescriptor", "bech32m")
+            + HelpExampleRpc("createwalletdescriptor", "\"bech32m\"")
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
         {
@@ -851,7 +851,7 @@ RPCMethod addhdkey()
             },
         },
         RPCExamples{
-            HelpExampleCli("addhdkey", "xprv") + HelpExampleRpc("addhdkey", "xprv")
+            HelpExampleCli("addhdkey", "xprv") + HelpExampleRpc("addhdkey", "\"xprv\"")
         },
         [&](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
         {

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -8,6 +8,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
 from collections import defaultdict
+import json
 import os
 import re
 
@@ -153,9 +154,18 @@ class HelpRpcTest(BitcoinTestFramework):
         os.mkdir(dump_dir)
         calls = [line.split(' ', 1)[0] for line in self.nodes[0].help().splitlines() if line and not line.startswith('==')]
         for call in calls:
+            help_text = self.nodes[0].help(call)
+            for line in help_text.splitlines():
+                if "--data-binary '" not in line:
+                    continue
+                payload = line.split("--data-binary '", 1)[1].rsplit("' -H 'content-type: application/json'", 1)[0]
+                try:
+                    json.loads(payload)
+                except json.JSONDecodeError as e:
+                    raise AssertionError(f"Invalid JSON in HelpExampleRpc for {call}: {e}: {payload}") from e
             with open(os.path.join(dump_dir, call), 'w') as f:
                 # Make sure the node can generate the help at runtime without crashing
-                f.write(self.nodes[0].help(call))
+                f.write(help_text)
 
     def wallet_help(self):
         assert 'getnewaddress ( "label" "address_type" )' in self.nodes[0].help('getnewaddress')


### PR DESCRIPTION
Resolves bitcoin/bitcoin#35864

## Summary

`HelpExampleRpc` builds JSON-RPC curl examples from literal argument strings. This change adds a functional-test guard that parses every generated curl payload as JSON, preventing future malformed examples from being published in RPC help text.

The guard exposed and this PR fixes malformed examples across blockchain, networking, mempool, wallet, and wallet-backup RPC help. The fixes cover missing commas, bare string placeholders, a JSON address-array example, and Windows path escaping.

## Testing

- `python3 -m py_compile test/functional/rpc_help.py`
- `rpc_help.py` functional test: passed
- `ctest --test-dir build --output-on-failure --parallel 2`: 100% passed, 0 failed out of 372 tests; 1 test skipped (`script_assets_tests`)
- Bitcoin Core build with wallet, IPC, ZMQ, and tests enabled: passed

The regtest RPC smoke workflow was also run separately with local-only disposable state; it mined 101 blocks, validated a signed transaction with `testmempoolaccept`, confirmed it, and shut the daemon down automatically.