### PR TITLE
psbt: classify missing Taproot script-path signatures as signer

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -280,9 +280,10 @@ static bool CreateSig(const BaseSignatureCreator& creator, SignatureData& sigdat
     return false;
 }
 
-static bool SignMuSig2(const BaseSignatureCreator& creator, SignatureData& sigdata, const SigningProvider& provider, std::vector<unsigned char>& sig_out, const XOnlyPubKey& script_pubkey, const uint256* merkle_root, const uint256* leaf_hash, SigVersion sigversion)
+static bool SignMuSig2(const BaseSignatureCreator& creator, SignatureData& sigdata, const SigningProvider& provider, std::vector<unsigned char>& sig_out, const XOnlyPubKey& script_pubkey, const uint256* merkle_root, const uint256* leaf_hash, SigVersion sigversion, bool* is_musig = nullptr)
 {
     Assert(sigversion == SigVersion::TAPROOT || sigversion == SigVersion::TAPSCRIPT);
+    if (is_musig) *is_musig = false;
 
     // Lookup derivation paths for the script pubkey
     KeyOriginInfo agg_info;
@@ -336,6 +337,8 @@ static bool SignMuSig2(const BaseSignatureCreator& creator, SignatureData& sigda
             if (!Assume(tweaked)) return false;
             plain_pub = tweaked->first.GetCPubKeys().at(tweaked->second ? 1 : 0);
         }
+
+        if (is_musig) *is_musig = true;
 
         // First try to aggregate
         if (creator.CreateMuSig2AggregateSig(part_pks, sig_out, agg_pub, plain_pub, leaf_hash, tweaks, sigversion, sigdata)) {
@@ -393,8 +396,14 @@ static bool CreateTaprootScriptSig(const BaseSignatureCreator& creator, Signatur
 
     if (creator.CreateSchnorrSig(provider, sig_out, pubkey, &leaf_hash, nullptr, sigversion)) {
         sigdata.taproot_script_sigs[lookup_key] = sig_out;
-    } else if (!SignMuSig2(creator, sigdata, provider, sig_out, pubkey, /*merkle_root=*/nullptr, &leaf_hash, sigversion)) {
-        return false;
+    } else {
+        bool is_musig{false};
+        if (!SignMuSig2(creator, sigdata, provider, sig_out, pubkey, /*merkle_root=*/nullptr, &leaf_hash, sigversion, &is_musig)) {
+            return false;
+        }
+        if (!is_musig && !sigdata.taproot_script_sigs.contains(lookup_key)) {
+            sigdata.missing_sigs.push_back(pubkey.GetEvenCorrespondingCPubKey().GetID());
+        }
     }
 
     return sigdata.taproot_script_sigs.contains(lookup_key);

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -1342,6 +1342,12 @@ class PSBTTest(BitcoinTestFramework):
         self.nodes[0].importdescriptors([{"desc": descsum_create("tr({})".format(privkey)), "timestamp":"now"}])
 
         psbt = watchonly.sendall([wallet.getnewaddress(), addr])["psbt"]
+
+        analysis = self.nodes[0].analyzepsbt(psbt)
+        assert_equal(analysis["next"], "signer")
+        for input_analysis in analysis["inputs"]:
+            assert_equal(input_analysis["next"], "signer")
+
         processed_psbt = self.nodes[0].walletprocesspsbt(psbt)
         txid = self.nodes[0].sendrawtransaction(processed_psbt["hex"])
         vout = find_vout_for_address(self.nodes[0], txid, addr)

--- a/test/functional/wallet_musig.py
+++ b/test/functional/wallet_musig.py
@@ -250,6 +250,11 @@ class WalletMuSigTest(BitcoinTestFramework):
                 assert_equal(utxo, wallet.listunspent()[0])
         psbt = wallets[0].walletcreatefundedpsbt(outputs=[{self.def_wallet.getnewaddress(): 5}], inputs=[utxo], change_type="bech32m", changePosition=1, locktime=self.nodes[0].getblockcount())["psbt"]
 
+        if comment == "tr(H, pk(musig(keys/*)))":
+            analysis = self.nodes[0].analyzepsbt(psbt)
+            assert_equal(analysis["next"], "updater")
+            assert_equal(analysis["inputs"][0]["next"], "updater")
+
         dec_psbt = self.nodes[0].decodepsbt(psbt)
         assert_equal(len(dec_psbt["inputs"]), 1)
         assert_equal(len(dec_psbt["inputs"][0]["musig2_participant_pubkeys"]), pattern.count("musig("))


### PR DESCRIPTION
This is my first Bitcoin Core PR.

I originally reported #36035 after running into this while experimenting with Taproot 2-of-3 multisig on Signet. After reporting it, I wanted to see whether I could actually trace the problem in the source code and try to fix it myself.

I used ChatGPT Pro as a tool to help me navigate the codebase, understand the PSBT analysis/signing flow, and test different hypotheses. I followed the changes myself, built Bitcoin Core locally, and ran the tests rather than just submitting generated code.

The issue appears to come from the Taproot script-path signing path not recording a missing signature in missing_sigs when a Schnorr signature is not available. AnalyzePSBT() uses missing_sigs to decide whether the next role should be signer. Without it, the PSBT was classified as updater, which is also why the GUI displayed “Transaction is missing some information about inputs.”

My first attempt at the fix did not work. The regression test still returned updater, which led me to notice that SignMuSig2() can return successfully without actually producing a Taproot script-path signature. I adjusted the change so that, after the Schnorr/MuSig2 attempts, a missing signature is recorded when no script-path signature was produced.

I also added a regression test that checks that this Taproot script-path case is classified as signer.

I tested the change locally with:

test/functional/rpc_psbt.py
test/functional/wallet_musig.py
test_bitcoin --run_test=psbt_tests
test_bitcoin --run_test=miniscript_tests
git diff --check

All of these passed with the current patch.

This appears to fix the behavior I reported in #36035. Since this is my first contribution, feedback on both the approach and the implementation is very welcome.

Fixes #36035