### PR TITLE
util: move function calls outside standard assertions

### DIFF
--- a/src/bench/connectblock.cpp
+++ b/src/bench/connectblock.cpp
@@ -112,7 +112,7 @@ void BenchmarkConnectBlock(benchmark::Bench& bench, std::vector<CKey>& keys, std
         auto* pindex{chainman->m_blockman.AddToBlockIndex(test_block, chainman->m_best_header)}; // Doing this here doesn't impact the benchmark
         CCoinsViewCache viewNew{&chainstate.CoinsTip()};
 
-        assert(chainstate.ConnectBlock(test_block, test_block_state, pindex, viewNew));
+        Assert(chainstate.ConnectBlock(test_block, test_block_state, pindex, viewNew));
     });
 }
 

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -71,7 +71,7 @@ static void DuplicateInputs(benchmark::Bench& bench)
 
     bench.run([&] {
         BlockValidationState cvstate{};
-        assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), false, false));
+        Assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), false, false));
         assert(cvstate.GetRejectReason() == "bad-txns-inputs-duplicate");
     });
 }

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -46,7 +46,7 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
     bench.minEpochIterations(5).run([&] {
         BlockFilterIndex filter_index(interfaces::MakeChain(test_setup->m_node), BlockFilterType::BASIC,
                                       /*n_cache_size=*/0, /*f_memory=*/false, /*f_wipe=*/true);
-        assert(filter_index.Init());
+        Assert(filter_index.Init());
         assert(!filter_index.BlockUntilSyncedToCurrentChain());
         filter_index.Sync();
 

--- a/src/bench/streams_findbyte.cpp
+++ b/src/bench/streams_findbyte.cpp
@@ -27,7 +27,7 @@ static void FindByte(benchmark::Bench& bench)
     bench.setup([&] { bf.SetPos(0); })
         .run([&] { bf.FindByte(std::byte(1)); });
 
-    assert(file.fclose() == 0);
+    Assert(file.fclose() == 0);
 }
 
 BENCHMARK(FindByte);

--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -86,7 +86,7 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
         total_weight_to_add += GetTransactionWeight(*tx);
         if (total_weight_to_add > orphanage->MaxGlobalUsage()) break;
 
-        assert(orphanage->AddTx(tx, peer));
+        Assert(orphanage->AddTx(tx, peer));
 
         // Sanity check: we should always be exiting at the point of hitting the weight limit.
         assert(txindex < NUM_TINY_TRANSACTIONS - 1);
@@ -101,7 +101,7 @@ static void OrphanageSinglePeerEviction(benchmark::Bench& bench)
     bench.epochs(1).epochIterations(1).run([&]() NO_THREAD_SAFETY_ANALYSIS {
         // Lastly, add the large transaction.
         const auto num_announcements_before_trim{orphanage->CountAnnouncements()};
-        assert(orphanage->AddTx(large_tx, peer));
+        Assert(orphanage->AddTx(large_tx, peer));
 
         // If there are multiple peers, note that they all have the same DoS score. We will evict only 1 item at a time for each new DoSiest peer.
         const auto num_announcements_after_trim{orphanage->CountAnnouncements()};
@@ -181,7 +181,7 @@ static void OrphanageMultiPeerEviction(benchmark::Bench& bench)
     bench.epochs(1).epochIterations(1).run([&]() NO_THREAD_SAFETY_ANALYSIS {
         const auto num_announcements_before_trim{orphanage->CountAnnouncements()};
         // There is a small gap between the total usage and the max usage. Add a transaction to fill it.
-        assert(orphanage->AddTx(last_tx, 0));
+        Assert(orphanage->AddTx(last_tx, 0));
 
         // If there are multiple peers, note that they all have the same DoS score. We will evict only 1 item at a time for each new DoSiest peer.
         const auto num_evicted{num_announcements_before_trim - orphanage->CountAnnouncements() + 1};
@@ -226,7 +226,7 @@ static void OrphanageEraseAll(benchmark::Bench& bench, bool block_or_disconnect)
 
             assert(GetTransactionWeight(*ptx) <= MAX_STANDARD_TX_WEIGHT);
             assert(!orphanage->HaveTx(ptx->GetWitnessHash()));
-            assert(orphanage->AddTx(ptx, peer));
+            Assert(orphanage->AddTx(ptx, peer));
 
             weight_left_for_peer -= GetTransactionWeight(*ptx);
             if (weight_left_for_peer < TINY_TX_WEIGHT * 2) break;

--- a/src/bench/wallet_migration.cpp
+++ b/src/bench/wallet_migration.cpp
@@ -71,8 +71,8 @@ static void WalletMigration(benchmark::Bench& bench)
             // Add watch-only addresses
             for (size_t w = 0; w < scripts_watch_only.size(); ++w) {
                 const auto& [script, dest] = scripts_watch_only.at(w);
-                assert(legacy_spkm->LoadWatchOnly(script));
-                assert(wallet->SetAddressBook(dest, strprintf("watch_%d", w), /*purpose=*/std::nullopt));
+                Assert(legacy_spkm->LoadWatchOnly(script));
+                Assert(wallet->SetAddressBook(dest, strprintf("watch_%d", w), /*purpose=*/std::nullopt));
                 batch.WriteWatchOnly(script, CKeyMetadata());
             }
 

--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -16,6 +16,7 @@
 #include <ipc/test/fuzz/ipc_fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 
 #include <future>
 #include <memory>
@@ -100,35 +101,35 @@ FUZZ_TARGET(ipc, .init = initialize_ipc)
                 static constexpr int MAX_ADD{1'000'000};
                 const int a = fuzzed_data_provider.ConsumeIntegralInRange<int>(MIN_ADD, MAX_ADD);
                 const int b = fuzzed_data_provider.ConsumeIntegralInRange<int>(MIN_ADD, MAX_ADD);
-                assert(ipc.m_client->add(a, b) == a + b);
+                Assert(ipc.m_client->add(a, b) == a + b);
             },
             [&] {
                 COutPoint outpoint{Txid::FromUint256(ConsumeUInt256(fuzzed_data_provider)),
                                    fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
                 COutPoint expected{outpoint.hash, outpoint.n ^ 0xFFFFFFFFu};
-                assert(ipc.m_client->passOutPoint(outpoint) == expected);
+                Assert(ipc.m_client->passOutPoint(outpoint) == expected);
             },
             [&] {
                 std::vector<uint8_t> value = ConsumeRandomLengthByteVector<uint8_t>(fuzzed_data_provider, 512);
                 std::vector<uint8_t> expected{value.rbegin(), value.rend()};
-                assert(ipc.m_client->passVectorUint8(value) == expected);
+                Assert(ipc.m_client->passVectorUint8(value) == expected);
             },
             [&] {
                 CScript script{ConsumeScript(fuzzed_data_provider)};
                 CScript expected{script};
                 expected << OP_NOP;
-                assert(ipc.m_client->passScript(script) == expected);
+                Assert(ipc.m_client->passScript(script) == expected);
             },
             [&] {
                 UniValue value;
                 if (!value.read(fuzzed_data_provider.ConsumeRandomLengthString(512))) return;
-                assert(ipc.m_client->passUniValue(value).write() == value.write());
+                Assert(ipc.m_client->passUniValue(value).write() == value.write());
             },
             [&] {
                 const CMutableTransaction mutable_tx = ConsumeTransaction(fuzzed_data_provider, std::nullopt);
                 if (mutable_tx.vin.empty()) return;
                 const CTransactionRef tx = MakeTransactionRef(mutable_tx);
-                assert(*ipc.m_client->passTransaction(tx) == *tx);
+                Assert(*ipc.m_client->passTransaction(tx) == *tx);
             });
     }
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -429,10 +429,12 @@ KeyPair::KeyPair(const CKey& key, const uint256* merkle_root)
     if (success && merkle_root) {
         secp256k1_xonly_pubkey pubkey;
         unsigned char pubkey_bytes[32];
-        assert(secp256k1_keypair_xonly_pub(secp256k1_context_static, &pubkey, nullptr, keypair));
-        assert(secp256k1_xonly_pubkey_serialize(secp256k1_context_static, pubkey_bytes, &pubkey));
-        uint256 tweak = XOnlyPubKey(pubkey_bytes).ComputeTapTweakHash(merkle_root->IsNull() ? nullptr : merkle_root);
-        success = secp256k1_keypair_xonly_tweak_add(secp256k1_context_static, keypair, tweak.data());
+        success = secp256k1_keypair_xonly_pub(secp256k1_context_static, &pubkey, nullptr, keypair) &&
+                  secp256k1_xonly_pubkey_serialize(secp256k1_context_static, pubkey_bytes, &pubkey);
+        if (success) {
+            uint256 tweak = XOnlyPubKey(pubkey_bytes).ComputeTapTweakHash(merkle_root->IsNull() ? nullptr : merkle_root);
+            success = secp256k1_keypair_xonly_tweak_add(secp256k1_context_static, keypair, tweak.data());
+        }
     }
     if (!success) ClearKeyPairData();
 }

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -11,6 +11,7 @@
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/readwritefile.h>
 
@@ -51,7 +52,7 @@ FUZZ_TARGET(banman, .init = initialize_banman)
     const bool start_with_corrupted_banlist{fuzzed_data_provider.ConsumeBool()};
     bool force_read_and_write_to_err{false};
     if (start_with_corrupted_banlist) {
-        assert(WriteBinaryFile(banlist_file + ".json",
+        Assert(WriteBinaryFile(banlist_file + ".json",
                                fuzzed_data_provider.ConsumeRandomLengthString()));
     } else {
         force_read_and_write_to_err = fuzzed_data_provider.ConsumeBool();

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -11,6 +11,7 @@
 #include <test/util/setup_common.h>
 #include <txdb.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 #include <validation.h>
 
 using kernel::CBlockFileInfo;
@@ -98,13 +99,13 @@ FUZZ_TARGET(block_index, .init = init_block_index)
     // what we stored above.
     CBlockFileInfo info;
     for (const auto& [n, file_info]: files_info) {
-        assert(block_index.ReadBlockFileInfo(n, info));
+        Assert(block_index.ReadBlockFileInfo(n, info));
         assert(info == *file_info);
     }
 
     // We should be able to read the last block file number. Its value should be consistent.
     int last_block_file;
-    assert(block_index.ReadLastBlockFile(last_block_file));
+    Assert(block_index.ReadLastBlockFile(last_block_file));
     assert(last_block_file == files_count - 1);
 
     // We should be able to flip and read the reindexing flag.

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -16,6 +16,7 @@
 #include <test/fuzz/util/threadinterrupt.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <util/translation.h>
 
 #include <cstdint>
@@ -148,7 +149,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                     assert(added_node_info.size() < connman.GetAddedNodeInfo(/*include_connected=*/true).size());
                     const auto remove{fuzzed_data_provider.ConsumeBool()};
                     if (remove) {
-                        assert(connman.RemoveAddedNode(node_str));
+                        Assert(connman.RemoveAddedNode(node_str));
                         assert(added_node_info.size() == connman.GetAddedNodeInfo(/*include_connected=*/true).size());
                     }
                 }

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -151,16 +151,16 @@ void VerifyIterator(CDBWrapper& dbw, const Oracle& oracle,
     }
     for (; it->Valid(); it->Next()) {
         uint16_t db_key;
-        assert(it->GetKey(db_key));
+        Assert(it->GetKey(db_key));
         if (oracle_it != oracle.end() && db_key == oracle_it->first) {
             std::vector<uint8_t> db_value;
-            assert(it->GetValue(db_value));
+            Assert(it->GetValue(db_value));
             assert(db_value == MakeValue(db_key, oracle_it->second));
             ++oracle_it;
         } else {
             assert(obfuscate);
             std::string key_str;
-            assert(it->GetKey(key_str));
+            Assert(it->GetKey(key_str));
             assert(key_str == OBFUSCATION_KEY);
         }
     }
@@ -428,7 +428,7 @@ FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLog
                 switch (op) {
                 case ReadOp::Read:
                     if (const auto oit{oracle.find(key)}; oit != oracle.end()) {
-                        assert(db.Read(key, v) && v == MakeValue(key, oit->second));
+                        Assert(db.Read(key, v) && v == MakeValue(key, oit->second));
                     } else {
                         assert(!db.Read(key, v));
                     }
@@ -444,8 +444,8 @@ FUZZ_TARGET(dbwrapper_concurrent_reads, .init = [] { static auto setup{MakeNoLog
                     if (const auto oit{oracle.lower_bound(key)}; oit != oracle.end()) {
                         assert(it->Valid());
                         uint16_t actual_key;
-                        assert(it->GetKey(actual_key) && actual_key == oit->first);
-                        assert(it->GetValue(v) && v == MakeValue(actual_key, oit->second));
+                        Assert(it->GetKey(actual_key) && actual_key == oit->first);
+                        Assert(it->GetValue(v) && v == MakeValue(actual_key, oit->second));
                     } else {
                         assert(!it->Valid());
                     }

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -17,6 +17,7 @@
 #include <test/util/time.h>
 #include <util/asmap.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <cstdint>
@@ -101,7 +102,7 @@ FUZZ_TARGET(local_address, .init = initialize_net)
                 if (!added) return;
                 assert(service.IsRoutable());
                 assert(IsLocal(service));
-                assert(SeenLocal(service));
+                Assert(SeenLocal(service));
             },
             [&] {
                 (void)RemoveLocal(service);

--- a/src/test/fuzz/parse_hd_keypath.cpp
+++ b/src/test/fuzz/parse_hd_keypath.cpp
@@ -6,6 +6,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/bip32.h>
+#include <util/check.h>
 
 #include <cassert>
 #include <cstdint>
@@ -24,7 +25,7 @@ FUZZ_TARGET(parse_hd_keypath)
     for (const bool apostrophe : {false, true}) {
         std::vector<uint32_t> roundtrip;
         const std::string written{WriteHDKeypath(random_keypath, apostrophe)};
-        assert(ParseHDKeypath(written, roundtrip));
+        Assert(ParseHDKeypath(written, roundtrip));
         assert(roundtrip == random_keypath);
     }
 }

--- a/src/test/fuzz/script_descriptor_cache.cpp
+++ b/src/test/fuzz/script_descriptor_cache.cpp
@@ -7,6 +7,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <optional>
@@ -27,12 +28,12 @@ FUZZ_TARGET(script_descriptor_cache)
             if (fuzzed_data_provider.ConsumeBool()) {
                 (void)descriptor_cache.GetCachedParentExtPubKey(key_exp_pos, xpub_fetched);
                 descriptor_cache.CacheParentExtPubKey(key_exp_pos, xpub);
-                assert(descriptor_cache.GetCachedParentExtPubKey(key_exp_pos, xpub_fetched));
+                Assert(descriptor_cache.GetCachedParentExtPubKey(key_exp_pos, xpub_fetched));
             } else {
                 const uint32_t der_index = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
                 (void)descriptor_cache.GetCachedDerivedExtPubKey(key_exp_pos, der_index, xpub_fetched);
                 descriptor_cache.CacheDerivedExtPubKey(key_exp_pos, der_index, xpub);
-                assert(descriptor_cache.GetCachedDerivedExtPubKey(key_exp_pos, der_index, xpub_fetched));
+                Assert(descriptor_cache.GetCachedDerivedExtPubKey(key_exp_pos, der_index, xpub_fetched));
             }
             assert(xpub == xpub_fetched);
         }

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -152,7 +152,7 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
             WriteCompactSize(outfile, 999); // index of coin
             outfile << Coin{coinbase->vout[0], /*nHeightIn=*/999, /*fCoinBaseIn=*/false};
         }
-        assert(outfile.fclose() == 0);
+        Assert(outfile.fclose() == 0);
     }
 
     const auto ActivateFuzzedSnapshot{[&] {

--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -135,7 +135,7 @@ FUZZ_TARGET(utxo_total_supply)
         current_block->vtx.front() = MakeTransactionRef(tx);
     }
     current_block->hashMerkleRoot = BlockMerkleRoot(*current_block);
-    assert(!MineBlock(node, current_block).IsNull());
+    Assert(!MineBlock(node, current_block).IsNull());
     circulation += GetBlockSubsidy(ActiveHeight(), Params().GetConsensus());
 
     assert(ActiveHeight() == 1);

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -15,6 +15,7 @@
 #include <serialize.h>
 #include <span.h>
 #include <sync.h>
+#include <util/check.h>
 
 #include <chrono>
 #include <optional>
@@ -58,7 +59,7 @@ void ConnmanTestMsg::Handshake(CNode& node,
     assert(node.nVersion == version);
     assert(node.GetCommonVersion() == std::min(version, node.AdvertisedVersion()));
     CNodeStateStats statestats;
-    assert(peerman.GetNodeStateStats(node.GetId(), statestats));
+    Assert(peerman.GetNodeStateStats(node.GetId(), statestats));
     assert(statestats.m_relay_txs == (relay_txs && !node.IsBlockOnlyConn()));
     assert(statestats.their_services == remote_services);
     if (successfully_connected) {
@@ -90,7 +91,7 @@ void ConnmanTestMsg::Reset()
 
 void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, std::span<const uint8_t> msg_bytes, bool& complete) const
 {
-    assert(node.ReceiveMsgBytes(msg_bytes, complete));
+    Assert(node.ReceiveMsgBytes(msg_bytes, complete));
     if (complete) {
         node.MarkReceivedMsgsForProcessing();
     }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -516,7 +516,7 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
     // - Default signature hashing type
     int nHashType = SIGHASH_ALL;
     std::map<int, bilingual_str> input_errors;
-    assert(SignTransaction(mempool_txn, &keystore, input_coins, {.sighash_type = nHashType}, input_errors));
+    Assert(SignTransaction(mempool_txn, &keystore, input_coins, {.sighash_type = nHashType}, input_errors));
     CAmount current_fee = inputs_amount - std::accumulate(outputs.begin(), outputs.end(), CAmount(0),
         [](const CAmount& acc, const CTxOut& out) {
         return acc + out.nValue;
@@ -533,7 +533,7 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
             mempool_txn.vout[fee_output.value()].nValue -= deduction;
             // Re-sign since an output has changed
             input_errors.clear();
-            assert(SignTransaction(mempool_txn, &keystore, input_coins, {.sighash_type = nHashType}, input_errors));
+            Assert(SignTransaction(mempool_txn, &keystore, input_coins, {.sighash_type = nHashType}, input_errors));
             current_fee = target_fee;
         }
     }

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -6,6 +6,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -36,7 +37,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
     {
         AutoFile outfile{fsbridge::fopen(wallet_path, "wb")};
         outfile << std::span{buffer};
-        assert(outfile.fclose() == 0);
+        Assert(outfile.fclose() == 0);
     }
 
     const DatabaseOptions options{};
@@ -51,7 +52,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
 
     auto db{MakeBerkeleyRODatabase(wallet_path, options, status, error)};
     if (db) {
-        assert(DumpWallet(g_setup->m_args, *db, error));
+        Assert(DumpWallet(g_setup->m_args, *db, error));
     } else {
         if (error.original.starts_with("AutoFile::ignore: end of file") ||
             error.original.starts_with("AutoFile::read: end of file") ||


### PR DESCRIPTION
**Problem:** `KeyPair::KeyPair()` performed two required `libsecp256k1` calls inside `assert()`.
Disabling assertions skips those calls, so the Taproot tweak is computed from uninitialized data.
Supported builds reject `NDEBUG`, so this affects only unsupported configurations, but it motivated a broader audit of calls inside standard assertions.

**Fix:** Evaluate the required key operations explicitly.
Audit the remaining call sites and use the always-evaluated `Assert()` helper only when a call initializes output used afterward, mutates state, performs I/O, or releases resources.
Leave pure predicates and calculations as standard assertions.


**Reproducer:** [Compiler Explorer](https://godbolt.org/z/rGPE1fYY7) demonstrates `assert(keypair_xonly_pub(&pubkey))` skipping the required key derivation under `-DNDEBUG`.