### PR TITLE
bench: Construct CTxOut and COutPoint in a single expression

### DIFF
--- a/src/bench/blockencodings.cpp
+++ b/src/bench/blockencodings.cpp
@@ -88,9 +88,7 @@ static void BlockEncodingBench(benchmark::Bench& bench, size_t n_pool, size_t n_
         tx.vin.resize(1);
         tx.vin[0].scriptSig = CScript() << sigspam;
         tx.vin[0].scriptWitness.stack.push_back({1});
-        tx.vout.resize(1);
-        tx.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
-        tx.vout[0].nValue = i;
+        tx.vout = {CTxOut{CAmount(i), CScript() << OP_1 << OP_EQUAL}};
         refs.push_back(MakeTransactionRef(tx));
     }
 

--- a/src/bench/mempool_ephemeral_spends.cpp
+++ b/src/bench/mempool_ephemeral_spends.cpp
@@ -50,9 +50,8 @@ static void MempoolCheckEphemeralSpends(benchmark::Bench& bench)
     tx1.vin.resize(1);
     tx1.vout.resize(number_outputs);
     for (size_t i = 0; i < tx1.vout.size(); i++) {
-        tx1.vout[i].scriptPubKey = CScript();
         // Each output progressively larger
-        tx1.vout[i].nValue = i * CENT;
+        tx1.vout[i] = CTxOut{CAmount(i) * CENT, CScript()};
     }
 
     const auto& parent_txid = tx1.GetHash();
@@ -60,9 +59,8 @@ static void MempoolCheckEphemeralSpends(benchmark::Bench& bench)
     // Spends all outputs of tx1, other details don't matter
     CMutableTransaction tx2;
     tx2.vin.resize(tx1.vout.size());
-    for (size_t i = 0; i < tx2.vin.size(); i++) {
-        tx2.vin[i].prevout.hash = parent_txid;
-        tx2.vin[i].prevout.n = i;
+    for (uint32_t i{0}; i < tx2.vin.size(); ++i) {
+        tx2.vin[i].prevout = COutPoint{parent_txid, i};
     }
     tx2.vout.resize(1);
 


### PR DESCRIPTION
Replaces field-by-field mutation of `CTxOut` and `COutPoint` in two bench files with brace initialisation, which requires the `size_t` conversions to be made explicit. 

Noticed while looking at #35994, where switching the proposed fix-it to `{}` surfaces implicit narrowing conversions like these.

The constructed values are unchanged.

*Note: Only the sites where a conversion is involved are included in this PR; the remaining field-by-field construction in `bench/` would be covered by #35994's follow-ups.*