### PR TITLE
init: ignore repeated `-addnode` startup values

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3831,12 +3831,24 @@ std::vector<CAddress> CConnman::GetAddresses(CNode& requestor, size_t max_addres
 
 bool CConnman::AddNode(const AddedNodeParams& add)
 {
-    const CService resolved(LookupNumeric(add.m_added_node, GetDefaultPort(add.m_added_node)));
+    uint16_t port{GetDefaultPort(add.m_added_node)};
+    const CService resolved(LookupNumeric(add.m_added_node, port));
     const bool resolved_is_valid{resolved.IsValid()};
+    std::string host;
+    const bool host_port_is_valid{SplitHostPort(add.m_added_node, port, host)};
 
     LOCK(m_added_nodes_mutex);
     for (const auto& it : m_added_node_params) {
-        if (add.m_added_node == it.m_added_node || (resolved_is_valid && resolved == LookupNumeric(it.m_added_node, GetDefaultPort(it.m_added_node)))) return false;
+        if (add.m_added_node == it.m_added_node) return false;
+
+        uint16_t existing_port{GetDefaultPort(it.m_added_node)};
+        if (resolved_is_valid && resolved == LookupNumeric(it.m_added_node, existing_port)) return false;
+
+        std::string existing_host;
+        if (host_port_is_valid && SplitHostPort(it.m_added_node, existing_port, existing_host) &&
+            host == existing_host && port == existing_port) {
+            return false;
+        }
     }
 
     m_added_node_params.push_back(add);

--- a/src/net.h
+++ b/src/net.h
@@ -30,6 +30,7 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/log.h>
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
 
@@ -1139,13 +1140,12 @@ public:
         }
         vWhitelistedRangeIncoming = connOptions.vWhitelistedRangeIncoming;
         vWhitelistedRangeOutgoing = connOptions.vWhitelistedRangeOutgoing;
-        {
-            LOCK(m_added_nodes_mutex);
-            // Attempt v2 connection if we support v2 - we'll reconnect with v1 if our
-            // peer doesn't support it or immediately disconnects us for another reason.
-            const bool use_v2transport(GetLocalServices() & NODE_P2P_V2);
-            for (const std::string& added_node : connOptions.m_added_nodes) {
-                m_added_node_params.push_back({added_node, use_v2transport});
+        // Attempt v2 connection if we support v2 - we'll reconnect with v1 if our
+        // peer doesn't support it or immediately disconnects us for another reason.
+        const bool use_v2transport(GetLocalServices() & NODE_P2P_V2);
+        for (const std::string& added_node : connOptions.m_added_nodes) {
+            if (!AddNode({added_node, use_v2transport})) {
+                LogWarning("Ignoring duplicate -addnode value: %s", added_node);
             }
         }
         m_onion_binds = connOptions.onion_binds;

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -163,4 +163,19 @@ BOOST_FIXTURE_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection, 
     connman->ClearTestNodes();
 }
 
+BOOST_AUTO_TEST_CASE(addnode_literal_host_and_effective_port_equivalence)
+{
+    ConnmanTestMsg connman{0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman, Params()};
+    const uint16_t default_port{Params().GetDefaultPort()};
+
+    BOOST_CHECK(connman.AddNode({/*m_added_node=*/"node.example", /*m_use_v2transport=*/true}));
+    BOOST_CHECK(!connman.AddNode({/*m_added_node=*/strprintf("node.example:%u", default_port), /*m_use_v2transport=*/true}));
+    BOOST_CHECK(connman.AddNode({/*m_added_node=*/strprintf("node.example:%u", default_port + 1), /*m_use_v2transport=*/true}));
+
+    BOOST_CHECK(connman.AddNode({/*m_added_node=*/strprintf("explicit.example:%u", default_port), /*m_use_v2transport=*/true}));
+    BOOST_CHECK(!connman.AddNode({/*m_added_node=*/"explicit.example", /*m_use_v2transport=*/true}));
+
+    BOOST_CHECK_EQUAL(connman.GetAddedNodeInfo(/*include_connected=*/true).size(), 3);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -280,6 +280,28 @@ class ConfArgsTest(BitcoinTestFramework):
 
         node.replace_in_config([("addnode=\n", "")])
 
+    def test_duplicate_addnode(self):
+        self.log.info("Test equivalent addnode configuration values are ignored")
+        node = self.nodes[0]
+
+        with node.assert_debug_log(expected_msgs=[
+            "Ignoring duplicate -addnode value: first.node",
+            "Ignoring duplicate -addnode value: first.node:18444",
+        ]):
+            self.start_node(0, extra_args=[
+                "-networkactive=0",
+                "-addnode=first.node",
+                "-addnode=first.node",
+                "-addnode=first.node:18444",
+                "-addnode=first.node:18445",
+                "-addnode=second.node",
+            ])
+        util.assert_equal(
+            [added["addednode"] for added in node.getaddednodeinfo()],
+            ["first.node", "first.node:18445", "second.node"],
+        )
+        self.stop_node(0)
+
     def test_networkactive(self):
         self.log.info('Test -networkactive option')
         with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: true\n']):
@@ -534,6 +556,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.test_log_buffer()
         self.test_args_log()
         self.test_empty_addnode()
+        self.test_duplicate_addnode()
         self.test_seed_peers()
         self.test_networkactive()
         self.test_connect_with_seednode()


### PR DESCRIPTION
Startup `-addnode` values are copied directly into the connection manager's added-node list. Unlike runtime `addnode add` calls, this path does not reject repeated values.

For example:

```
-addnode=example.com
-addnode=example.com
```

Both entries are currently stored. While the destination is disconnected, `ThreadOpenAddedConnections()` processes
each entry during every retry cycle. 

This can cause redundant DNS lookups, connection attempts, and log messages. `getaddednodeinfo` also reports the repeated entry.

---

This change is complementary to, and independent of, #35600.

#35600 prevents overlapping manual connection attempts by tracking destinations while a connection attempt is in progress. 
This PR instead removes repeated `-addnode` values before the connection threads start, preventing duplicate stored entries and sequential redundant retries.

It does not replace or broaden #35600's in-flight connection handling.