### PR TITLE
build: honor CMAKE_INSTALL_LIBEXECDIR in wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,6 +637,10 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
 endif()
 
+# CMAKE_INSTALL_LIBEXECDIR is substituted into test/config.ini and
+# bitcoin-build-config.h. test/ is added before src/.
+include(GNUInstallDirs)
+
 add_subdirectory(test)
 add_subdirectory(doc)
 

--- a/cmake/bitcoin-build-config.h.in
+++ b/cmake/bitcoin-build-config.h.in
@@ -100,6 +100,9 @@
 /* Define to the home page for this package. */
 #define CLIENT_URL "@PROJECT_HOMEPAGE_URL@"
 
+/* Define to the install directory used for internal executables. */
+#define BITCOIN_LIBEXECDIR "@CMAKE_INSTALL_LIBEXECDIR@"
+
 /* Define to the version of this package. */
 #define CLIENT_VERSION_STRING "@CLIENT_VERSION_STRING@"
 

--- a/src/bitcoin.cpp
+++ b/src/bitcoin.cpp
@@ -18,6 +18,8 @@
 #include <tinyformat.h>
 #include <vector>
 
+static_assert(BITCOIN_LIBEXECDIR[0] != '\0', "BITCOIN_LIBEXECDIR must not be empty");
+
 const TranslateFn G_TRANSLATION_FUN{nullptr};
 
 static constexpr auto HELP_USAGE = R"(Usage: %s [OPTIONS] COMMAND...
@@ -173,8 +175,8 @@ bool UseMultiprocess(const CommandLine& cmd)
 }
 
 //! Execute the specified bitcoind, bitcoin-qt or other command line in `args`
-//! using src, bin and libexec directory paths relative to this executable, where
-//! the path to this executable is specified in `wrapper_argv0`.
+//! using src, bin and the configured libexec directory paths relative to this
+//! executable, where the path to this executable is specified in `wrapper_argv0`.
 //!
 //! @param args Command line arguments to execute, where first argument should
 //!             be a relative path to a bitcoind, bitcoin-qt or other executable
@@ -226,9 +228,9 @@ static void ExecCommand(const std::vector<const char*>& args, std::string_view w
     // (https://github.com/bitcoin/bitcoin/pull/31375#discussion_r1861814807)
     const bool fallback_os_search{!fs::PathFromString(std::string{wrapper_argv0}).has_parent_path()};
 
-    // If wrapper is installed in a bin/ directory, look for target executable
-    // in libexec/
-    (wrapper_dir.filename() == "bin" && try_exec(wrapper_dir.parent_path() / "libexec" / arg0.filename())) ||
+    // If wrapper is installed in a bin/ directory, look for the target in
+    // CMAKE_INSTALL_LIBEXECDIR (defaults to libexec).
+    (wrapper_dir.filename() == "bin" && try_exec(wrapper_dir.parent_path() / BITCOIN_LIBEXECDIR / arg0.filename())) ||
 #ifdef WIN32
     // Otherwise check the "daemon" subdirectory in a windows install.
     (!wrapper_dir.empty() && try_exec(wrapper_dir / "daemon" / arg0.filename())) ||

--- a/test/config.ini.in
+++ b/test/config.ini.in
@@ -11,6 +11,7 @@ CLIENT_BUGREPORT=@CLIENT_BUGREPORT@
 SRCDIR=@abs_top_srcdir@
 BUILDDIR=@abs_top_builddir@
 EXEEXT=@EXEEXT@
+LIBEXECDIR=@CMAKE_INSTALL_LIBEXECDIR@
 RPCAUTH=@abs_top_srcdir@/share/rpcauth/rpcauth.py
 
 [components]

--- a/test/functional/tool_bitcoin.py
+++ b/test/functional/tool_bitcoin.py
@@ -12,8 +12,11 @@ from test_framework.util import (
     assert_equal,
 )
 
+import os
 import platform
 import re
+import shutil
+import subprocess
 
 
 class ToolBitcoinTest(BitcoinTestFramework):
@@ -85,6 +88,54 @@ class ToolBitcoinTest(BitcoinTestFramework):
             self.log.info("Ensure bitcoin recognizes -ipcbind in config file")
             append_config(node.datadir_path, ["ipcbind=unix"])
             self.test_args([], [], expect_exe="bitcoin-node")
+
+        self.test_installed_libexecdir()
+
+    def test_installed_libexecdir(self):
+        # Build-tree tests keep every binary next to the wrapper, so they never
+        # hit the installed prefix/bin -> prefix/<LIBEXECDIR> lookup.
+        libexecdir = self.config["environment"]["LIBEXECDIR"]
+        if os.path.isabs(libexecdir):
+            self.log.info("Skipping installed-layout check; CMAKE_INSTALL_LIBEXECDIR is absolute")
+            return
+
+        exeext = self.config["environment"]["EXEEXT"]
+        bitcoin_src = self.get_binaries().paths.bitcoin_bin
+        bitcoind_src = self.get_binaries().paths.bitcoind
+        prefix = self.nodes[0].datadir_path / "fake-prefix"
+
+        def make_layout(name, internal_subdir):
+            root = prefix / name
+            bindir = root / "bin"
+            internaldir = root / internal_subdir
+            bindir.mkdir(parents=True)
+            internaldir.mkdir(parents=True)
+            wrapper = bindir / f"bitcoin{exeext}"
+            shutil.copy2(bitcoin_src, wrapper)
+            shutil.copy2(bitcoind_src, internaldir / f"bitcoind{exeext}")
+            return wrapper
+
+        def run_wrapper(wrapper):
+            env = os.environ.copy()
+            env["PATH"] = ""  # invoked by path; don't let $PATH hide a miss
+            return subprocess.run(
+                [wrapper, "node", "-version"],
+                capture_output=True,
+                env=env,
+                timeout=60,
+            )
+
+        self.log.info("Ensure installed wrapper finds binaries in the configured libexec dir")
+        result = run_wrapper(make_layout("configured", libexecdir))
+        assert_equal(result.returncode, 0)
+        assert_equal(get_exe_name(result.stdout), b"bitcoind")
+        assert_equal(result.stderr, b"")
+
+        other = "lib" if libexecdir != "lib" else "libexec"
+        self.log.info(f"Ensure installed wrapper does not look in an unconfigured {other} dir")
+        result = run_wrapper(make_layout("unconfigured", other))
+        if result.returncode == 0:
+            raise AssertionError(f"wrapper ran bitcoind from unconfigured {other}/: {result.stdout!r} {result.stderr!r}")
 
 
 def get_node_output(node):


### PR DESCRIPTION
Fixes #35785

Internal binaries are installed to CMAKE_INSTALL_LIBEXECDIR. That
defaults to libexec, but a distro can set it to something else
(Arch uses lib). The bitcoin wrapper always looked in ../libexec
under the install prefix, so those builds fail after cmake --install
for bitcoin-node, chainstate, and the other internal binaries.

The wrapper now uses the same CMake value.

tool_bitcoin.py copies the wrapper into a fake prefix/bin and
bitcoind only into prefix/<LIBEXECDIR>, then runs it by absolute
path. 

Putting the binary in a different directory should fail.
Normal functional tests miss this because every binary sits next
to the wrapper in the build tree.