### PR TITLE
ci: Make `test_bitcoin-qt.exe` output visible

### DIFF
--- a/.github/ci-windows-cross.py
+++ b/.github/ci-windows-cross.py
@@ -150,6 +150,7 @@ def run_functional_tests():
 def run_unit_tests():
     workspace = Path.cwd()
     os.environ["DIR_UNIT_TEST_DATA"] = str(workspace / "unit_test_data")
+    os.environ["QT_ASSUME_STDERR_HAS_CONSOLE"] = "1"
     # Can't use ctest here like other jobs as we don't have a CMake build tree.
     commands = [
         ["./bin/test_bitcoin-qt.exe"],

--- a/.github/ci-windows.py
+++ b/.github/ci-windows.py
@@ -177,6 +177,7 @@ def run_tests(ci_type):
         for var, exe in test_envs.items():
             os.environ[var] = str(release_bin / exe)
 
+        os.environ["QT_ASSUME_STDERR_HAS_CONSOLE"] = "1"
         ctest_cmd = [
             "ctest",
             "--test-dir",


### PR DESCRIPTION
When run in the GHA environment, there is no console attached, so Qt's [`stderrHasConsoleAttached()`](https://github.com/qt/qtbase/blob/5d8cae8a76ee5293ea885bd8fd8b2604819edfe3/src/corelib/global/qlogging.cpp#L296) returns false and the entire test report is lost. Set `QT_ASSUME_STDERR_HAS_CONSOLE=1` to override the detection, as documented in Qt's [`qlogging.cpp`](https://github.com/qt/qtbase/blob/5d8cae8a76ee5293ea885bd8fd8b2604819edfe3/src/corelib/global/qlogging.cpp#L302-L303):
```c++
        if (qEnvironmentVariableIntValue("QT_ASSUME_STDERR_HAS_CONSOLE"))
            return true;
```