### PR TITLE
wallet: Remove mapMasterKeys and enforce that only one encryption key can exist

### DIFF
--- a/src/bench/wallet_encrypt.cpp
+++ b/src/bench/wallet_encrypt.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -78,9 +79,7 @@ static void WalletEncrypt(benchmark::Bench& bench, unsigned int key_count)
         .run([&] {
             wallet->EncryptWallet(secure_pass);
 
-            for (const auto& [_, key] : wallet->mapMasterKeys){
-                assert(key.nDeriveIterations == CMasterKey::DEFAULT_DERIVE_ITERATIONS);
-            }
+            assert(wallet->m_encryption_key->nDeriveIterations == CMasterKey::DEFAULT_DERIVE_ITERATIONS);
         });
     TestUnloadWallet(std::move(wallet));
 }

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -41,6 +41,8 @@ public:
     unsigned int nDeriveIterations;
     //! Use this for more parameters to key derivation (currently unused)
     std::vector<unsigned char> vchOtherDerivationParameters;
+    //! Id of this CMasterKey. Only used for writing the key of the database record. Retained for backwards compatibility, otherwise unused.
+    uint32_t m_id{1};
 
     //! Default/minimum number of key derivation rounds
     // 25000 rounds is just under 0.1 seconds on a 1.86 GHz Pentium M

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -629,16 +629,13 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
 
     {
         LOCK(cs_wallet);
-        for (const auto& [_, master_key] : mapMasterKeys)
-        {
-            if (!DecryptMasterKey(strWalletPassphrase, master_key, plain_master_key)) {
-                continue; // try another master key
-            }
-            if (Unlock(plain_master_key)) {
-                // Now that we've unlocked, upgrade the descriptor cache
-                UpgradeDescriptorCache();
-                return true;
-            }
+        if (!DecryptMasterKey(strWalletPassphrase, *m_encryption_key, plain_master_key)) {
+            return false;
+        }
+        if (Unlock(plain_master_key)) {
+            // Now that we've unlocked, upgrade the descriptor cache
+            UpgradeDescriptorCache();
+            return true;
         }
     }
     return false;
@@ -653,23 +650,20 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
         Lock();
 
         CKeyingMaterial plain_master_key;
-        for (auto& [master_key_id, master_key] : mapMasterKeys)
+        if (!DecryptMasterKey(strOldWalletPassphrase, *m_encryption_key, plain_master_key)) {
+            return false;
+        }
+        if (Unlock(plain_master_key))
         {
-            if (!DecryptMasterKey(strOldWalletPassphrase, master_key, plain_master_key)) {
+            if (!EncryptMasterKey(strNewWalletPassphrase, plain_master_key, *m_encryption_key)) {
                 return false;
             }
-            if (Unlock(plain_master_key))
-            {
-                if (!EncryptMasterKey(strNewWalletPassphrase, plain_master_key, master_key)) {
-                    return false;
-                }
-                WalletLogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
+            WalletLogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", m_encryption_key->nDeriveIterations);
 
-                WalletBatch(GetDatabase()).WriteMasterKey(master_key);
-                if (fWasLocked)
-                    Lock();
-                return true;
-            }
+            WalletBatch(GetDatabase()).WriteMasterKey(*m_encryption_key);
+            if (fWasLocked)
+                Lock();
+            return true;
         }
     }
 
@@ -865,7 +859,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 
     {
         LOCK2(m_relock_mutex, cs_wallet);
-        mapMasterKeys[++nMasterKeyMaxID] = master_key;
+        m_encryption_key = master_key;
         WalletBatch* encrypted_batch = new WalletBatch(GetDatabase());
         if (!encrypted_batch->TxnBegin()) {
             delete encrypted_batch;
@@ -3576,7 +3570,7 @@ bool CWallet::WithEncryptionKey(std::function<bool (const CKeyingMaterial&)> cb)
 
 bool CWallet::HasEncryptionKeys() const
 {
-    return !mapMasterKeys.empty();
+    return m_encryption_key.has_value();
 }
 
 bool CWallet::HaveCryptedKeys() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -665,7 +665,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
                 }
                 WalletLogPrintf("Wallet passphrase changed to an nDeriveIterations of %i\n", master_key.nDeriveIterations);
 
-                WalletBatch(GetDatabase()).WriteMasterKey(master_key_id, master_key);
+                WalletBatch(GetDatabase()).WriteMasterKey(master_key);
                 if (fWasLocked)
                     Lock();
                 return true;
@@ -872,7 +872,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
             encrypted_batch = nullptr;
             return false;
         }
-        encrypted_batch->WriteMasterKey(nMasterKeyMaxID, master_key);
+        encrypted_batch->WriteMasterKey(master_key);
 
         for (const auto& spk_man_pair : m_spk_managers) {
             auto spk_man = spk_man_pair.second.get();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -468,9 +468,7 @@ public:
      */
     const std::string& GetName() const { return m_name; }
 
-    typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
-    MasterKeyMap mapMasterKeys;
-    unsigned int nMasterKeyMaxID = 0;
+    std::optional<CMasterKey> m_encryption_key;
 
     /** Construct wallet with specified name and database implementation. */
     CWallet(interfaces::Chain* chain, const std::string& name, std::unique_ptr<WalletDatabase> database)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -401,20 +401,18 @@ bool LoadEncryptionKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue,
     LOCK(pwallet->cs_wallet);
     try {
         // Master encryption key is loaded into only the wallet and not any of the ScriptPubKeyMans.
-        unsigned int nID;
+        uint32_t nID;
         ssKey >> nID;
         CMasterKey kMasterKey;
         ssValue >> kMasterKey;
         kMasterKey.m_id = nID;
-        if(pwallet->mapMasterKeys.contains(nID))
-        {
-            strErr = strprintf("Error reading wallet database: duplicate CMasterKey id %u", nID);
+
+        if (pwallet->m_encryption_key.has_value()) {
+            strErr = strprintf("Error reading wallet database: more than one encryption key");
             return false;
         }
-        pwallet->mapMasterKeys[nID] = kMasterKey;
-        if (pwallet->nMasterKeyMaxID < nID)
-            pwallet->nMasterKeyMaxID = nID;
 
+        pwallet->m_encryption_key = kMasterKey;
     } catch (const std::exception& e) {
         if (strErr.empty()) {
             strErr = e.what();
@@ -1214,13 +1212,11 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     // Removing the mkey records is only safe if there are no *ckey records.
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && pwallet->HasEncryptionKeys() && !pwallet->HaveCryptedKeys()) {
         pwallet->WalletLogPrintf("Detected extraneous encryption keys in this wallet without private keys. Removing extraneous encryption keys.\n");
-        for (const auto& [id, _] : pwallet->mapMasterKeys) {
-            if (!EraseMasterKey(id)) {
-                pwallet->WalletLogPrintf("Error: Unable to remove extraneous encryption key '%u'. Wallet corrupt.\n", id);
-                return DBErrors::CORRUPT;
-            }
+        if (!EraseMasterKey(pwallet->m_encryption_key->m_id)) {
+            pwallet->WalletLogPrintf("Error: Unable to remove extraneous encryption key. Wallet corrupt.\n");
+            return DBErrors::CORRUPT;
         }
-        pwallet->mapMasterKeys.clear();
+        pwallet->m_encryption_key.reset();
     }
 
     return result;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -161,9 +161,9 @@ bool WalletBatch::WriteCryptedKey(const CPubKey& vchPubKey,
     return true;
 }
 
-bool WalletBatch::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
+bool WalletBatch::WriteMasterKey(const CMasterKey& kMasterKey)
 {
-    return WriteIC(std::make_pair(DBKeys::MASTER_KEY, nID), kMasterKey, true);
+    return WriteIC(std::make_pair(DBKeys::MASTER_KEY, kMasterKey.m_id), kMasterKey, true);
 }
 
 bool WalletBatch::EraseMasterKey(unsigned int id)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -405,6 +405,7 @@ bool LoadEncryptionKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue,
         ssKey >> nID;
         CMasterKey kMasterKey;
         ssValue >> kMasterKey;
+        kMasterKey.m_id = nID;
         if(pwallet->mapMasterKeys.contains(nID))
         {
             strErr = strprintf("Error reading wallet database: duplicate CMasterKey id %u", nID);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -237,7 +237,7 @@ public:
     bool WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, bool overwrite);
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
-    bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
+    bool WriteMasterKey(const CMasterKey& kMasterKey);
     bool EraseMasterKey(unsigned int id);
 
     bool WriteWatchOnly(const CScript &script, const CKeyMetadata &keymeta);


### PR DESCRIPTION
`mapMasterKeys` was introduced in #352 without a clear rationale. Likely it was to allow the user to have multiple passphrases by encrypting the wallet's encryption key with different passphrases. However, this functionality was never implemented, and current code enforces in a few places (inconsistently) that there is only one encryption key.

By removing `mapMasterKeys` and replacing it with a single `m_encryption_key`, we can remove this confusion and simplify encryption key handling. No one should have a wallet that has more than one encryption key, and the ID of that key should be `1`.

The format of the database record remains unchanged. If a wallet somehow has an encryption key with an ID other than `1`, the record will stay the same and the `id` is stored. Otherwise, new encryption keys always have an ID of `1`.

If a wallet has more than one encryption key, this becomes a corruption error because it should never happen outside of someone doing something weird with their wallet.

***

I asked Matt for his rationale for adding `mapMasterKeys` and his response was

> I have no idea I barely knew how to code when I wrote that shit.