### PR TITLE
doc: Correct after HTTPRequest::m_client changed to weak_ptr

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1084,8 +1084,9 @@ void HTTPServer::DisconnectClients()
                                         // First check for idle timeout. We reset the timer when we send and receive data,
                                         // but if the server is busy handling a request we should ignore the timeout until
                                         // the reply is sent. If we did erase the shared_ptr<HTTPRemoteClient> reference in m_connected
-                                        // while the server is busy with a request, there would still be a reference in a worker
-                                        // thread keeping the socket open even after "disconnecting".
+                                        // while the server is busy with a request, it might be prematurely dropped before
+                                        // the response has been sent, or if the HTTPRequest was holding a temporary shared_ptr
+                                        // client on a worker thread - it would keep the socket open even after "disconnecting".
                                         const bool is_idle{m_rpcservertimeout.count() > 0 &&
                                                            now - client->m_idle_since.load() > m_rpcservertimeout &&
                                                            !client->m_req_busy};

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -331,7 +331,7 @@ private:
     /**
      * List of HTTPRemoteClients with connected sockets.
      * Connections will only be added and removed in the I/O thread, but
-     * shared pointers may be passed to worker threads to handle requests
+     * weak pointers may be passed to worker threads to handle requests
      * and send replies.
      */
     std::vector<std::shared_ptr<HTTPRemoteClient>> m_connected;
@@ -477,7 +477,7 @@ private:
      * Close underlying socket connections for flagged clients
      * by removing their shared pointer from m_connected. If an HTTPRemoteClient
      * is busy in a worker thread, its connection will be closed once that
-     * job is done and the HTTPRequest is out of scope.
+     * job is done.
      */
     void DisconnectClients();
 };


### PR DESCRIPTION
There were lingering comments from when `HTTPRequest::m_client` was a `shared_ptr`.
Prompted by https://github.com/bitcoin/bitcoin/pull/36007#issuecomment-5329937262.

Follow-up to #36007.