### PR TITLE
rpc, descriptor: warn when multipath expansion clones single-path key expressions

### DIFF
--- a/doc/release-notes-36005.md
+++ b/doc/release-notes-36005.md
@@ -1,0 +1,15 @@
+Updated RPCs
+------------
+
+- Descriptors mixing multipath key expressions with single-path ones (e.g.
+  `wsh(multi(2,A/<0;1>/*,B/0/*))`) now produce a warning, since the single-path
+  key expressions are repeated in every expanded descriptor and the same keys
+  end up in all of the resulting scripts. The warning is returned by
+  `importdescriptors` and `getdescriptorinfo`. (#35985)
+
+- `getdescriptorinfo` now returns a `warnings` field with the descriptor's
+  warnings, including the existing warnings for unsafe `older()` values in
+  miniscript descriptors.
+
+- The `warnings` field of RPC results no longer contains duplicates, which
+  `importdescriptors` previously returned once per multipath expansion.

--- a/src/rpc/output_script.cpp
+++ b/src/rpc/output_script.cpp
@@ -185,6 +185,10 @@ static RPCMethod getdescriptorinfo()
                 {RPCResult::Type::BOOL, "isrange", "Whether the descriptor is ranged"},
                 {RPCResult::Type::BOOL, "issolvable", "Whether the descriptor is solvable"},
                 {RPCResult::Type::BOOL, "hasprivatekeys", "Whether the input descriptor contained at least one private key"},
+                {RPCResult::Type::ARR, "warnings", /*optional=*/true, "Warning messages, if any, about the descriptor.",
+                {
+                    {RPCResult::Type::STR, "", ""},
+                }},
             }
         },
         RPCExamples{
@@ -216,6 +220,14 @@ static RPCMethod getdescriptorinfo()
             result.pushKV("isrange", descs.at(0)->IsRange());
             result.pushKV("issolvable", descs.at(0)->IsSolvable());
             result.pushKV("hasprivatekeys", provider.keys.size() > 0);
+
+            UniValue warnings(UniValue::VARR);
+            for (const auto& desc : descs) {
+                for (const std::string& w : desc->Warnings()) {
+                    warnings.push_back(w);
+                }
+            }
+            PushWarnings(warnings, result);
             return result;
         },
     };

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <set>
 #include <string_view>
 #include <tuple>
 #include <utility>
@@ -1402,14 +1403,19 @@ std::vector<uint32_t> ParsePathBIP32(const std::string& path)
 
 void PushWarnings(const UniValue& warnings, UniValue& obj)
 {
-    if (warnings.empty()) return;
-    obj.pushKV("warnings", warnings);
+    UniValue distinct(UniValue::VARR);
+    std::set<std::string> seen;
+    for (const auto& w : warnings.getValues()) {
+        if (seen.insert(w.get_str()).second) distinct.push_back(w);
+    }
+    if (distinct.empty()) return;
+    obj.pushKV("warnings", distinct);
 }
 
 void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj)
 {
     if (warnings.empty()) return;
-    obj.pushKV("warnings", BilingualStringsToUniValue(warnings));
+    PushWarnings(BilingualStringsToUniValue(warnings), obj);
 }
 
 std::vector<RPCResult> ScriptPubKeyDoc() {

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -542,7 +542,8 @@ private:
 };
 
 /**
- * Push warning messages to an RPC "warnings" field as a JSON array of strings.
+ * Push warning messages to an RPC "warnings" field as a JSON array of strings,
+ * only keeping the first occurrence of duplicate warnings.
  *
  * @param[in] warnings  Warning messages to push.
  * @param[out] obj      UniValue object to push the warnings array object to.

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -834,6 +834,9 @@ public:
     }
 };
 
+//! Warning for descriptors mixing multipath and single-path key expressions, see Parse().
+const std::string MULTIPATH_CLONED_KEYS_WARNING = "multipath expansion: key expressions without a multipath specifier are repeated in every expanded descriptor, reusing the same keys";
+
 /** Base class for all Descriptor implementations. */
 class DescriptorImpl : public Descriptor
 {
@@ -1084,6 +1087,9 @@ public:
         }
         return all;
     }
+
+    //! Add a warning to this descriptor. Used by Parse().
+    void AddWarning(std::string warning) { m_warnings.push_back(std::move(warning)); }
 
     uint32_t GetMaxKeyExpr() const final
     {
@@ -2336,7 +2342,7 @@ struct KeyParser {
 
 /** Parse a script in a particular context. */
 // NOLINTNEXTLINE(misc-no-recursion)
-std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index, std::span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error)
+std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index, std::span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error, bool& multipath_cloned)
 {
     using namespace script;
     Assume(ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH || ctx == ParseScriptContext::P2WSH || ctx == ParseScriptContext::P2TR);
@@ -2441,6 +2447,7 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         // For length 1 vectors, clone key providers until vector is the same length
         for (auto& vec : providers) {
             if (vec.size() == 1) {
+                if (max_providers_len > 1) multipath_cloned = true;
                 for (size_t i = 1; i < max_providers_len; ++i) {
                     vec.emplace_back(vec.at(0)->Clone());
                 }
@@ -2487,7 +2494,7 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         return {};
     }
     if (ctx == ParseScriptContext::TOP && Func("sh", expr)) {
-        auto descs = ParseScript(key_exp_index, expr, ParseScriptContext::P2SH, out, error);
+        auto descs = ParseScript(key_exp_index, expr, ParseScriptContext::P2SH, out, error, multipath_cloned);
         if (descs.empty() || expr.size()) return {};
         std::vector<std::unique_ptr<DescriptorImpl>> ret;
         ret.reserve(descs.size());
@@ -2500,7 +2507,7 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         return {};
     }
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH) && Func("wsh", expr)) {
-        auto descs = ParseScript(key_exp_index, expr, ParseScriptContext::P2WSH, out, error);
+        auto descs = ParseScript(key_exp_index, expr, ParseScriptContext::P2WSH, out, error, multipath_cloned);
         if (descs.empty() || expr.size()) return {};
         for (auto& desc : descs) {
             ret.emplace_back(std::make_unique<WSHDescriptor>(std::move(desc)));
@@ -2554,7 +2561,7 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
                 }
                 // Process the actual script expression.
                 auto sarg = Expr(expr);
-                subscripts.emplace_back(ParseScript(key_exp_index, sarg, ParseScriptContext::P2TR, out, error));
+                subscripts.emplace_back(ParseScript(key_exp_index, sarg, ParseScriptContext::P2TR, out, error, multipath_cloned));
                 if (subscripts.back().empty()) return {};
                 max_providers_len = std::max(max_providers_len, subscripts.back().size());
                 depths.push_back(branches.size());
@@ -2587,6 +2594,7 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
         // For length 1 vectors, clone subdescs until vector is the same length
         for (auto& vec : subscripts) {
             if (vec.size() == 1) {
+                if (max_providers_len > 1) multipath_cloned = true;
                 for (size_t i = 1; i < max_providers_len; ++i) {
                     vec.emplace_back(vec.at(0)->Clone());
                 }
@@ -2600,6 +2608,9 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
             error = strprintf("tr(): Multipath internal key mismatches multipath subscripts lengths");
             return {};
         }
+
+        // A single-path internal key is about to be cloned into every multipath branch, flag it
+        if (internal_keys.size() == 1 && max_providers_len > 1) multipath_cloned = true;
 
         while (internal_keys.size() < max_providers_len) {
             internal_keys.emplace_back(internal_keys.at(0)->Clone());
@@ -2726,6 +2737,7 @@ std::vector<std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index
 
             for (auto& vec : parser.m_keys) {
                 if (vec.size() == 1) {
+                    if (num_multipath > 1) multipath_cloned = true;
                     for (size_t i = 1; i < num_multipath; ++i) {
                         vec.emplace_back(vec.at(0)->Clone());
                     }
@@ -2960,11 +2972,13 @@ std::vector<std::unique_ptr<Descriptor>> Parse(std::string_view descriptor, Flat
     std::span<const char> sp{descriptor};
     if (!CheckChecksum(sp, require_checksum, error)) return {};
     uint32_t key_exp_index = 0;
-    auto ret = ParseScript(key_exp_index, sp, ParseScriptContext::TOP, out, error);
+    bool multipath_cloned = false;
+    auto ret = ParseScript(key_exp_index, sp, ParseScriptContext::TOP, out, error, multipath_cloned);
     if (sp.empty() && !ret.empty()) {
         std::vector<std::unique_ptr<Descriptor>> descs;
         descs.reserve(ret.size());
         for (auto& r : ret) {
+            if (multipath_cloned) r->AddWarning(MULTIPATH_CLONED_KEYS_WARNING);
             descs.emplace_back(std::unique_ptr<Descriptor>(std::move(r)));
         }
         return descs;

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -1345,6 +1345,60 @@ BOOST_AUTO_TEST_CASE(descriptor_older_warnings)
     }
 }
 
+void CheckMultipathCloneWarning(const std::string& desc, bool expect_warning)
+{
+    const std::string expected_warning = "multipath expansion: key expressions without a multipath specifier are repeated in every expanded descriptor, reusing the same keys";
+    FlatSigningProvider keys;
+    std::string error;
+    auto descs = Parse(desc, keys, error);
+    BOOST_REQUIRE_MESSAGE(!descs.empty(), desc + ": " + error);
+    for (const auto& d : descs) {
+        const auto warnings = d->Warnings();
+        if (expect_warning) {
+            BOOST_REQUIRE_MESSAGE(warnings.size() == 1U, desc);
+            BOOST_CHECK_EQUAL(warnings[0], expected_warning);
+        } else {
+            BOOST_CHECK_MESSAGE(warnings.empty(), desc);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_multipath_clone_warnings)
+{
+    const std::string xpub_a = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL";
+    const std::string xpub_b = "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y";
+
+    // multi(): a single-path key next to a multipath one is cloned into every branch
+    CheckMultipathCloneWarning("wsh(multi(1," + xpub_a + "/<0;1>/*," + xpub_b + "/0/*))", /*expect_warning=*/true);
+    CheckMultipathCloneWarning("wsh(multi(1," + xpub_a + "/<0;1>/*," + xpub_b + "/<2;3>/*))", /*expect_warning=*/false);
+    CheckMultipathCloneWarning("wsh(multi(1," + xpub_a + "/0/*," + xpub_b + "/1/*))", /*expect_warning=*/false);
+    // A bare non-ranged pubkey is cloned too
+    CheckMultipathCloneWarning("wsh(multi(1," + xpub_a + "/<0;1>/*,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))", /*expect_warning=*/true);
+
+    // tr(): cloned internal key, including the BIP341 NUMS point: an identical internal key
+    // revealed by script-path spends is a clustering vector too
+    CheckMultipathCloneWarning("tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk(" + xpub_a + "/<0;1>/*))", /*expect_warning=*/true);
+    CheckMultipathCloneWarning("tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,pk(" + xpub_a + "/<0;1>/*))", /*expect_warning=*/true);
+    // tr(): cloned subscript
+    CheckMultipathCloneWarning("tr(" + xpub_a + "/<0;1>/*,pk(" + xpub_b + "/0/*))", /*expect_warning=*/true);
+    CheckMultipathCloneWarning("tr(" + xpub_a + "/<0;1>/*,pk(" + xpub_b + "/<2;3>/*))", /*expect_warning=*/false);
+
+    // Miniscript: a single-path key next to a multipath one is cloned into every branch
+    CheckMultipathCloneWarning("wsh(and_v(v:pk(" + xpub_a + "/<0;1>/*),pk(" + xpub_b + "/0/*)))", /*expect_warning=*/true);
+    CheckMultipathCloneWarning("wsh(and_v(v:pk(" + xpub_a + "/<0;1>/*),pk(" + xpub_b + "/<2;3>/*)))", /*expect_warning=*/false);
+
+    // musig(): no warning even with cloned single-path participants, the per-branch aggregate keys
+    // differ so nothing observable is reused on chain
+    CheckMultipathCloneWarning("rawtr(musig(" + xpub_a + "/<1;2>/0/*," + xpub_b + "/0/*))", /*expect_warning=*/false);
+    CheckMultipathCloneWarning("rawtr(musig(" + xpub_a + "," + xpub_b + ")/<0;1>/*)", /*expect_warning=*/false);
+    CheckMultipathCloneWarning("tr(" + xpub_a + "/<0;1>/*,and_v(v:pk(musig(" + xpub_a + "/<1;2>," + xpub_b + ")),older(10)))", /*expect_warning=*/false);
+    // A single-path musig() cloned as tr() internal key does reuse the aggregate key across branches
+    CheckMultipathCloneWarning("tr(musig(" + xpub_a + "," + xpub_b + "),pk(" + xpub_a + "/<0;1>/*))", /*expect_warning=*/true);
+
+    // Multipath descriptor with a single key expression, nothing is cloned
+    CheckMultipathCloneWarning("wpkh(" + xpub_a + "/<0;1>/*)", /*expect_warning=*/false);
+}
+
 void CheckSingleUnparsable(const std::string& desc, const std::string& expected_error)
 {
     FlatSigningProvider keys;

--- a/test/functional/rpc_getdescriptorinfo.py
+++ b/test/functional/rpc_getdescriptorinfo.py
@@ -20,7 +20,7 @@ class DescriptorTest(BitcoinTestFramework):
         self.extra_args = [["-disablewallet"]]
         self.wallet_names = []
 
-    def test_desc(self, desc, isrange, issolvable, hasprivatekeys, expanded_descs=None):
+    def test_desc(self, desc, isrange, issolvable, hasprivatekeys, expanded_descs=None, warnings=None):
         info = self.nodes[0].getdescriptorinfo(desc)
         assert_equal(info, self.nodes[0].getdescriptorinfo(descsum_create(desc)))
         if expanded_descs is not None:
@@ -32,6 +32,10 @@ class DescriptorTest(BitcoinTestFramework):
         assert_equal(info['isrange'], isrange)
         assert_equal(info['issolvable'], issolvable)
         assert_equal(info['hasprivatekeys'], hasprivatekeys)
+        if warnings is not None:
+            assert_equal(info['warnings'], warnings)
+        else:
+            assert "warnings" not in info
 
     def run_test(self):
         assert_raises_rpc_error(-1, 'getdescriptorinfo', self.nodes[0].getdescriptorinfo)
@@ -79,6 +83,13 @@ class DescriptorTest(BitcoinTestFramework):
             expanded_descs=["wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/*)", "wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)"])
         self.test_desc("wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/<1;2>/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/<2;3>/0/*))", isrange=True, issolvable=True, hasprivatekeys=False,
             expanded_descs=["wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/2/0/*))", "wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/2/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/3/0/*))"])
+        # A multipath descriptor mixing multipath and single-path key expressions warns about key reuse
+        self.test_desc("wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/<1;2>/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0/*))", isrange=True, issolvable=True, hasprivatekeys=False,
+            expanded_descs=["wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0/*))", "wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/2/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0/*))"],
+            warnings=["multipath expansion: key expressions without a multipath specifier are repeated in every expanded descriptor, reusing the same keys"])
+        # Warnings from the descriptor itself are surfaced too
+        self.test_desc("wsh(and_v(v:pk(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/*),older(65536)))", isrange=True, issolvable=True, hasprivatekeys=False,
+            warnings=["height-based relative locktime: older(65536) > 65535 blocks is unsafe"])
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -1104,6 +1104,18 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                 warnings=[expected_warning],
             )
 
+            self.log.debug("Importing an unsafe value in a multipath descriptor results in a single warning")
+            self.test_importdesc(
+                {
+                    'desc': descsum_create(f"wsh(and_v(v:pk([12345678/0h/0h]{xpub}/<0;1>/*),older({unsafe_value})))"),
+                    'active': True,
+                    'range': [0, 2],
+                    'timestamp': 'now'
+                },
+                success=True,
+                warnings=[expected_warning],
+            )
+
 
         self.test_import_unused_key()
         self.test_import_unused_key_existing()

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -37,6 +37,7 @@ from test_framework.wallet_util import (
 )
 
 MISSING_KEYS_WARNING = "Not all private keys provided. Some wallet functionality may return unexpected errors"
+MULTIPATH_CLONED_KEYS_WARNING = "multipath expansion: key expressions without a multipath specifier are repeated in every expanded descriptor, reusing the same keys"
 
 class ImportDescriptorsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -1069,6 +1070,15 @@ class ImportDescriptorsTest(BitcoinTestFramework):
             assert_equal(w_multipath.getnewaddress(address_type="bech32"), w_multisplit.getnewaddress(address_type="bech32"))
             assert_equal(w_multipath.getrawchangeaddress(address_type="bech32"), w_multisplit.getrawchangeaddress(address_type="bech32"))
         assert_equal(sorted(w_multipath.listdescriptors()["descriptors"], key=lambda x: x["desc"]), sorted(w_multisplit.listdescriptors()["descriptors"], key=lambda x: x["desc"]))
+
+        self.log.info("Mixing multipath and single-path key expressions results in a warning")
+        xpub2 = ExtendedPrivateKey.generate().pubkey().to_string()
+        self.test_importdesc({"desc": descsum_create(f"wsh(multi(1,{xpub}/<2;3>/0/*,{xpub2}/0/*))"),
+                              "active": True,
+                              "range": 10,
+                              "timestamp": "now"},
+                              success=True,
+                              warnings=[MULTIPATH_CLONED_KEYS_WARNING])
 
         self.log.info("Test older() safety")
 


### PR DESCRIPTION
This PR:
  - deduplicate warnings pushed with `PushWarnings` in RPC calls
  - warn when single-path key expressions or tr() subscripts are cloned into every multipath expansion; surfaced by `importdescriptors` and by a new `warnings` field on `getdescriptorinfo` (which also exposes the existing miniscript `older()` warnings)

Cloning internal to musig() is not warned: both `musig(A,B)/<0;1>/*` and `musig(A/<1;2>,B)` derive a distinct aggregate key per branch, so nothing observable is reused.

closes #35985

