### PR TITLE
wallet: WalletBatch->WriteVersion respect argument

### DIFF
--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -271,8 +271,14 @@ public:
 
     DBErrors LoadWallet(CWallet* pwallet);
 
-    //! Write the given client_version.
-    bool WriteVersion(int client_version) { return m_batch->Write(DBKeys::VERSION, CLIENT_VERSION); }
+    /**
+     * Write the given `client_version` to m_batch, indicating the last version
+     * of client software to load this wallet.
+     *
+     * @param[in]   client_version  `CLIENT_VERSION` outside of test code.
+     * @return      A bool indicating whether or not the write succeeded.
+     */
+    bool WriteVersion(int client_version) { return m_batch->Write(DBKeys::VERSION, client_version); }
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);


### PR DESCRIPTION
> Previously would use global `CLIENT_VERSION` no matter what, but this is one sense a refactor since all of the places where WriteVersion is called currently call it with `CLIENT_VERSION` anyways. The `client_version` argument is kept since future test code may want to write other versions.

> Addresses a review comment from [#32636](https://github.com/bitcoin/bitcoin/pull/32636#discussion_r2356299627):

This was originally pointed out in https://github.com/bitcoin/bitcoin/pull/32636#discussion_r2356299627, and the followup (#34490) was never merged. However I think it's confusing to have functions that take arguments but ignore them (and it's dead code), so I've cherry-picked the fix up from #34490.