### PR TITLE
psbt: Remove unused `IsNull()` methods

### DIFF
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -31,11 +31,6 @@ PartiallySignedTransaction::PartiallySignedTransaction(const CMutableTransaction
     }
 }
 
-bool PartiallySignedTransaction::IsNull() const
-{
-    return inputs.empty() && outputs.empty() && unknown.empty();
-}
-
 bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
 {
     // Prohibited to merge two PSBTs over different transactions
@@ -289,11 +284,6 @@ COutPoint PSBTInput::GetOutPoint() const
     return COutPoint(prev_txid, prev_out);
 }
 
-bool PSBTInput::IsNull() const
-{
-    return !non_witness_utxo && witness_utxo.IsNull() && partial_sigs.empty() && unknown.empty() && hd_keypaths.empty() && redeem_script.empty() && witness_script.empty();
-}
-
 void PSBTInput::FillSignatureData(SignatureData& sigdata) const
 {
     if (!final_script_sig.empty()) {
@@ -526,11 +516,6 @@ void PSBTOutput::FromSignatureData(const SignatureData& sigdata)
         m_tap_bip32_paths.emplace(pubkey, leaf_origin);
     }
     m_musig2_participants.insert(sigdata.musig2_pubkeys.begin(), sigdata.musig2_pubkeys.end());
-}
-
-bool PSBTOutput::IsNull() const
-{
-    return redeem_script.empty() && witness_script.empty() && hd_keypaths.empty() && unknown.empty();
 }
 
 bool PSBTOutput::Merge(const PSBTOutput& output)

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -321,7 +321,6 @@ public:
     std::set<PSBTProprietary> m_proprietary;
     std::optional<int> sighash_type;
 
-    bool IsNull() const;
     void FillSignatureData(SignatureData& sigdata) const;
     void FromSignatureData(const SignatureData& sigdata);
     [[nodiscard]] bool Merge(const PSBTInput& input);
@@ -956,7 +955,6 @@ public:
     CAmount amount;
     CScript script;
 
-    bool IsNull() const;
     void FillSignatureData(SignatureData& sigdata) const;
     void FromSignatureData(const SignatureData& sigdata);
     [[nodiscard]] bool Merge(const PSBTOutput& output);
@@ -1254,7 +1252,6 @@ public:
     uint32_t tx_version;
     std::optional<uint32_t> fallback_locktime;
 
-    bool IsNull() const;
     uint32_t GetVersion() const;
 
     /** Merge psbt into this. The two psbts must have the same underlying CTransaction (i.e. the

--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -54,12 +54,10 @@ FUZZ_TARGET(psbt)
         (void)PSBTRoleName(input_analysis.next);
     }
 
-    (void)psbt.IsNull();
     (void)psbt.GetUnsignedTx();
 
     for (const PSBTInput& input : psbt.inputs) {
         (void)PSBTInputSigned(input);
-        (void)input.IsNull();
         PSBTInput input_mod = input;
         CTxOut tx_out;
         if (input.GetUTXO(tx_out)) {
@@ -96,7 +94,6 @@ FUZZ_TARGET(psbt)
     (void)CountPSBTUnsignedInputs(psbt);
 
     for (const PSBTOutput& output : psbt.outputs) {
-        (void)output.IsNull();
         PSBTOutput output_mod = output;
         // A PSBT output must roundtrip to signature data.
         PSBTOutput output_fill{psbt_version, output_mod.amount, output_mod.script};


### PR DESCRIPTION
This PR removes the `IsNull()` methods from `PartiallySignedTransaction`, `PSBTInput`, and `PSBTOutput`, along with their calls from the fuzz target.

This methods have no production callers, their only callers are the fuzz target. As such, keeping these methods seems not useful.

The motivation for this PR came from jeanpablojp's comment on [#35848](https://github.com/bitcoin/bitcoin/pull/35848#issuecomment-5274013825), added him as coauthor.