### PR TITLE
txorphanage: bound orphan memory by storing transactions serialized

### DIFF
--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -73,7 +73,7 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
     auto large_tx = MakeTransactionBulkedTo(1, MAX_STANDARD_TX_WEIGHT, det_rand);
     assert(GetTransactionWeight(*large_tx) <= MAX_STANDARD_TX_WEIGHT);
 
-    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
+    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER)};
 
     // Populate the orphanage. To maximize the number of evictions, first fill up with tiny transactions, then add a huge one.
     NodeId peer{0};
@@ -118,7 +118,7 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
     static constexpr unsigned int NUM_PEERS{39};
     // All peers will have the same transactions. We want to be just under the weight limit, so divide the max usage limit by the number of unique transactions.
     static constexpr node::TxOrphanage::Count NUM_UNIQUE_TXNS{node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE / NUM_PEERS};
-    static constexpr node::TxOrphanage::Usage TOTAL_USAGE_LIMIT{node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER * NUM_PEERS};
+    static constexpr node::TxOrphanage::Usage TOTAL_USAGE_LIMIT{node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER * NUM_PEERS};
     // Subtract 4 because BulkTransaction rounds up and we must avoid going over the weight limit early.
     static constexpr node::TxOrphanage::Usage LARGE_TX_WEIGHT{TOTAL_USAGE_LIMIT / NUM_UNIQUE_TXNS - 4};
     static_assert(LARGE_TX_WEIGHT >= TINY_TX_WEIGHT * 2, "Tx is too small, increase NUM_PEERS");
@@ -136,7 +136,7 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
     indexes.resize(NUM_UNIQUE_TXNS);
     std::iota(indexes.begin(), indexes.end(), 0);
 
-    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
+    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER)};
     // Every peer sends the same transactions, all from shared_txs.
     // Each peer has 1 or 2 assigned transactions, which they must place as the last and second-to-last positions.
     // The assignments ensure that every transaction is in some peer's last 2 transactions, and is thus remains in the orphanage until the end of LimitOrphans.
@@ -194,7 +194,7 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
 static void OrphanageEraseAll(benchmark::Bench& bench, bool block_or_disconnect)
 {
     FastRandomContext det_rand{true};
-    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER)};
+    const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER)};
     // This is an unrealistically large number of inputs for a block, as there is almost no room given to witness data,
     // outputs, and overhead for individual transactions. The entire block is 1 transaction with 20,000 inputs.
     constexpr unsigned int NUM_BLOCK_INPUTS{MAX_BLOCK_WEIGHT / APPROX_WEIGHT_PER_INPUT};
@@ -215,7 +215,7 @@ static void OrphanageEraseAll(benchmark::Bench& bench, bool block_or_disconnect)
     static_assert(7 * NUM_TXNS_PER_PEER + INPUTS_PER_TX - 1 >= INPUTS_PER_PEER);
 
     for (NodeId peer{0}; peer < NUM_PEERS; ++peer) {
-        int64_t weight_left_for_peer{node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER};
+        int64_t weight_left_for_peer{node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER};
         for (unsigned int txnum{0}; txnum < node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE / NUM_PEERS; ++txnum) {
             // Transactions must be unique since they use different (though overlapping) inputs.
             const unsigned int start_input = peer * INPUTS_PER_PEER + txnum * 7;

--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -46,12 +46,11 @@ static CTransactionRef MakeTransactionBulkedTo(unsigned int num_inputs, int64_t 
     return MakeTransactionRef(tx);
 }
 
-// Constructs a transaction using a subset of inputs[start_input : start_input + num_inputs] up to the weight_limit.
-static CTransactionRef MakeTransactionSpendingUpTo(const std::vector<CTxIn>& inputs, unsigned int start_input, unsigned int num_inputs, int64_t weight_limit)
+// Constructs a transaction using inputs[start_input : start_input + num_inputs].
+static CTransactionRef MakeTransactionSpendingUpTo(const std::vector<CTxIn>& inputs, unsigned int start_input, unsigned int num_inputs)
 {
     CMutableTransaction tx;
     for (unsigned int i{start_input}; i < start_input + num_inputs; ++i) {
-        if (GetTransactionWeight(*MakeTransactionRef(tx)) + APPROX_WEIGHT_PER_INPUT >= weight_limit) break;
         tx.vin.emplace_back(inputs.at(i % inputs.size()));
     }
     assert(tx.vin.size() > 0);
@@ -70,8 +69,12 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
     for (unsigned int i{0}; i < NUM_TINY_TRANSACTIONS; ++i) {
         tiny_txs.emplace_back(MakeTransactionBulkedTo(1, TINY_TX_WEIGHT, det_rand));
     }
+    // All of the tiny transactions are accounted the same usage.
+    const auto TINY_TX_USAGE{node::GetOrphanUsage(tiny_txs.front())};
+    assert(std::all_of(tiny_txs.begin(), tiny_txs.end(), [&](const auto& tx) { return node::GetOrphanUsage(tx) == TINY_TX_USAGE; }));
     auto large_tx = MakeTransactionBulkedTo(1, MAX_STANDARD_TX_WEIGHT, det_rand);
     assert(GetTransactionWeight(*large_tx) <= MAX_STANDARD_TX_WEIGHT);
+    const auto LARGE_TX_USAGE{node::GetOrphanUsage(large_tx)};
 
     const auto orphanage{node::MakeTxOrphanage(/*max_global_latency_score=*/node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE, /*reserved_peer_usage=*/node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER)};
 
@@ -79,16 +82,16 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
     NodeId peer{0};
     // Add tiny transactions until we are just about to hit the memory limit, up to the max number of announcements.
     // We use the same tiny transactions for all peers to minimize their contribution to the usage limit.
-    int64_t total_weight_to_add{0};
+    node::TxOrphanage::Usage total_usage_to_add{0};
     for (unsigned int txindex{0}; txindex < NUM_TINY_TRANSACTIONS; ++txindex) {
         const auto& tx{tiny_txs.at(txindex)};
 
-        total_weight_to_add += GetTransactionWeight(*tx);
-        if (total_weight_to_add > orphanage->MaxGlobalUsage()) break;
+        total_usage_to_add += TINY_TX_USAGE;
+        if (total_usage_to_add > orphanage->MaxGlobalUsage()) break;
 
         assert(orphanage->AddTx(tx, peer));
 
-        // Sanity check: we should always be exiting at the point of hitting the weight limit.
+        // Sanity check: we should always be exiting at the point of hitting the usage limit.
         assert(txindex < NUM_TINY_TRANSACTIONS - 1);
     }
 
@@ -96,7 +99,10 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
     // If we need to trim already, that means the benchmark is not representative of what LimitOrphans may do in a single call.
     assert(orphanage->TotalOrphanUsage() <= orphanage->MaxGlobalUsage());
     assert(orphanage->TotalLatencyScore() <= orphanage->MaxGlobalLatencyScore());
-    assert(orphanage->TotalOrphanUsage() + TINY_TX_WEIGHT > orphanage->MaxGlobalUsage());
+    assert(orphanage->TotalOrphanUsage() + TINY_TX_USAGE > orphanage->MaxGlobalUsage());
+    const auto total_usage_before{orphanage->TotalOrphanUsage()};
+    // Adding the large transaction must evict exactly enough tiny ones to get back within the global limit.
+    const auto expected_evicted{(total_usage_before + LARGE_TX_USAGE - orphanage->MaxGlobalUsage() + TINY_TX_USAGE - 1) / TINY_TX_USAGE};
 
     bench.epochs(1).epochIterations(1).run([&]() NO_THREAD_SAFETY_ANALYSIS {
         // Lastly, add the large transaction.
@@ -105,11 +111,12 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
 
         // If there are multiple peers, note that they all have the same DoS score. We will evict only 1 item at a time for each new DoSiest peer.
         const auto num_announcements_after_trim{orphanage->CountAnnouncements()};
-        const auto num_evicted{num_announcements_before_trim - num_announcements_after_trim};
+        // The large transaction itself was added before trimming, hence the +1.
+        const auto num_evicted{num_announcements_before_trim + 1 - num_announcements_after_trim};
 
         // The number of evictions is the same regardless of the number of peers. In both cases, we can exceed the
         // usage limit using 1 maximally-sized transaction.
-        assert(num_evicted == MAX_STANDARD_TX_WEIGHT / TINY_TX_WEIGHT);
+        assert(num_evicted == expected_evicted);
     });
 }
 static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
@@ -132,6 +139,9 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
     for (unsigned int i{0}; i < NUM_UNIQUE_TXNS; ++i) {
         shared_txs.emplace_back(MakeTransactionBulkedTo(9, LARGE_TX_WEIGHT, det_rand));
     }
+    // All of the shared transactions are accounted the same usage.
+    const auto LARGE_TX_USAGE{node::GetOrphanUsage(shared_txs.front())};
+    assert(std::all_of(shared_txs.begin(), shared_txs.end(), [&](const auto& tx) { return node::GetOrphanUsage(tx) == LARGE_TX_USAGE; }));
     std::vector<size_t> indexes;
     indexes.resize(NUM_UNIQUE_TXNS);
     std::iota(indexes.begin(), indexes.end(), 0);
@@ -173,7 +183,8 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
     assert(orphanage->CountAnnouncements() == NUM_PEERS * NUM_UNIQUE_TXNS);
     const auto total_usage{orphanage->TotalOrphanUsage()};
     const auto max_usage{orphanage->MaxGlobalUsage()};
-    assert(max_usage - total_usage <= LARGE_TX_WEIGHT);
+    assert(max_usage >= total_usage);
+    assert(max_usage - total_usage <= LARGE_TX_USAGE);
     assert(orphanage->TotalLatencyScore() <= orphanage->MaxGlobalLatencyScore());
 
     auto last_tx = MakeTransactionBulkedTo(0, max_usage - total_usage + 1, det_rand);
@@ -184,7 +195,8 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
         assert(orphanage->AddTx(last_tx, 0));
 
         // If there are multiple peers, note that they all have the same DoS score. We will evict only 1 item at a time for each new DoSiest peer.
-        const auto num_evicted{num_announcements_before_trim - orphanage->CountAnnouncements() + 1};
+        // The filler transaction itself was added before trimming, hence the +1.
+        const auto num_evicted{num_announcements_before_trim + 1 - orphanage->CountAnnouncements()};
         // The trimming happens as a round robin. In the first NUM_UNIQUE_TXNS - 2 rounds for each peer, only duplicates are evicted.
         // Once each peer has 2 transactions left, it's possible to select a peer whose oldest transaction is unique.
         assert(num_evicted >= (NUM_UNIQUE_TXNS - 2) * NUM_PEERS);
@@ -215,21 +227,20 @@ static void OrphanageEraseAll(benchmark::Bench& bench, bool block_or_disconnect)
     static_assert(7 * NUM_TXNS_PER_PEER + INPUTS_PER_TX - 1 >= INPUTS_PER_PEER);
 
     for (NodeId peer{0}; peer < NUM_PEERS; ++peer) {
-        int64_t weight_left_for_peer{node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER};
+        node::TxOrphanage::Usage usage_left_for_peer{node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER};
         for (unsigned int txnum{0}; txnum < node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE / NUM_PEERS; ++txnum) {
             // Transactions must be unique since they use different (though overlapping) inputs.
             const unsigned int start_input = peer * INPUTS_PER_PEER + txnum * 7;
 
-            // Note that we shouldn't be able to hit the weight limit with these small transactions.
-            const int64_t weight_limit{std::min<int64_t>(weight_left_for_peer, MAX_STANDARD_TX_WEIGHT)};
-            auto ptx = MakeTransactionSpendingUpTo(block_tx->vin, /*start_input=*/start_input, /*num_inputs=*/INPUTS_PER_TX, /*weight_limit=*/weight_limit);
+            auto ptx = MakeTransactionSpendingUpTo(block_tx->vin, /*start_input=*/start_input, /*num_inputs=*/INPUTS_PER_TX);
 
             assert(GetTransactionWeight(*ptx) <= MAX_STANDARD_TX_WEIGHT);
             assert(!orphanage->HaveTx(ptx->GetWitnessHash()));
             assert(orphanage->AddTx(ptx, peer));
 
-            weight_left_for_peer -= GetTransactionWeight(*ptx);
-            if (weight_left_for_peer < TINY_TX_WEIGHT * 2) break;
+            // Note that we shouldn't be able to hit the usage limit with these small transactions.
+            usage_left_for_peer -= node::GetOrphanUsage(ptx);
+            assert(usage_left_for_peer > 0);
         }
     }
 

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -177,8 +177,8 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
     // - exists in orphanage
     // - peer can be an orphan resolution candidate
     if (const auto* wtxid = std::get_if<Wtxid>(&gtxid)) {
-        if (auto orphan_tx{m_orphanage->GetTx(*wtxid)}) {
-            auto unique_parents{GetUniqueParents(*orphan_tx)};
+        if (auto unique_parents_opt{m_orphanage->GetParentTxids(*wtxid)}) {
+            auto& unique_parents{*unique_parents_opt};
             std::erase_if(unique_parents, [&](const auto& txid) {
                 return AlreadyHaveTx(txid, /*include_reconsiderable=*/false);
             });
@@ -190,7 +190,7 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
             }
 
             if (MaybeAddOrphanResolutionCandidate(unique_parents, *wtxid, peer, now)) {
-                m_orphanage->AddAnnouncer(orphan_tx->GetWitnessHash(), peer);
+                m_orphanage->AddAnnouncer(*wtxid, peer);
             }
 
             // Return even if the peer isn't an orphan resolution candidate. This would be caught by AlreadyHaveTx.

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -314,10 +314,13 @@ std::optional<PackageToValidate> TxDownloadManagerImpl::Find1P1CPackage(const CT
     // of children that replace each other, this helps us accept the highest feerate (probably the
     // most recent) one efficiently.
     for (const auto& child : cpfp_candidates_same_peer) {
-        Package maybe_cpfp_package{ptx, child};
-        if (!RecentRejectsReconsiderableFilter().contains(GetPackageHash(maybe_cpfp_package)) &&
-            !RecentRejectsFilter().contains(child->GetHash().ToUint256())) {
-            return PackageToValidate{ptx, child, nodeid, nodeid};
+        if (!RecentRejectsFilter().contains(child.txid.ToUint256()) &&
+            !RecentRejectsReconsiderableFilter().contains(GetPackageHashFromWtxids({parent_wtxid, child.wtxid}))) {
+            // Only materialize the selected child, so that rejected candidates cost no
+            // more than a few filter lookups.
+            auto child_tx{m_orphanage->GetTx(child.wtxid)};
+            if (!Assume(child_tx)) continue;
+            return PackageToValidate{ptx, child_tx, nodeid, nodeid};
         }
     }
     return std::nullopt;

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -26,6 +26,17 @@ namespace node {
 static constexpr NodeId MIN_PEER{std::numeric_limits<NodeId>::min()};
 /** Maximum NodeId for upper_bound lookups. */
 static constexpr NodeId MAX_PEER{std::numeric_limits<NodeId>::max()};
+
+TxOrphanage::Usage GetOrphanUsage(const CTransactionRef& tx)
+{
+    // The total memory is a function of the memory used to store the transaction itself, each entry in m_orphans, and
+    // each entry in m_outpoint_to_orphan_wtxids. We use weight because it is often higher than the actual memory usage
+    // of the transaction. This metric conveniently encompasses m_outpoint_to_orphan_wtxids usage since input data does
+    // not get the witness discount, and makes it easier to reason about each peer's limits using well-understood
+    // transaction attributes.
+    return GetTransactionWeight(*tx);
+}
+
 class TxOrphanageImpl final : public TxOrphanage {
     // Type alias for sequence numbers
     using SequenceNumber = uint64_t;
@@ -41,21 +52,20 @@ class TxOrphanageImpl final : public TxOrphanage {
         const NodeId m_announcer;
         /** What order this transaction entered the orphanage. */
         const SequenceNumber m_entry_sequence;
+        /** Memory accounted for this announcement, cached at construction. Caching guarantees that the same value is
+         * added and subtracted from the per-peer and global totals, and avoids recomputing it on every operation. */
+        const TxOrphanage::Usage m_usage;
         /** Whether this tx should be reconsidered. Always starts out false. A peer's workset is the collection of all
          * announcements with m_reconsider=true. */
         bool m_reconsider{false};
 
         Announcement(const CTransactionRef& tx, NodeId peer, SequenceNumber seq) :
-            m_tx{tx}, m_announcer{peer}, m_entry_sequence{seq}
+            m_tx{tx}, m_announcer{peer}, m_entry_sequence{seq}, m_usage{GetOrphanUsage(tx)}
         { }
 
-        /** Get an approximation for "memory usage". The total memory is a function of the memory used to store the
-         * transaction itself, each entry in m_orphans, and each entry in m_outpoint_to_orphan_wtxids. We use weight because
-         * it is often higher than the actual memory usage of the transaction. This metric conveniently encompasses
-         * m_outpoint_to_orphan_wtxids usage since input data does not get the witness discount, and makes it easier to
-         * reason about each peer's limits using well-understood transaction attributes. */
-        TxOrphanage::Usage GetMemUsage()  const {
-            return GetTransactionWeight(*m_tx);
+        /** Get an approximation for "memory usage" (see GetOrphanUsage). */
+        TxOrphanage::Usage GetMemUsage() const {
+            return m_usage;
         }
 
         /** Get an approximation of how much this transaction contributes to latency in EraseForBlock and EraseForPeer.

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -103,7 +103,7 @@ class TxOrphanageImpl final : public TxOrphanage {
     AnnouncementMap m_orphans;
 
     const TxOrphanage::Count m_max_global_latency_score{DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE};
-    const TxOrphanage::Usage m_reserved_usage_per_peer{DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER};
+    const TxOrphanage::Usage m_reserved_usage_per_peer{DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER};
 
     /** Number of unique orphans by wtxid. Less than or equal to the number of entries in m_orphans. */
     TxOrphanage::Count m_unique_orphans{0};

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -231,6 +231,7 @@ public:
     bool AddTx(const CTransactionRef& tx, NodeId peer) override;
     bool AddAnnouncer(const Wtxid& wtxid, NodeId peer) override;
     CTransactionRef GetTx(const Wtxid& wtxid) const override;
+    std::optional<std::vector<Txid>> GetParentTxids(const Wtxid& wtxid) const override;
     bool HaveTx(const Wtxid& wtxid) const override;
     bool HaveTxFromPeer(const Wtxid& wtxid, NodeId peer) const override;
     CTransactionRef GetTxToReconsider(NodeId peer) override;
@@ -592,6 +593,19 @@ CTransactionRef TxOrphanageImpl::GetTx(const Wtxid& wtxid) const
     auto it_lower = m_orphans.get<ByWtxid>().lower_bound(ByWtxidView{wtxid, MIN_PEER});
     if (it_lower != m_orphans.get<ByWtxid>().end() && it_lower->m_tx->GetWitnessHash() == wtxid) return it_lower->m_tx;
     return nullptr;
+}
+
+std::optional<std::vector<Txid>> TxOrphanageImpl::GetParentTxids(const Wtxid& wtxid) const
+{
+    auto it_lower = m_orphans.get<ByWtxid>().lower_bound(ByWtxidView{wtxid, MIN_PEER});
+    if (it_lower == m_orphans.get<ByWtxid>().end() || it_lower->m_tx->GetWitnessHash() != wtxid) return std::nullopt;
+
+    std::vector<Txid> unique_parents;
+    unique_parents.reserve(it_lower->m_tx->vin.size());
+    for (const auto& input : it_lower->m_tx->vin) unique_parents.push_back(input.prevout.hash);
+    std::sort(unique_parents.begin(), unique_parents.end());
+    unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
+    return unique_parents;
 }
 
 bool TxOrphanageImpl::HaveTxFromPeer(const Wtxid& wtxid, NodeId peer) const

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -7,6 +7,8 @@
 #include <consensus/validation.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <serialize.h>
+#include <streams.h>
 #include <util/feefrac.h>
 #include <util/hasher.h>
 #include <util/log.h>
@@ -27,13 +29,75 @@ static constexpr NodeId MIN_PEER{std::numeric_limits<NodeId>::min()};
 /** Maximum NodeId for upper_bound lookups. */
 static constexpr NodeId MAX_PEER{std::numeric_limits<NodeId>::max()};
 
+/** Data for a unique orphan transaction, shared by all announcements of the same wtxid (like the CTransactionRef it
+ * replaces). The transaction is kept in serialized form: deserialized, every witness stack element is an individually
+ * heap-allocated vector, so a transaction of standard weight can use many times more memory than its weight suggests
+ * (~28x for a witness stack of 1-byte elements). Serialized, an orphan's memory usage is bounded by its weight (see
+ * GetOrphanUsage), so the existing weight-based accounting bounds the actual memory. The transaction is deserialized
+ * again on the paths that hand it back out (orphan resolution, RPC), all of which feed into full (re)validation whose
+ * cost dwarfs a deserialization. */
+struct OrphanTxData {
+    /** The serialized transaction, including witness. */
+    const std::vector<unsigned char> m_encoded;
+    const Wtxid m_wtxid;
+    const Txid m_txid;
+    /** The transaction's prevouts, cached so that maintaining m_outpoint_to_orphan_wtxids, EraseForBlock and latency
+     * scores do not require deserializing. */
+    const std::vector<COutPoint> m_prevouts;
+    /** Memory accounted for this orphan (see GetOrphanUsage), cached at construction. Caching guarantees that the
+     * same value is added and subtracted from the per-peer and global totals, and avoids recomputing it on every
+     * operation. */
+    const TxOrphanage::Usage m_usage;
+
+    explicit OrphanTxData(const CTransactionRef& tx)
+        : m_encoded{EncodeTx(*tx)},
+          m_wtxid{tx->GetWitnessHash()},
+          m_txid{tx->GetHash()},
+          m_prevouts{CachePrevouts(*tx)},
+          m_usage{GetOrphanUsage(tx)}
+    {}
+
+    static std::vector<unsigned char> EncodeTx(const CTransaction& tx)
+    {
+        std::vector<unsigned char> encoded;
+        encoded.reserve(GetSerializeSize(TX_WITH_WITNESS(tx)));
+        VectorWriter writer{encoded, 0};
+        writer << TX_WITH_WITNESS(tx);
+        return encoded;
+    }
+
+    static std::vector<COutPoint> CachePrevouts(const CTransaction& tx)
+    {
+        std::vector<COutPoint> prevouts;
+        prevouts.reserve(tx.vin.size());
+        for (const auto& input : tx.vin) prevouts.push_back(input.prevout);
+        return prevouts;
+    }
+
+    /** Deserialize the transaction, for the paths that hand the orphan back out. */
+    CTransactionRef MakeTxRef() const
+    {
+        SpanReader reader{m_encoded};
+        CMutableTransaction mtx;
+        reader >> TX_WITH_WITNESS(mtx);
+        auto ptx{MakeTransactionRef(std::move(mtx))};
+        Assume(ptx->GetWitnessHash() == m_wtxid);
+        return ptx;
+    }
+};
+
 TxOrphanage::Usage GetOrphanUsage(const CTransactionRef& tx)
 {
     // The total memory is a function of the memory used to store the transaction itself, each entry in m_orphans, and
-    // each entry in m_outpoint_to_orphan_wtxids. We use weight because it is often higher than the actual memory usage
-    // of the transaction. This metric conveniently encompasses m_outpoint_to_orphan_wtxids usage since input data does
-    // not get the witness discount, and makes it easier to reason about each peer's limits using well-understood
-    // transaction attributes.
+    // each entry in m_outpoint_to_orphan_wtxids. We use weight because, with the transaction kept in serialized form,
+    // it is an upper bound on the memory used to store the transaction: its serialized size never exceeds its weight.
+    // This metric conveniently encompasses m_outpoint_to_orphan_wtxids usage since input data does not get the witness
+    // discount, and makes it easier to reason about each peer's limits using well-understood transaction attributes.
+    //
+    // The remaining per-orphan overhead not covered by this (the entry in m_orphans, the entries in
+    // m_outpoint_to_orphan_wtxids, and OrphanTxData's cached prevouts and hashes) is bounded by the latency score
+    // limits, which permit DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE announcements and 10 times as many inputs, i.e. a few
+    // MB in total, regardless of how high the usage limits are.
     return GetTransactionWeight(*tx);
 }
 
@@ -47,25 +111,23 @@ class TxOrphanageImpl final : public TxOrphanage {
      * announcements for the same tx, and multiple transactions with the same txid but different wtxid are possible. */
     struct Announcement
     {
-        const CTransactionRef m_tx;
+        /** The orphan's data, shared between all announcements of the same wtxid. */
+        const std::shared_ptr<const OrphanTxData> m_tx_data;
         /** Which peer announced this tx */
         const NodeId m_announcer;
         /** What order this transaction entered the orphanage. */
         const SequenceNumber m_entry_sequence;
-        /** Memory accounted for this announcement, cached at construction. Caching guarantees that the same value is
-         * added and subtracted from the per-peer and global totals, and avoids recomputing it on every operation. */
-        const TxOrphanage::Usage m_usage;
         /** Whether this tx should be reconsidered. Always starts out false. A peer's workset is the collection of all
          * announcements with m_reconsider=true. */
         bool m_reconsider{false};
 
-        Announcement(const CTransactionRef& tx, NodeId peer, SequenceNumber seq) :
-            m_tx{tx}, m_announcer{peer}, m_entry_sequence{seq}, m_usage{GetOrphanUsage(tx)}
+        Announcement(const std::shared_ptr<const OrphanTxData>& tx_data, NodeId peer, SequenceNumber seq) :
+            m_tx_data{tx_data}, m_announcer{peer}, m_entry_sequence{seq}
         { }
 
         /** Get an approximation for "memory usage" (see GetOrphanUsage). */
         TxOrphanage::Usage GetMemUsage() const {
-            return m_usage;
+            return m_tx_data->m_usage;
         }
 
         /** Get an approximation of how much this transaction contributes to latency in EraseForBlock and EraseForPeer.
@@ -74,7 +136,7 @@ class TxOrphanageImpl final : public TxOrphanage {
          * small number of inputs (9 or fewer) are counted as 1 to make it easier to reason about each peer's limits in
          * terms of "normal" transactions. */
         TxOrphanage::Count GetLatencyScore() const {
-            return 1 + (m_tx->vin.size() / 10);
+            return 1 + (m_tx_data->m_prevouts.size() / 10);
         }
     };
 
@@ -86,7 +148,7 @@ class TxOrphanageImpl final : public TxOrphanage {
         using result_type = ByWtxidView;
         result_type operator()(const Announcement& ann) const
         {
-            return ByWtxidView{ann.m_tx->GetWitnessHash(), ann.m_announcer};
+            return ByWtxidView{ann.m_tx_data->m_wtxid, ann.m_announcer};
         }
     };
 
@@ -263,9 +325,9 @@ void TxOrphanageImpl::Erase(Iter<Tag> it)
         m_unique_orphan_usage -= it->GetMemUsage();
 
         // Remove references in m_outpoint_to_orphan_wtxids
-        const auto& wtxid{it->m_tx->GetWitnessHash()};
-        for (const auto& input : it->m_tx->vin) {
-            auto it_prev = m_outpoint_to_orphan_wtxids.find(input.prevout);
+        const auto& wtxid{it->m_tx_data->m_wtxid};
+        for (const auto& prevout : it->m_tx_data->m_prevouts) {
+            auto it_prev = m_outpoint_to_orphan_wtxids.find(prevout);
             if (it_prev != m_outpoint_to_orphan_wtxids.end()) {
                 it_prev->second.erase(wtxid);
                 // Clean up keys if they point to an empty set.
@@ -278,7 +340,7 @@ void TxOrphanageImpl::Erase(Iter<Tag> it)
 
     // If this was the (unique) reconsiderable announcement for its wtxid, then the wtxid won't
     // have any reconsiderable announcements left after erasing.
-    if (it->m_reconsider) m_reconsiderable_wtxids.erase(it->m_tx->GetWitnessHash());
+    if (it->m_reconsider) m_reconsiderable_wtxids.erase(it->m_tx_data->m_wtxid);
 
     m_orphans.get<Tag>().erase(it);
 }
@@ -288,8 +350,8 @@ bool TxOrphanageImpl::IsUnique(Iter<ByWtxid> it) const
     // Iterators ByWtxid are sorted by wtxid, so check if neighboring elements have the same wtxid.
     auto& index = m_orphans.get<ByWtxid>();
     if (it == index.end()) return false;
-    if (std::next(it) != index.end() && std::next(it)->m_tx->GetWitnessHash() == it->m_tx->GetWitnessHash()) return false;
-    if (it != index.begin() && std::prev(it)->m_tx->GetWitnessHash() == it->m_tx->GetWitnessHash()) return false;
+    if (std::next(it) != index.end() && std::next(it)->m_tx_data->m_wtxid == it->m_tx_data->m_wtxid) return false;
+    if (it != index.begin() && std::prev(it)->m_tx_data->m_wtxid == it->m_tx_data->m_wtxid) return false;
     return true;
 }
 
@@ -321,16 +383,21 @@ bool TxOrphanageImpl::AddTx(const CTransactionRef& tx, NodeId peer)
     const auto& txid{tx->GetHash()};
 
     // Ignore transactions above max standard size to avoid a send-big-orphans memory exhaustion attack.
-    TxOrphanage::Usage sz = GetTransactionWeight(*tx);
-    if (sz > MAX_STANDARD_TX_WEIGHT) {
-        LogDebug(BCLog::TXPACKAGES, "ignoring large orphan tx (size: %u, txid: %s, wtxid: %s)\n", sz, txid.ToString(), wtxid.ToString());
+    const TxOrphanage::Usage weight{GetTransactionWeight(*tx)};
+    if (weight > MAX_STANDARD_TX_WEIGHT) {
+        LogDebug(BCLog::TXPACKAGES, "ignoring large orphan tx (size: %d, txid: %s, wtxid: %s)\n", weight, txid.ToString(), wtxid.ToString());
         return false;
     }
 
     // We will return false if the tx already exists under a different peer.
     const bool brand_new{!HaveTx(wtxid)};
 
-    auto [iter, inserted] = m_orphans.get<ByWtxid>().emplace(tx, peer, m_current_sequence);
+    // Share the OrphanTxData with the existing announcements of the same wtxid. This also deduplicates the
+    // underlying transaction data if the same transaction was downloaded from more than one peer.
+    const auto tx_data{brand_new ? std::make_shared<const OrphanTxData>(tx)
+                                 : m_orphans.get<ByWtxid>().lower_bound(ByWtxidView{wtxid, MIN_PEER})->m_tx_data};
+
+    auto [iter, inserted] = m_orphans.get<ByWtxid>().emplace(tx_data, peer, m_current_sequence);
     // If the announcement (same wtxid, same peer) already exists, emplacement fails. Return false.
     if (!inserted) return false;
 
@@ -340,8 +407,8 @@ bool TxOrphanageImpl::AddTx(const CTransactionRef& tx, NodeId peer)
 
     // Add links in m_outpoint_to_orphan_wtxids
     if (brand_new) {
-        for (const auto& input : tx->vin) {
-            auto& wtxids_for_prevout = m_outpoint_to_orphan_wtxids.try_emplace(input.prevout).first->second;
+        for (const auto& prevout : tx_data->m_prevouts) {
+            auto& wtxids_for_prevout = m_outpoint_to_orphan_wtxids.try_emplace(prevout).first->second;
             wtxids_for_prevout.emplace(wtxid);
         }
 
@@ -349,8 +416,8 @@ bool TxOrphanageImpl::AddTx(const CTransactionRef& tx, NodeId peer)
         m_unique_orphan_usage += iter->GetMemUsage();
         m_unique_rounded_input_scores += iter->GetLatencyScore() - 1;
 
-        LogDebug(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s), weight: %u (mapsz %u outsz %u)\n",
-                    txid.ToString(), wtxid.ToString(), sz, m_orphans.size(), m_outpoint_to_orphan_wtxids.size());
+        LogDebug(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s), weight: %d (mapsz %u outsz %u)\n",
+                    txid.ToString(), wtxid.ToString(), weight, m_orphans.size(), m_outpoint_to_orphan_wtxids.size());
         Assume(IsUnique(iter));
     } else {
         LogDebug(BCLog::TXPACKAGES, "added peer=%d as announcer of orphan tx %s (wtxid=%s)\n",
@@ -371,11 +438,11 @@ bool TxOrphanageImpl::AddAnnouncer(const Wtxid& wtxid, NodeId peer)
     // Do nothing if this transaction isn't already present. We can't create an entry if we don't
     // have the tx data.
     if (it == index_by_wtxid.end()) return false;
-    if (it->m_tx->GetWitnessHash() != wtxid) return false;
+    if (it->m_tx_data->m_wtxid != wtxid) return false;
 
-    // Add another announcement, copying the CTransactionRef from one that already exists.
-    const auto& ptx = it->m_tx;
-    auto [iter, inserted] = index_by_wtxid.emplace(ptx, peer, m_current_sequence);
+    // Add another announcement, sharing the OrphanTxData of one that already exists.
+    const auto& tx_data = it->m_tx_data;
+    auto [iter, inserted] = index_by_wtxid.emplace(tx_data, peer, m_current_sequence);
     // If the announcement (same wtxid, same peer) already exists, emplacement fails. Return false.
     if (!inserted) return false;
 
@@ -383,7 +450,7 @@ bool TxOrphanageImpl::AddAnnouncer(const Wtxid& wtxid, NodeId peer)
     auto& peer_info = m_peer_orphanage_info.try_emplace(peer).first->second;
     peer_info.Add(*iter);
 
-    const auto& txid = ptx->GetHash();
+    const auto& txid = tx_data->m_txid;
     LogDebug(BCLog::TXPACKAGES, "added peer=%d as announcer of orphan tx %s (wtxid=%s)\n",
                 peer, txid.ToString(), wtxid.ToString());
 
@@ -399,13 +466,13 @@ bool TxOrphanageImpl::EraseTxInternal(const Wtxid& wtxid)
     auto& index_by_wtxid = m_orphans.get<ByWtxid>();
 
     auto it = index_by_wtxid.lower_bound(ByWtxidView{wtxid, MIN_PEER});
-    if (it == index_by_wtxid.end() || it->m_tx->GetWitnessHash() != wtxid) return false;
+    if (it == index_by_wtxid.end() || it->m_tx_data->m_wtxid != wtxid) return false;
 
     auto it_end = index_by_wtxid.upper_bound(ByWtxidView{wtxid, MAX_PEER});
     unsigned int num_ann{0};
-    const auto txid = it->m_tx->GetHash();
+    const auto txid = it->m_tx_data->m_txid;
     while (it != it_end) {
-        Assume(it->m_tx->GetWitnessHash() == wtxid);
+        Assume(it->m_tx_data->m_wtxid == wtxid);
         Erase<ByWtxid>(it++);
         num_ann += 1;
     }
@@ -555,7 +622,7 @@ std::vector<std::pair<Wtxid, NodeId>> TxOrphanageImpl::AddChildrenToWorkSet(cons
 
                 // Belt and suspenders, each entry in m_outpoint_to_orphan_wtxids should always have at least 1 announcement.
                 auto it = index_by_wtxid.lower_bound(ByWtxidView{wtxid, MIN_PEER});
-                if (!Assume(it != index_by_wtxid.end() && it->m_tx->GetWitnessHash() == wtxid)) continue;
+                if (!Assume(it != index_by_wtxid.end() && it->m_tx_data->m_wtxid == wtxid)) continue;
 
                 // Select a random peer to assign orphan processing, reducing wasted work if the orphan is still missing
                 // inputs. However, we don't want to create an issue in which the assigned peer can purposefully stop us
@@ -565,7 +632,7 @@ std::vector<std::pair<Wtxid, NodeId>> TxOrphanageImpl::AddChildrenToWorkSet(cons
                 if (!Assume(num_announcers > 0)) continue;
                 std::advance(it, rng.randrange(num_announcers));
 
-                if (!Assume(it->m_tx->GetWitnessHash() == wtxid)) break;
+                if (!Assume(it->m_tx_data->m_wtxid == wtxid)) break;
 
                 // Mark this orphan as ready to be reconsidered.
                 static constexpr auto mark_reconsidered_modifier = [](auto& ann) { ann.m_reconsider = true; };
@@ -575,7 +642,7 @@ std::vector<std::pair<Wtxid, NodeId>> TxOrphanageImpl::AddChildrenToWorkSet(cons
                 m_reconsiderable_wtxids.insert(wtxid);
 
                 LogDebug(BCLog::TXPACKAGES, "added %s (wtxid=%s) to peer %d workset\n",
-                            it->m_tx->GetHash().ToString(), it->m_tx->GetWitnessHash().ToString(), it->m_announcer);
+                            it->m_tx_data->m_txid.ToString(), it->m_tx_data->m_wtxid.ToString(), it->m_announcer);
             }
         }
     }
@@ -585,24 +652,25 @@ std::vector<std::pair<Wtxid, NodeId>> TxOrphanageImpl::AddChildrenToWorkSet(cons
 bool TxOrphanageImpl::HaveTx(const Wtxid& wtxid) const
 {
     auto it_lower = m_orphans.get<ByWtxid>().lower_bound(ByWtxidView{wtxid, MIN_PEER});
-    return it_lower != m_orphans.get<ByWtxid>().end() && it_lower->m_tx->GetWitnessHash() == wtxid;
+    return it_lower != m_orphans.get<ByWtxid>().end() && it_lower->m_tx_data->m_wtxid == wtxid;
 }
 
 CTransactionRef TxOrphanageImpl::GetTx(const Wtxid& wtxid) const
 {
     auto it_lower = m_orphans.get<ByWtxid>().lower_bound(ByWtxidView{wtxid, MIN_PEER});
-    if (it_lower != m_orphans.get<ByWtxid>().end() && it_lower->m_tx->GetWitnessHash() == wtxid) return it_lower->m_tx;
+    if (it_lower != m_orphans.get<ByWtxid>().end() && it_lower->m_tx_data->m_wtxid == wtxid) return it_lower->m_tx_data->MakeTxRef();
     return nullptr;
 }
 
 std::optional<std::vector<Txid>> TxOrphanageImpl::GetParentTxids(const Wtxid& wtxid) const
 {
     auto it_lower = m_orphans.get<ByWtxid>().lower_bound(ByWtxidView{wtxid, MIN_PEER});
-    if (it_lower == m_orphans.get<ByWtxid>().end() || it_lower->m_tx->GetWitnessHash() != wtxid) return std::nullopt;
+    if (it_lower == m_orphans.get<ByWtxid>().end() || it_lower->m_tx_data->m_wtxid != wtxid) return std::nullopt;
 
+    const auto& prevouts{it_lower->m_tx_data->m_prevouts};
     std::vector<Txid> unique_parents;
-    unique_parents.reserve(it_lower->m_tx->vin.size());
-    for (const auto& input : it_lower->m_tx->vin) unique_parents.push_back(input.prevout.hash);
+    unique_parents.reserve(prevouts.size());
+    for (const auto& prevout : prevouts) unique_parents.push_back(prevout.hash);
     std::sort(unique_parents.begin(), unique_parents.end());
     unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
     return unique_parents;
@@ -625,8 +693,8 @@ CTransactionRef TxOrphanageImpl::GetTxToReconsider(NodeId peer)
         m_orphans.get<ByPeer>().modify(it, mark_reconsidered_modifier);
         // As there is exactly one m_reconsider announcement per reconsiderable wtxids, flipping
         // the m_reconsider flag means the wtxid is no longer reconsiderable.
-        m_reconsiderable_wtxids.erase(it->m_tx->GetWitnessHash());
-        return it->m_tx;
+        m_reconsiderable_wtxids.erase(it->m_tx_data->m_wtxid);
+        return it->m_tx_data->MakeTxRef();
     }
     return nullptr;
 }
@@ -690,9 +758,9 @@ std::vector<TxOrphanage::OrphanId> TxOrphanageImpl::GetChildrenFromSamePeer(cons
         --it_upper;
         if (!Assume(it_upper->m_announcer == peer)) break;
         // Check if this tx spends from parent.
-        for (const auto& input : it_upper->m_tx->vin) {
-            if (input.prevout.hash == parent_txid) {
-                children_found.push_back({it_upper->m_tx->GetHash(), it_upper->m_tx->GetWitnessHash()});
+        for (const auto& prevout : it_upper->m_tx_data->m_prevouts) {
+            if (prevout.hash == parent_txid) {
+                children_found.push_back({it_upper->m_tx_data->m_txid, it_upper->m_tx_data->m_wtxid});
                 break;
             }
         }
@@ -711,8 +779,8 @@ std::vector<TxOrphanage::OrphanInfo> TxOrphanageImpl::GetOrphanTransactions() co
     while (it != index_by_wtxid.end()) {
         this_orphan_announcers.insert(it->m_announcer);
         // If this is the last entry, or the next entry has a different wtxid, build a OrphanInfo.
-        if (std::next(it) == index_by_wtxid.end() || std::next(it)->m_tx->GetWitnessHash() != it->m_tx->GetWitnessHash()) {
-            result.emplace_back(it->m_tx, std::move(this_orphan_announcers));
+        if (std::next(it) == index_by_wtxid.end() || std::next(it)->m_tx_data->m_wtxid != it->m_tx_data->m_wtxid) {
+            result.emplace_back(it->m_tx_data->MakeTxRef(), std::move(this_orphan_announcers));
             this_orphan_announcers.clear();
         }
 
@@ -731,10 +799,10 @@ void TxOrphanageImpl::SanityCheck() const
     std::set<Wtxid> reconstructed_reconsiderable_wtxids;
 
     for (auto it = m_orphans.begin(); it != m_orphans.end(); ++it) {
-        for (const auto& input : it->m_tx->vin) {
-            all_outpoints.insert(input.prevout);
+        for (const auto& prevout : it->m_tx_data->m_prevouts) {
+            all_outpoints.insert(prevout);
         }
-        unique_wtxids_to_scores.emplace(it->m_tx->GetWitnessHash(), std::make_pair(it->GetMemUsage(), it->GetLatencyScore() - 1));
+        unique_wtxids_to_scores.emplace(it->m_tx_data->m_wtxid, std::make_pair(it->GetMemUsage(), it->GetLatencyScore() - 1));
 
         auto& peer_info = reconstructed_peer_info[it->m_announcer];
         peer_info.m_total_usage += it->GetMemUsage();
@@ -742,7 +810,7 @@ void TxOrphanageImpl::SanityCheck() const
         peer_info.m_total_latency_score += it->GetLatencyScore();
 
         if (it->m_reconsider) {
-            auto [_, added] = reconstructed_reconsiderable_wtxids.insert(it->m_tx->GetWitnessHash());
+            auto [_, added] = reconstructed_reconsiderable_wtxids.insert(it->m_tx_data->m_wtxid);
             // Check that there is only ever 1 announcement per wtxid with m_reconsider set.
             assert(added);
         }

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -240,7 +240,7 @@ public:
     void EraseForBlock(const CBlock& block) override;
     std::vector<std::pair<Wtxid, NodeId>> AddChildrenToWorkSet(const CTransaction& tx, FastRandomContext& rng) override;
     bool HaveTxToReconsider(NodeId peer) override;
-    std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const override;
+    std::vector<OrphanId> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const override;
     std::vector<OrphanInfo> GetOrphanTransactions() const override;
     TxOrphanage::Usage TotalOrphanUsage() const override;
     void SanityCheck() const override;
@@ -673,9 +673,9 @@ void TxOrphanageImpl::EraseForBlock(const CBlock& block)
     LimitOrphans();
 }
 
-std::vector<CTransactionRef> TxOrphanageImpl::GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId peer) const
+std::vector<TxOrphanage::OrphanId> TxOrphanageImpl::GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId peer) const
 {
-    std::vector<CTransactionRef> children_found;
+    std::vector<OrphanId> children_found;
     const auto& parent_txid{parent->GetHash()};
 
     // Iterate through all orphans from this peer, in reverse order, so that more recent
@@ -692,7 +692,7 @@ std::vector<CTransactionRef> TxOrphanageImpl::GetChildrenFromSamePeer(const CTra
         // Check if this tx spends from parent.
         for (const auto& input : it_upper->m_tx->vin) {
             if (input.prevout.hash == parent_txid) {
-                children_found.emplace_back(it_upper->m_tx);
+                children_found.push_back({it_upper->m_tx->GetHash(), it_upper->m_tx->GetWitnessHash()});
                 break;
             }
         }

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -149,5 +149,10 @@ public:
 /** Create a new TxOrphanage instance */
 std::unique_ptr<TxOrphanage> MakeTxOrphanage() noexcept;
 std::unique_ptr<TxOrphanage> MakeTxOrphanage(TxOrphanage::Count max_global_latency_score, TxOrphanage::Usage reserved_peer_usage) noexcept;
+
+/** Get the amount TxOrphanage accounts for this transaction, i.e. its contribution to
+ * TotalOrphanUsage() and UsageByPeer(). Exposed so that tests, benchmarks and RPC report the same
+ * metric that the orphanage uses internally. */
+TxOrphanage::Usage GetOrphanUsage(const CTransactionRef& tx);
 } // namespace node
 #endif // BITCOIN_NODE_TXORPHANAGE_H

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <set>
 #include <utility>
 #include <vector>
@@ -65,6 +66,10 @@ public:
 
     /** Get a transaction by its witness txid */
     virtual CTransactionRef GetTx(const Wtxid& wtxid) const = 0;
+
+    /** Get the unique parent txids (deduplicated prevout hashes, sorted) of an orphan, or std::nullopt if no tx
+     * with this wtxid exists. */
+    virtual std::optional<std::vector<Txid>> GetParentTxids(const Wtxid& wtxid) const = 0;
 
     /** Check if we already have an orphan transaction (by wtxid only) */
     virtual bool HaveTx(const Wtxid& wtxid) const = 0;

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -5,15 +5,17 @@
 #ifndef BITCOIN_NODE_TXORPHANAGE_H
 #define BITCOIN_NODE_TXORPHANAGE_H
 
-#include <consensus/validation.h>
 #include <net.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <sync.h>
-#include <util/time.h>
 
-#include <map>
+#include <cstdint>
+#include <memory>
 #include <set>
+#include <utility>
+#include <vector>
+
+class FastRandomContext;
 
 namespace node {
 /** Default value for TxOrphanage::m_reserved_usage_per_peer. Helps limit the total amount of memory used by the orphanage. */

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -19,7 +19,7 @@ class FastRandomContext;
 
 namespace node {
 /** Default value for TxOrphanage::m_reserved_usage_per_peer. Helps limit the total amount of memory used by the orphanage. */
-inline constexpr int64_t DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER{404'000};
+inline constexpr int64_t DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER{404'000};
 /** Default value for TxOrphanage::m_max_global_latency_score. Helps limit the maximum latency for operations like
  * EraseForBlock and LimitOrphans. */
 inline constexpr unsigned int DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE{3000};

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -43,6 +43,11 @@ public:
     using Usage = int64_t;
     using Count = unsigned int;
 
+    struct OrphanId {
+        Txid txid;
+        Wtxid wtxid;
+    };
+
     /** Allows providing orphan information externally */
     struct OrphanInfo {
         CTransactionRef tx;
@@ -101,9 +106,10 @@ public:
     /** Does this peer have any work to do? */
     virtual bool HaveTxToReconsider(NodeId peer) = 0;
 
-    /** Get all children that spend from this tx and were received from nodeid. Sorted
-     * reconsiderable before non-reconsiderable, then from most recent to least recent. */
-    virtual std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const = 0;
+    /** Get the txids and wtxids of all children that spend from this tx and were received from nodeid. Sorted
+     * reconsiderable before non-reconsiderable, then from most recent to least recent. Use GetTx() to retrieve a
+     * selected child. */
+    virtual std::vector<OrphanId> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const = 0;
 
     /** Get all orphan transactions */
     virtual std::vector<OrphanInfo> GetOrphanTransactions() const = 0;

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <utility>
 
 /** IsTopoSortedPackage where a set of txids has been pre-populated. The set is assumed to be correct and
  * is mutated within this function (even if return value is false). */
@@ -155,15 +156,20 @@ uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions)
     std::transform(transactions.cbegin(), transactions.cend(), std::back_inserter(wtxids_copy),
         [](const auto& tx){ return tx->GetWitnessHash(); });
 
+    return GetPackageHashFromWtxids(std::move(wtxids_copy));
+}
+
+uint256 GetPackageHashFromWtxids(std::vector<Wtxid> wtxids)
+{
     // Sort in ascending order
-    std::sort(wtxids_copy.begin(), wtxids_copy.end(), [](const auto& lhs, const auto& rhs) {
+    std::sort(wtxids.begin(), wtxids.end(), [](const auto& lhs, const auto& rhs) {
         return std::lexicographical_compare(std::make_reverse_iterator(lhs.end()), std::make_reverse_iterator(lhs.begin()),
                                             std::make_reverse_iterator(rhs.end()), std::make_reverse_iterator(rhs.begin()));
     });
 
     // Get sha256 hash of the wtxids concatenated in this order
     HashWriter hashwriter;
-    for (const auto& wtxid : wtxids_copy) {
+    for (const auto& wtxid : wtxids) {
         hashwriter << wtxid;
     }
     return hashwriter.GetSHA256();

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -89,4 +89,7 @@ bool IsChildWithParentsTree(const Package& package);
  */
 uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions);
 
+/** Same as GetPackageHash(), but computed from the transactions' wtxids without needing the transactions. */
+uint256 GetPackageHashFromWtxids(std::vector<Wtxid> wtxids);
+
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -234,7 +234,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
     FastRandomContext orphanage_rng{ConsumeUInt256(fuzzed_data_provider)};
     FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
 
-    // We have num_peers peers. Some subset of them will never exceed their reserved weight or announcement count, and
+    // We have num_peers peers. Some subset of them will never exceed their reserved usage or announcement count, and
     // should therefore never have any orphans evicted.
     const unsigned int MAX_PEERS = 125;
     const unsigned int num_peers = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(1, MAX_PEERS);
@@ -246,15 +246,15 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
 
     // Params for orphanage.
     const unsigned int global_latency_score_limit = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(num_peers, 6'000);
-    const int64_t per_peer_weight_reservation = fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(1, 4'040'000);
-    auto orphanage = node::MakeTxOrphanage(global_latency_score_limit, per_peer_weight_reservation);
+    const int64_t per_peer_usage_reservation = fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(1, 4'040'000);
+    auto orphanage = node::MakeTxOrphanage(global_latency_score_limit, per_peer_usage_reservation);
 
     // The actual limit, MaxPeerLatencyScore(), may be higher, since TxOrphanage only counts peers
     // that have announced an orphan. The honest peer will not experience evictions if it never
     // exceeds this.
     const unsigned int honest_latency_limit = global_latency_score_limit / num_peers;
     // Honest peer will not experience evictions if it never exceeds this.
-    const int64_t honest_mem_limit = per_peer_weight_reservation;
+    const int64_t honest_mem_limit = per_peer_usage_reservation;
 
     std::vector<COutPoint> outpoints; // Duplicates are tolerated
     outpoints.reserve(400);
@@ -304,7 +304,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
         // orphanage functions
         LIMITED_WHILE (fuzzed_data_provider.remaining_bytes(), 10 * global_latency_score_limit) {
             NodeId peer_id = fuzzed_data_provider.ConsumeIntegralInRange<NodeId>(0, num_peers - 1);
-            const auto tx_weight{GetTransactionWeight(*tx)};
+            const auto tx_usage{node::GetOrphanUsage(tx)};
 
             // This protected peer will never send orphans that would
             // exceed their own personal allotment, so is never evicted.
@@ -315,7 +315,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                 [&] { // AddTx
                     bool have_tx_and_peer = orphanage->HaveTxFromPeer(wtxid, peer_id);
                     if (peer_is_protected && !have_tx_and_peer &&
-                        (orphanage->UsageByPeer(peer_id) + tx_weight > honest_mem_limit ||
+                        (orphanage->UsageByPeer(peer_id) + tx_usage > honest_mem_limit ||
                         orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size() / 10) + 1 > honest_latency_limit)) {
                         // We never want our protected peer oversized or over-announced
                     } else {
@@ -330,7 +330,7 @@ FUZZ_TARGET(txorphan_protected, .init = initialize_orphanage)
                     // AddAnnouncer should return false if tx doesn't exist or we already HaveTxFromPeer.
                     {
                         if (peer_is_protected && !have_tx_and_peer &&
-                            (orphanage->UsageByPeer(peer_id) + tx_weight > honest_mem_limit ||
+                            (orphanage->UsageByPeer(peer_id) + tx_usage > honest_mem_limit ||
                             orphanage->LatencyScoreFromPeer(peer_id) + (tx->vin.size() / 10) + 1 > honest_latency_limit)) {
                             // We never want our protected peer oversized
                         } else {
@@ -464,9 +464,10 @@ FUZZ_TARGET(txorphanage_sim)
         // Convert to CTransactionRef.
         txn[txorder[t]] = MakeTransactionRef(std::move(tx));
         wtxids.insert(txn[txorder[t]]->GetWitnessHash());
-        auto weight = GetTransactionWeight(*txn[txorder[t]]);
-        assert(weight < MAX_STANDARD_TX_WEIGHT);
-        total_usage += GetTransactionWeight(*txn[txorder[t]]);
+        // The simulation assumes that every transaction can be stored, i.e. none of them is rejected for being too
+        // large. See TxOrphanageImpl::AddTx.
+        assert(GetTransactionWeight(*txn[txorder[t]]) < MAX_STANDARD_TX_WEIGHT);
+        total_usage += node::GetOrphanUsage(txn[txorder[t]]);
     }
 
     //
@@ -555,7 +556,7 @@ FUZZ_TARGET(txorphanage_sim)
         for (auto& ann : sim_announcements) {
             if (ann.announcer != peer) continue;
             count += 1 + (txn[ann.tx]->vin.size() / 10);
-            usage += GetTransactionWeight(*txn[ann.tx]);
+            usage += node::GetOrphanUsage(txn[ann.tx]);
         }
         return std::max<ByRatioNegSize<FeeFrac>>(FeeFrac{count, max_count}, FeeFrac{usage, max_usage});
     };
@@ -694,7 +695,7 @@ FUZZ_TARGET(txorphanage_sim)
             node::TxOrphanage::Count total_latency_score = sim_announcements.size();
             for (unsigned tx = 0; tx < NUM_TX; ++tx) {
                 if (have_tx_fn(tx)) {
-                    total_usage += GetTransactionWeight(*txn[tx]);
+                    total_usage += node::GetOrphanUsage(txn[tx]);
                     total_latency_score += txn[tx]->vin.size() / 10;
                 }
             }
@@ -751,7 +752,7 @@ FUZZ_TARGET(txorphanage_sim)
     for (unsigned tx = 0; tx < NUM_TX; ++tx) {
         bool sim_have_tx = have_tx_fn(tx);
         if (sim_have_tx) {
-            orphan_usage += GetTransactionWeight(*txn[tx]);
+            orphan_usage += node::GetOrphanUsage(txn[tx]);
             total_latency_score += txn[tx]->vin.size() / 10;
         }
         unique_orphans += sim_have_tx;
@@ -769,7 +770,7 @@ FUZZ_TARGET(txorphanage_sim)
         for (NodeId peer = 0; peer < NUM_PEERS; ++peer) {
             auto it_sim_ann = find_announce_fn(tx, peer);
             bool sim_have_ann = it_sim_ann != sim_announcements.end();
-            if (sim_have_ann) usage_by_peer[peer] += GetTransactionWeight(*txn[tx]);
+            if (sim_have_ann) usage_by_peer[peer] += node::GetOrphanUsage(txn[tx]);
             count_by_peer[peer] += sim_have_ann;
             // GetOrphanTransactions (announcers presence)
             if (sim_have_ann) assert(sim_have_tx);

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -95,7 +95,10 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
 
             // Check that all txns returned from GetChildrenFrom* are indeed a direct child of this tx.
             NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
-            for (const auto& child : orphanage->GetChildrenFromSamePeer(ptx_potential_parent, peer_id)) {
+            for (const auto& child_id : orphanage->GetChildrenFromSamePeer(ptx_potential_parent, peer_id)) {
+                const auto child{orphanage->GetTx(child_id.wtxid)};
+                assert(child);
+                assert(child->GetHash() == child_id.txid);
                 assert(std::any_of(child->vin.cbegin(), child->vin.cend(), [&](const auto& input) {
                     return input.prevout.hash == ptx_potential_parent->GetHash();
                 }));
@@ -793,7 +796,8 @@ FUZZ_TARGET(txorphanage_sim)
                     if (!matching_parent) continue;
                     // Found an announcement from peer which is a child of txn[tx].
                     assert(it != children_from_peer.rend());
-                    assert((*it)->GetWitnessHash() == txn[ann.tx]->GetWitnessHash());
+                    assert(it->wtxid == txn[ann.tx]->GetWitnessHash());
+                    assert(it->txid == txn[ann.tx]->GetHash());
                     ++it;
                 }
             }

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -285,53 +285,53 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
         auto orphanage{node::MakeTxOrphanage()};
         // These stay the same regardless of number of peers
         BOOST_CHECK_EQUAL(orphanage->MaxGlobalLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
-        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
 
         // These change with number of peers
-        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
         BOOST_CHECK_EQUAL(orphanage->MaxPeerLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
 
         // Number of peers = 1
         orphanage->AddTx(txns.at(0), 0);
         BOOST_CHECK_EQUAL(orphanage->MaxGlobalLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
-        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
-        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
         BOOST_CHECK_EQUAL(orphanage->MaxPeerLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
 
         // Number of peers = 2
         orphanage->AddTx(txns.at(1), 1);
         BOOST_CHECK_EQUAL(orphanage->MaxGlobalLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
-        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
-        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER * 2);
+        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER * 2);
         BOOST_CHECK_EQUAL(orphanage->MaxPeerLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE / 2);
 
         // Number of peers = 3
         orphanage->AddTx(txns.at(2), 2);
         BOOST_CHECK_EQUAL(orphanage->MaxGlobalLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
-        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
-        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER * 3);
+        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER * 3);
         BOOST_CHECK_EQUAL(orphanage->MaxPeerLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE / 3);
 
         // Number of peers didn't change.
         orphanage->AddTx(txns.at(3), 2);
         BOOST_CHECK_EQUAL(orphanage->MaxGlobalLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
-        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
-        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER * 3);
+        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER * 3);
         BOOST_CHECK_EQUAL(orphanage->MaxPeerLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE / 3);
 
         // Once a peer has no orphans, it is not considered in the limits.
         // Number of peers = 2
         orphanage->EraseForPeer(2);
         BOOST_CHECK_EQUAL(orphanage->MaxGlobalLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
-        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
-        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER * 2);
+        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER * 2);
         BOOST_CHECK_EQUAL(orphanage->MaxPeerLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE / 2);
 
         // Number of peers = 1
         orphanage->EraseTx(txns.at(0)->GetWitnessHash());
         BOOST_CHECK_EQUAL(orphanage->MaxGlobalLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
-        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
-        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_WEIGHT_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->ReservedPeerUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
+        BOOST_CHECK_EQUAL(orphanage->MaxGlobalUsage(), node::DEFAULT_RESERVED_ORPHAN_USAGE_PER_PEER);
         BOOST_CHECK_EQUAL(orphanage->MaxPeerLatencyScore(), node::DEFAULT_MAX_ORPHANAGE_LATENCY_SCORE);
 
         orphanage->SanityCheck();

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -80,8 +80,7 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
 
     // Construct transactions to use. They must all be the same size.
     static constexpr unsigned int NUM_TXNS_CREATED = 100;
-    static constexpr int64_t TX_SIZE{469};
-    static constexpr int64_t TOTAL_SIZE = NUM_TXNS_CREATED * TX_SIZE;
+    static constexpr int64_t TX_WEIGHT{469};
 
     std::vector<CTransactionRef> txns;
     txns.reserve(NUM_TXNS_CREATED);
@@ -89,15 +88,20 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
     for (unsigned int i{0}; i < NUM_TXNS_CREATED; ++i) {
         auto ptx = MakeTransactionSpending({}, det_rand);
         txns.emplace_back(ptx);
-        BOOST_CHECK_EQUAL(TX_SIZE, GetTransactionWeight(*ptx));
+        BOOST_CHECK_EQUAL(TX_WEIGHT, GetTransactionWeight(*ptx));
     }
+    // The orphanage accounts the same usage for each of them. Don't hardcode the value, as it is
+    // not necessarily the same on all platforms.
+    const int64_t TX_USAGE{node::GetOrphanUsage(txns.front())};
+    for (const auto& ptx : txns) BOOST_CHECK_EQUAL(TX_USAGE, node::GetOrphanUsage(ptx));
+    const int64_t TOTAL_USAGE{NUM_TXNS_CREATED * TX_USAGE};
 
     // Single peer: eviction is triggered if either limit is hit
     {
         // Test announcement limits
         NodeId peer{8};
-        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_latency_score=*/1, /*reserved_peer_usage=*/TX_SIZE * 10);
-        auto orphanage_low_mem = node::MakeTxOrphanage(/*max_global_latency_score=*/10, /*reserved_peer_usage=*/TX_SIZE);
+        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_latency_score=*/1, /*reserved_peer_usage=*/TX_USAGE * 10);
+        auto orphanage_low_mem = node::MakeTxOrphanage(/*max_global_latency_score=*/10, /*reserved_peer_usage=*/TX_USAGE);
 
         // Add the first transaction
         orphanage_low_ann->AddTx(txns.at(0), peer);
@@ -121,7 +125,7 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
     {
         // Test latency score limits
         NodeId peer{10};
-        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_latency_score=*/5, /*reserved_peer_usage=*/TX_SIZE * 1000);
+        auto orphanage_low_ann = node::MakeTxOrphanage(/*max_global_latency_score=*/5, /*reserved_peer_usage=*/TX_USAGE * 1000);
 
         // Add the first transaction
         orphanage_low_ann->AddTx(txns.at(0), peer);
@@ -155,7 +159,7 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
 
         // Test announcement limits
         NodeId peer{9};
-        auto orphanage = node::MakeTxOrphanage(/*max_global_latency_score=*/3, /*reserved_peer_usage=*/TX_SIZE * 10);
+        auto orphanage = node::MakeTxOrphanage(/*max_global_latency_score=*/3, /*reserved_peer_usage=*/TX_USAGE * 10);
 
         // First add a tx which will be made reconsiderable.
         orphanage->AddTx(children.at(0), peer);
@@ -221,7 +225,7 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
 
         unsigned int max_announcements = 60;
         // Set a high per-peer reservation so announcement limit is always hit first.
-        auto orphanage = node::MakeTxOrphanage(max_announcements, TOTAL_SIZE * 10);
+        auto orphanage = node::MakeTxOrphanage(max_announcements, TOTAL_USAGE * 10);
 
         // No evictions happen before the global limit is reached.
         for (unsigned int i{0}; i < max_announcements; ++i) {
@@ -339,17 +343,19 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
 
     // Test eviction of multiple transactions at a time
     {
-        // Create a large transaction that is 10 times larger than the normal size transaction.
+        // Create a large transaction that uses 10 times as much of the orphanage's usage allowance
+        // as a normal size transaction. The eviction expectations below rely on it being between 10
+        // and 11 times as large.
         CMutableTransaction tx_large;
         tx_large.vin.resize(1);
-        BulkTransaction(tx_large, 10 * TX_SIZE);
+        BulkTransaction(tx_large, 10 * TX_WEIGHT);
         auto ptx_large = MakeTransactionRef(tx_large);
 
-        const auto large_tx_size = GetTransactionWeight(*ptx_large);
-        BOOST_CHECK(large_tx_size > 10 * TX_SIZE);
-        BOOST_CHECK(large_tx_size < 11 * TX_SIZE);
+        const auto large_tx_usage{node::GetOrphanUsage(ptx_large)};
+        BOOST_CHECK_GE(large_tx_usage, 10 * TX_USAGE);
+        BOOST_CHECK_LT(large_tx_usage, 11 * TX_USAGE);
 
-        auto orphanage = node::MakeTxOrphanage(20, large_tx_size);
+        auto orphanage = node::MakeTxOrphanage(20, large_tx_usage);
         // One peer sends 10 normal size transactions. The other peer sends 10 normal transactions and 1 very large one
         NodeId peer_normal{0};
         NodeId peer_large{1};

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -65,11 +65,23 @@ static CTransactionRef MakeMutation(const CTransactionRef& ptx)
     return mutated_tx;
 }
 
-static bool EqualTxns(const std::set<CTransactionRef>& set_txns, const std::vector<CTransactionRef>& vec_txns)
+static bool SameTxns(const std::vector<CTransactionRef>& expected, const std::vector<node::TxOrphanage::OrphanId>& actual)
+{
+    if (expected.size() != actual.size()) return false;
+    for (size_t i{0}; i < expected.size(); ++i) {
+        if (expected.at(i)->GetHash() != actual.at(i).txid ||
+            expected.at(i)->GetWitnessHash() != actual.at(i).wtxid) return false;
+    }
+    return true;
+}
+
+static bool EqualTxns(const std::set<CTransactionRef>& set_txns, const std::vector<node::TxOrphanage::OrphanId>& vec_txns)
 {
     if (vec_txns.size() != set_txns.size()) return false;
+    std::set<std::pair<Txid, Wtxid>> expected_ids;
+    for (const auto& tx : set_txns) expected_ids.emplace(tx->GetHash(), tx->GetWitnessHash());
     for (const auto& tx : vec_txns) {
-        if (!set_txns.contains(tx)) return false;
+        if (expected_ids.erase({tx.txid, tx.wtxid}) != 1) return false;
     }
     return true;
 }
@@ -608,8 +620,8 @@ BOOST_AUTO_TEST_CASE(get_children)
         std::vector<CTransactionRef> expected_parent1_children{child_p1n0_p2n0, child_p1n0_p1n1, child_p1n0};
         std::vector<CTransactionRef> expected_parent2_children{child_p1n0_p2n0, child_p2n1};
 
-        BOOST_CHECK(expected_parent1_children == orphanage->GetChildrenFromSamePeer(parent1, node1));
-        BOOST_CHECK(expected_parent2_children == orphanage->GetChildrenFromSamePeer(parent2, node1));
+        BOOST_CHECK(SameTxns(expected_parent1_children, orphanage->GetChildrenFromSamePeer(parent1, node1)));
+        BOOST_CHECK(SameTxns(expected_parent2_children, orphanage->GetChildrenFromSamePeer(parent2, node1)));
 
         // The peer must match
         BOOST_CHECK(orphanage->GetChildrenFromSamePeer(parent1, node2).empty());
@@ -656,7 +668,7 @@ BOOST_AUTO_TEST_CASE(get_children)
             std::vector<CTransactionRef> expected_parent1_node2{child_p1n0_p2n0, child_p1n0_p1n1};
             BOOST_CHECK(orphanage->HaveTxFromPeer(child_p1n0_p1n1->GetWitnessHash(), node2));
             BOOST_CHECK(orphanage->HaveTxFromPeer(child_p1n0_p2n0->GetWitnessHash(), node2));
-            BOOST_CHECK(expected_parent1_node2 == orphanage->GetChildrenFromSamePeer(parent1, node2));
+            BOOST_CHECK(SameTxns(expected_parent1_node2, orphanage->GetChildrenFromSamePeer(parent1, node2)));
         }
 
         // Children of parent2 from node2:

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -8,6 +8,7 @@
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <pubkey.h>
+#include <serialize.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <test/util/common.h>
@@ -704,6 +705,61 @@ BOOST_AUTO_TEST_CASE(too_large_orphan_tx)
     BulkTransaction(tx, MAX_STANDARD_TX_WEIGHT);
     BOOST_CHECK_EQUAL(GetTransactionWeight(CTransaction(tx)), MAX_STANDARD_TX_WEIGHT);
     BOOST_CHECK(orphanage->AddTx(MakeTransactionRef(tx), 0));
+}
+
+BOOST_AUTO_TEST_CASE(witness_heavy_orphan_tx)
+{
+    FastRandomContext det_rand{true};
+
+    // A transaction whose witness is a stack of many 1-byte elements is of standard weight (and its full
+    // witness standardness cannot be checked, since its inputs are missing). Deserialized, it would use ~28 times more
+    // memory than its weight suggests, as every element is an individually heap-allocated vector. Since orphans
+    // are stored in serialized form, its memory usage is bounded by the weight that is accounted for it.
+    const auto parent{MakeTransactionSpending({}, det_rand)};
+    CMutableTransaction mtx;
+    mtx.vin.emplace_back(parent->GetHash(), 0);
+    mtx.vout.resize(1);
+    mtx.vin[0].scriptWitness.stack.assign(199'000, std::vector<unsigned char>{1});
+    const auto ptx{MakeTransactionRef(mtx)};
+    const auto weight{GetTransactionWeight(*ptx)};
+    BOOST_CHECK_LE(weight, MAX_STANDARD_TX_WEIGHT);
+    // The serialized transaction, which is what the orphanage keeps, is smaller than the accounted weight.
+    BOOST_CHECK_LT(static_cast<int64_t>(GetSerializeSize(TX_WITH_WITNESS(*ptx))), weight);
+
+    auto orphanage{node::MakeTxOrphanage()};
+
+    // It is stored and accounted its weight.
+    BOOST_CHECK(orphanage->AddTx(ptx, 0));
+    BOOST_CHECK(orphanage->HaveTx(ptx->GetWitnessHash()));
+    BOOST_CHECK_EQUAL(orphanage->UsageByPeer(0), weight);
+    BOOST_CHECK_EQUAL(orphanage->UsageByPeer(0), node::GetOrphanUsage(ptx));
+
+    // Candidate enumeration exposes only cached IDs, even for a witness-heavy child.
+    const auto children{orphanage->GetChildrenFromSamePeer(parent, 0)};
+    BOOST_REQUIRE_EQUAL(children.size(), 1);
+    BOOST_CHECK(children[0].txid == ptx->GetHash());
+    BOOST_CHECK(children[0].wtxid == ptx->GetWitnessHash());
+    BOOST_CHECK(orphanage->GetChildrenFromSamePeer(parent, 1).empty());
+
+    // It fits within the peer's reservation alongside normal orphans, which are left in place.
+    std::vector<CTransactionRef> normal_txns;
+    for (unsigned int i{0}; i < 10; ++i) {
+        normal_txns.emplace_back(MakeTransactionSpending({}, det_rand));
+        BOOST_CHECK(orphanage->AddTx(normal_txns.back(), 0));
+    }
+    BOOST_CHECK(orphanage->HaveTx(ptx->GetWitnessHash()));
+    BOOST_CHECK_EQUAL(orphanage->CountUniqueOrphans(), normal_txns.size() + 1);
+    for (const auto& normal_tx : normal_txns) BOOST_CHECK(orphanage->HaveTx(normal_tx->GetWitnessHash()));
+    BOOST_CHECK_LE(orphanage->UsageByPeer(0), orphanage->ReservedPeerUsage());
+
+    // The transaction handed back out deserializes to the original.
+    const auto ptx_out{orphanage->GetTx(ptx->GetWitnessHash())};
+    BOOST_REQUIRE(ptx_out != nullptr);
+    // It is a fresh deserialization, not the stored reference: the orphanage keeps the transaction serialized.
+    BOOST_CHECK(ptx_out != ptx);
+    BOOST_CHECK(ptx_out->GetWitnessHash() == ptx->GetWitnessHash());
+    BOOST_CHECK_EQUAL(ptx_out->vin[0].scriptWitness.stack.size(), 199'000);
+    orphanage->SanityCheck();
 }
 
 BOOST_AUTO_TEST_CASE(process_block)

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -65,6 +65,13 @@ static CTransactionRef MakeMutation(const CTransactionRef& ptx)
     return mutated_tx;
 }
 
+// The following helpers compare transactions by wtxid: the orphanage hands out freshly deserialized transactions,
+// not the refs that were passed in, so pointer identity cannot be used.
+static bool SameTx(const CTransactionRef& lhs, const CTransactionRef& rhs)
+{
+    return lhs && rhs && lhs->GetWitnessHash() == rhs->GetWitnessHash();
+}
+
 static bool SameTxns(const std::vector<CTransactionRef>& expected, const std::vector<node::TxOrphanage::OrphanId>& actual)
 {
     if (expected.size() != actual.size()) return false;
@@ -214,7 +221,7 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
         BOOST_CHECK(!orphanage->HaveTx(children.at(5)->GetWitnessHash()));
 
         // Transactions are marked non-reconsiderable again when returned through GetTxToReconsider
-        BOOST_CHECK_EQUAL(orphanage->GetTxToReconsider(peer), children.at(0));
+        BOOST_CHECK(SameTx(orphanage->GetTxToReconsider(peer), children.at(0)));
         orphanage->AddTx(children.at(6), peer);
         BOOST_CHECK(!orphanage->HaveTx(children.at(0)->GetWitnessHash()));
         BOOST_CHECK(orphanage->HaveTx(children.at(3)->GetWitnessHash()));
@@ -223,8 +230,8 @@ BOOST_AUTO_TEST_CASE(peer_dos_limits)
 
         // The first transaction returned from GetTxToReconsider is the older one, not the one that was marked for
         // reconsideration earlier.
-        BOOST_CHECK_EQUAL(orphanage->GetTxToReconsider(peer), children.at(3));
-        BOOST_CHECK_EQUAL(orphanage->GetTxToReconsider(peer), children.at(4));
+        BOOST_CHECK(SameTx(orphanage->GetTxToReconsider(peer), children.at(3)));
+        BOOST_CHECK(SameTx(orphanage->GetTxToReconsider(peer), children.at(4)));
 
         orphanage->SanityCheck();
     }
@@ -553,7 +560,7 @@ BOOST_AUTO_TEST_CASE(same_txid_diff_witness)
     // EraseTx fails as transaction by this wtxid doesn't exist.
     BOOST_CHECK_EQUAL(orphanage->EraseTx(mutated_wtxid), 0);
     BOOST_CHECK(orphanage->HaveTx(normal_wtxid));
-    BOOST_CHECK(orphanage->GetTx(normal_wtxid) == child_normal);
+    BOOST_CHECK(SameTx(orphanage->GetTx(normal_wtxid), child_normal));
     BOOST_CHECK(!orphanage->HaveTx(mutated_wtxid));
     BOOST_CHECK(orphanage->GetTx(mutated_wtxid) == nullptr);
 

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -337,4 +337,66 @@ BOOST_FIXTURE_TEST_CASE(handle_missing_inputs, TestChain100Setup)
     }
 }
 
+/** Add n children of parent to the orphanage, all announced by peer, in creation order (oldest first). */
+static std::vector<CTransactionRef> AddChildrenFromPeer(node::TxDownloadManagerImpl& manager, const CTransactionRef& parent, NodeId peer, size_t n)
+{
+    std::vector<CTransactionRef> children;
+    for (size_t i{0}; i < n; ++i) {
+        CMutableTransaction child;
+        child.vin.emplace_back(parent->GetHash(), 0);
+        child.vin[0].scriptWitness.stack.push_back({1});
+        child.vout.emplace_back(CENT, CScript());
+        child.nLockTime = i;
+        children.push_back(MakeTransactionRef(child));
+        BOOST_REQUIRE(manager.m_orphanage->AddTx(children.back(), peer));
+    }
+    return children;
+}
+
+BOOST_FIXTURE_TEST_CASE(find_1p1c_selection_order, TestChain100Setup)
+{
+    CTxMemPool& pool{*Assert(m_node.mempool)};
+    node::TxDownloadOptions opts{.m_mempool = pool, .m_deterministic_txrequest = true};
+    node::TxDownloadManagerImpl manager{opts};
+    const auto parent{CreatePlaceholderTx(true)};
+    manager.RecentRejectsReconsiderableFilter().insert(parent->GetWitnessHash().ToUint256());
+    const auto children{AddChildrenFromPeer(manager, parent, /*peer=*/0, /*n=*/3)};
+
+    // The most recently announced child is selected first.
+    const auto selected{manager.Find1P1CPackage(parent, 0)};
+    BOOST_REQUIRE(selected);
+    BOOST_REQUIRE_EQUAL(selected->m_txns.size(), 2);
+    BOOST_CHECK(selected->m_txns.front()->GetWitnessHash() == parent->GetWitnessHash());
+    BOOST_CHECK(selected->m_txns.back()->GetWitnessHash() == children[2]->GetWitnessHash());
+
+    // Only children announced by the same peer are considered.
+    BOOST_CHECK(!manager.Find1P1CPackage(parent, 1));
+}
+
+BOOST_FIXTURE_TEST_CASE(find_1p1c_reject_filters, TestChain100Setup)
+{
+    CTxMemPool& pool{*Assert(m_node.mempool)};
+    node::TxDownloadOptions opts{.m_mempool = pool, .m_deterministic_txrequest = true};
+    node::TxDownloadManagerImpl manager{opts};
+    const auto parent{CreatePlaceholderTx(true)};
+    manager.RecentRejectsReconsiderableFilter().insert(parent->GetWitnessHash().ToUint256());
+    const auto children{AddChildrenFromPeer(manager, parent, /*peer=*/0, /*n=*/3)};
+
+    // A child whose package with this parent was already rejected is skipped in favor of the next one.
+    manager.MempoolRejectedPackage({parent, children[2]});
+    auto selected{manager.Find1P1CPackage(parent, 0)};
+    BOOST_REQUIRE(selected);
+    BOOST_CHECK(selected->m_txns.back()->GetWitnessHash() == children[1]->GetWitnessHash());
+
+    // A child whose txid was rejected is skipped as well.
+    manager.RecentRejectsFilter().insert(children[1]->GetHash().ToUint256());
+    selected = manager.Find1P1CPackage(parent, 0);
+    BOOST_REQUIRE(selected);
+    BOOST_CHECK(selected->m_txns.back()->GetWitnessHash() == children[0]->GetWitnessHash());
+
+    // Nothing is returned once every child is rejected.
+    manager.MempoolRejectedPackage({parent, children[0]});
+    BOOST_CHECK(!manager.Find1P1CPackage(parent, 0));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -129,6 +129,13 @@ BOOST_AUTO_TEST_CASE(package_hash_tests)
     BOOST_CHECK_EQUAL(calculated_hash_123, GetPackageHash(package_213));
     BOOST_CHECK_EQUAL(calculated_hash_123, GetPackageHash(package_312));
     BOOST_CHECK_EQUAL(calculated_hash_123, GetPackageHash(package_321));
+
+    // Metadata-only selection must use exactly the same rejection-cache keys.
+    BOOST_CHECK_EQUAL(calculated_hash_123, GetPackageHashFromWtxids({wtxid_1, wtxid_2, wtxid_3}));
+    BOOST_CHECK_EQUAL(calculated_hash_123, GetPackageHashFromWtxids({wtxid_3, wtxid_1, wtxid_2}));
+    BOOST_CHECK_EQUAL(GetPackageHash({ptx_1, ptx_2}), GetPackageHashFromWtxids({wtxid_2, wtxid_1}));
+    BOOST_CHECK_EQUAL(GetPackageHash({ptx_1, ptx_1}), GetPackageHashFromWtxids({wtxid_1, wtxid_1}));
+    BOOST_CHECK_EQUAL(GetPackageHash({}), GetPackageHashFromWtxids({}));
 }
 
 BOOST_AUTO_TEST_CASE(package_sanitization_tests)


### PR DESCRIPTION
The orphanage limits the "usage" of the orphans it stores, per peer and globally, to bound the amount of memory an attacker can make us hold on to. It uses weight as a proxy for that memory, on the assumption that weight is "often higher than the actual memory usage of the transaction".

That assumption does not hold for a deserialized transaction. Every witness stack element is an individually heap-allocated vector, costing its 24-byte slot in the stack vector plus a 32-byte minimum allocation, while only weighing 2WU. A transaction of 199,000 1-byte witness elements weighs 398,247WU (i.e. it is of standard weight, and witness standardness cannot be checked while the inputs are missing), but uses 11.1MB of memory: 28 times what is accounted for it, and one such orphan can be retained per peer.

Rather than change the accounting metric, keep orphans in serialized form, deserializing them again on the paths that hand them back out. Serialized, a transaction's memory usage is bounded by its weight, so the existing weight-based accounting becomes a true upper bound on memory and the worst case is the peers' combined allowances.

Admission, eviction and accounting behavior are unchanged: no transaction that was previously accepted is refused, so orphan resolution (and thus 1p1c package relay) keeps working for standard-weight transactions whose witnesses consist of many small elements, such as BitVM-style transactions.