### PR TITLE
build: Always define HAVE_SYSTEM

### DIFF
--- a/cmake/bitcoin-build-config.h.in
+++ b/cmake/bitcoin-build-config.h.in
@@ -89,7 +89,7 @@
 #cmakedefine HAVE_SYSCTL_ARND 1
 
 /* Define to 1 if std::system is available. */
-#cmakedefine HAVE_SYSTEM 1
+#cmakedefine01 HAVE_SYSTEM
 
 /* Define to the address where bug reports for this package should be sent. */
 #define CLIENT_BUGREPORT "@CLIENT_BUGREPORT@"


### PR DESCRIPTION
When this feature is unavailable, `#cmakedefine` leaves its macro undefined, triggering `-Wundef`. I noticed this while building the kernel for iOs.

Use `#cmakedefine01` to always generate 0 or 1.