### PR TITLE
Release: Prepare "Translation string freeze" step

### DIFF
--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -399,6 +399,10 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>All Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Amount: %1
 </source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
This PR follows our [Release Process](https://github.com/bitcoin/bitcoin/blob/4df077d7cd32c71646a85a2464a58c322a0cee11/doc/release-process.md).

It is required for the translation string freeze, as https://github.com/bitcoin-core/gui/pull/957 introduced a new translatable string after the soft translation string freeze.

Steps to reproduce the diff:
```console
cmake --preset dev-mode
cmake --build build_dev_mode --target translate
```