### PR TITLE
rpc: avoid quadratic output lookups

### DIFF
--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -105,19 +105,23 @@ std::vector<std::pair<CTxDestination, CAmount>> ParseOutputs(const UniValue& out
     std::set<CTxDestination> destinations;
     std::vector<std::pair<CTxDestination, CAmount>> parsed_outputs;
     bool has_data{false};
-    for (const std::string& name_ : outputs.getKeys()) {
+    const auto& keys{outputs.getKeys()};
+    const auto& values{outputs.getValues()};
+    for (size_t i{0}; i < keys.size(); ++i) {
+        const auto& name_{keys[i]};
+        const auto& value{values[i]};
         if (name_ == "data") {
             if (has_data) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, duplicate key: data");
             }
             has_data = true;
-            std::vector<unsigned char> data = ParseHexV(outputs[name_].getValStr(), "Data");
+            std::vector<unsigned char> data = ParseHexV(value.getValStr(), "Data");
             CTxDestination destination{CNoDestination{CScript() << OP_RETURN << data}};
             CAmount amount{0};
             parsed_outputs.emplace_back(destination, amount);
         } else {
             CTxDestination destination{DecodeDestination(name_)};
-            CAmount amount{AmountFromValue(outputs[name_])};
+            CAmount amount{AmountFromValue(value)};
             if (!IsValidDestination(destination)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Bitcoin address: ") + name_);
             }


### PR DESCRIPTION
**Problem:** Transaction-creation RPCs currently take quadratic time to parse outputs.
An authenticated RPC client can therefore tie up a worker with a large request.
`sendmany` also holds the wallet lock while parsing, delaying other operations on the same wallet.

**Fix:** Parse transaction outputs in linear time by reading corresponding keys and values by index instead of looking up each value by key.

**Reproducer:** Run `time build/bin/test_bitcoin --run_test=rpc_tests/parse_outputs` before and after the fix:
<details>
<summary>parse_outputs test in `rpc_tests.cpp`</summary>

```cpp
BOOST_AUTO_TEST_CASE(parse_outputs)
{
    constexpr size_t OUTPUT_COUNT{10'000};
    UniValue outputs{UniValue::VOBJ};
    for (size_t i{0}; i < OUTPUT_COUNT; ++i) {
        auto destination{EncodeDestination(WitnessV0ScriptHash{CScript{} << i})};
        outputs.pushKVEnd(destination, ValueFromAmount(i + 1));
    }

    const auto parsed_outputs{ParseOutputs(outputs)};
    BOOST_REQUIRE_EQUAL(parsed_outputs.size(), OUTPUT_COUNT);
    for (size_t i{OUTPUT_COUNT}; i > 0; --i) {
        std::pair expected{CTxDestination{WitnessV0ScriptHash{CScript{} << (i - 1)}}, static_cast<CAmount>(i)};
        BOOST_CHECK(parsed_outputs[i - 1] == expected);
    }
}
```
</details>
E.g. on my M4 Max with `debug` build:

```python
Before  ████████████████████  1.80 s
After   █████▒░░░░░░░░░░░░░░  0.50 s  -72%
```
Related to #35889
