### PR TITLE
btcsignals: destroy callbacks on disconnect

### DIFF
--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -81,6 +81,65 @@ BOOST_AUTO_TEST_CASE(disconnects)
     BOOST_CHECK_EQUAL(val, 6);
 }
 
+/* Characterize when a callback object and the state it owns are destroyed.
+ * disconnect() only disables the callback. The object itself is kept alive
+ * both by the signal, until a later connect() call garbage collects
+ * disconnected entries (or the signal is destroyed), and by every connection
+ * handle referencing it. It is destroyed when the last of these references
+ * goes away.
+ */
+BOOST_AUTO_TEST_CASE(callback_destruction)
+{
+    // With no connection handle held, callbacks are destroyed with the signal.
+    std::weak_ptr<int> weak0;
+    {
+        btcsignals::signal<void()> sig0;
+        auto state0{std::make_shared<int>(0)};
+        weak0 = state0;
+        sig0.connect([state0 = std::move(state0)] {});
+        BOOST_CHECK(!weak0.expired());
+    }
+    BOOST_CHECK(weak0.expired());
+
+    // disconnect() does not destroy the callback. A later connect() garbage
+    // collects the signal's reference, and the callback is destroyed once the
+    // connection handle is released as well.
+    btcsignals::signal<void()> sig1;
+    auto state1{std::make_shared<int>(0)};
+    std::weak_ptr<int> weak1{state1};
+    auto conn1{sig1.connect([state1 = std::move(state1)] {})};
+    conn1.disconnect();
+    BOOST_CHECK(!weak1.expired());
+    sig1.connect([] {}); // garbage collects the signal's reference
+    BOOST_CHECK(!weak1.expired());
+    conn1 = {}; // release the last connection handle
+    BOOST_CHECK(weak1.expired());
+}
+
+/* A callback that disconnects itself during emission remains valid until its
+ * invocation returns, and afterwards is destroyed under the same rules as any
+ * other disconnected callback.
+ */
+BOOST_AUTO_TEST_CASE(self_disconnect_destruction)
+{
+    btcsignals::signal<void()> sig0;
+    auto state0{std::make_shared<int>(0)};
+    std::weak_ptr<int> weak0{state0};
+    btcsignals::connection conn0;
+    conn0 = sig0.connect([&conn0, weak0, state0 = std::move(state0)] {
+        conn0.disconnect();
+        // The callback and the state it owns stay valid while it executes.
+        BOOST_CHECK(!weak0.expired());
+        *state0 += 1;
+    });
+    sig0();
+    BOOST_CHECK(!weak0.expired());
+    conn0 = {}; // release the connection handle
+    BOOST_CHECK(!weak0.expired());
+    sig0.connect([] {}); // garbage collects the signal's reference
+    BOOST_CHECK(weak0.expired());
+}
+
 BOOST_AUTO_TEST_CASE(any_of_combiner)
 {
     btcsignals::signal<bool(), btcsignals::any_of> sig0;

--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -81,16 +81,13 @@ BOOST_AUTO_TEST_CASE(disconnects)
     BOOST_CHECK_EQUAL(val, 6);
 }
 
-/* Characterize when a callback object and the state it owns are destroyed.
- * disconnect() only disables the callback. The object itself is kept alive
- * both by the signal, until a later connect() call garbage collects
- * disconnected entries (or the signal is destroyed), and by every connection
- * handle referencing it. It is destroyed when the last of these references
- * goes away.
+/* Characterize when a callback object and the state it owns are destroyed:
+ * eagerly on disconnect(), or with the signal if never disconnected.
+ * Connection handles do not keep the callback alive.
  */
 BOOST_AUTO_TEST_CASE(callback_destruction)
 {
-    // With no connection handle held, callbacks are destroyed with the signal.
+    // With no disconnect, callbacks are destroyed with the signal.
     std::weak_ptr<int> weak0;
     {
         btcsignals::signal<void()> sig0;
@@ -101,24 +98,18 @@ BOOST_AUTO_TEST_CASE(callback_destruction)
     }
     BOOST_CHECK(weak0.expired());
 
-    // disconnect() does not destroy the callback. A later connect() garbage
-    // collects the signal's reference, and the callback is destroyed once the
-    // connection handle is released as well.
+    // disconnect() destroys the callback immediately, even while a connection
+    // handle is still held.
     btcsignals::signal<void()> sig1;
     auto state1{std::make_shared<int>(0)};
     std::weak_ptr<int> weak1{state1};
     auto conn1{sig1.connect([state1 = std::move(state1)] {})};
     conn1.disconnect();
-    BOOST_CHECK(!weak1.expired());
-    sig1.connect([] {}); // garbage collects the signal's reference
-    BOOST_CHECK(!weak1.expired());
-    conn1 = {}; // release the last connection handle
     BOOST_CHECK(weak1.expired());
 }
 
 /* A callback that disconnects itself during emission remains valid until its
- * invocation returns, and afterwards is destroyed under the same rules as any
- * other disconnected callback.
+ * invocation returns, and is destroyed as soon as it does.
  */
 BOOST_AUTO_TEST_CASE(self_disconnect_destruction)
 {
@@ -133,10 +124,6 @@ BOOST_AUTO_TEST_CASE(self_disconnect_destruction)
         *state0 += 1;
     });
     sig0();
-    BOOST_CHECK(!weak0.expired());
-    conn0 = {}; // release the connection handle
-    BOOST_CHECK(!weak0.expired());
-    sig0.connect([] {}); // garbage collects the signal's reference
     BOOST_CHECK(weak0.expired());
 }
 

--- a/src/util/btcsignals.h
+++ b/src/util/btcsignals.h
@@ -24,6 +24,13 @@
  * imply, std::function is used to store the callbacks. Lifetime management of
  * the callbacks is left up to the user.
  *
+ * Disconnecting a connection destroys the associated callback object eagerly
+ * (or, if the callback is currently executing on another thread, as soon as
+ * the last in-flight invocation completes), matching boost::signals2
+ * behavior. This makes callback lifetime predictable when callbacks own
+ * resources whose release has side effects, instead of tying it to unrelated
+ * future connect() calls and to the lifetimes of connection handles.
+ *
  * All usage is thread-safe except for interacting with a connection while
  * copying/moving it on another thread.
  */
@@ -66,7 +73,22 @@ class connection
         friend class connection;
         std::atomic_bool m_connected{true};
 
-        void disconnect() { m_connected.store(false); }
+        void disconnect()
+        {
+            m_connected.store(false);
+            // Destroy the owned callback now instead of waiting for the next
+            // signal::connect() garbage collection, which may never happen. An
+            // invocation that already loaded the owner keeps the callback
+            // alive until it returns.
+            m_owner.store(nullptr);
+        }
+
+    protected:
+        //! Type-erased owner of the callback stored by the derived
+        //! signal::connection_holder. Loaded by signal invocation to keep the
+        //! callback alive while it runs, cleared by disconnect().
+        std::atomic<std::shared_ptr<const void>> m_owner{};
+
     public:
         bool connected() const { return m_connected.load(); }
     };
@@ -94,8 +116,10 @@ public:
      * If a connection is disabled as part of a signal's callback function, it
      * will _not_ be executed in the current signal invocation.
      *
-     * Note that disconnected callbacks are not removed from their owning
-     * signals here. They are garbage collected in signal::connect().
+     * The callback object is destroyed here (or when the last concurrently
+     * executing invocation of it completes). The empty holder entry is not
+     * removed from the owning signal; it is garbage collected in
+     * signal::connect().
      */
     void disconnect()
     {
@@ -157,11 +181,20 @@ class signal
      */
     struct connection_holder : connection::liveness {
         template <typename Callable>
-        connection_holder(Callable&& callback) : m_callback{std::forward<Callable>(callback)}
+        connection_holder(Callable&& callback)
         {
+            auto owner{std::make_shared<const function_type>(std::forward<Callable>(callback))};
+            m_callback = owner.get();
+            m_owner.store(std::move(owner));
         }
 
-        const function_type m_callback;
+        //! Load the owner, keeping the callback alive while the returned
+        //! shared_ptr is held. Returns null if disconnected.
+        std::shared_ptr<const void> owner() const { return m_owner.load(); }
+
+        //! Raw pointer to the callback, only valid while holding a shared_ptr
+        //! returned by owner().
+        const function_type* m_callback;
     };
 
     mutable Mutex m_mutex;
@@ -209,8 +242,11 @@ public:
             static_assert(std::is_same_v<result_type, typename function_type::result_type>,
                           "Callback result type must be equal to the combiner result type (void).");
             for (const auto& connection : connections) {
-                if (connection->connected()) {
-                    connection->m_callback(args...);
+                // Loading the owner both checks that the connection is still
+                // connected and keeps the callback alive for the duration of
+                // the call if it is disconnected concurrently.
+                if (const auto owner{connection->owner()}) {
+                    (*connection->m_callback)(args...);
                 }
             }
         } else {
@@ -220,8 +256,8 @@ public:
                           "Callback result type must be equal to the combiner result type (bool).");
             result_type ret{false};
             for (const auto& connection : connections) {
-                if (connection->connected()) {
-                    ret |= connection->m_callback(args...);
+                if (const auto owner{connection->owner()}) {
+                    ret |= (*connection->m_callback)(args...);
                 }
             }
             return ret;

--- a/src/util/btcsignals.h
+++ b/src/util/btcsignals.h
@@ -80,14 +80,27 @@ class connection
             // signal::connect() garbage collection, which may never happen. An
             // invocation that already loaded the owner keeps the callback
             // alive until it returns.
+#ifdef __cpp_lib_atomic_shared_ptr
             m_owner.store(nullptr);
+#else
+            std::atomic_store(&m_owner, std::shared_ptr<const void>{});
+#endif
         }
 
     protected:
         //! Type-erased owner of the callback stored by the derived
         //! signal::connection_holder. Loaded by signal invocation to keep the
         //! callback alive while it runs, cleared by disconnect().
+        //!
+        //! std::atomic<shared_ptr<T>> is a C++20 specialization (feature-test
+        //! macro __cpp_lib_atomic_shared_ptr). Fall back to the C++14 free
+        //! functions atomic_load/atomic_store, which are specifically overloaded
+        //! for shared_ptr, on implementations that do not provide it.
+#ifdef __cpp_lib_atomic_shared_ptr
         std::atomic<std::shared_ptr<const void>> m_owner{};
+#else
+        std::shared_ptr<const void> m_owner{};
+#endif
 
     public:
         bool connected() const { return m_connected.load(); }
@@ -185,12 +198,23 @@ class signal
         {
             auto owner{std::make_shared<const function_type>(std::forward<Callable>(callback))};
             m_callback = owner.get();
+#ifdef __cpp_lib_atomic_shared_ptr
             m_owner.store(std::move(owner));
+#else
+            std::atomic_store(&m_owner, std::shared_ptr<const void>(std::move(owner)));
+#endif
         }
 
         //! Load the owner, keeping the callback alive while the returned
         //! shared_ptr is held. Returns null if disconnected.
-        std::shared_ptr<const void> owner() const { return m_owner.load(); }
+        std::shared_ptr<const void> owner() const
+        {
+#ifdef __cpp_lib_atomic_shared_ptr
+            return m_owner.load();
+#else
+            return std::atomic_load(&m_owner);
+#endif
+        }
 
         //! Raw pointer to the callback, only valid while holding a shared_ptr
         //! returned by owner().


### PR DESCRIPTION
Currently callback functions connected to signals do not get freed when their `connection::disconnect` method is called or when their associated `scoped_connection` is destroyed. They live as long as the signal does, even if they will never be called, and can only get [garbage collected](https://github.com/bitcoin/bitcoin/blob/0fd515bbb7070a502dd2fe6d16f5f3cbac591283/src/util/btcsignals.h#L240-L241) if new connections are added.

This behavior is different that previous boost signals behavior and causes a [deadlock](https://github.com/bitcoin/bitcoin/actions/runs/31848571315/job/94919834743) on GUI shutdown in #10102 because when the node registers signal callbacks (`handleInitMessage`, etc) that get forwarded to the GUI, the callbacks own `mp::EventLoopRef` references, and if the callbacks aren't freed, the node process can't shut down.

This change restores boost signals behavior freeing callbacks when they are disconnected or when `scoped_connection` objects are destroyed to avoid this problem and make callback lifetimes more predictable.