### PR TITLE
test: cover OP_SUCCESSx bypassing the initial stack element size limit

### DIFF
--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1206,6 +1206,7 @@ def spenders_taproot_active():
         add_spender(spenders, "opsuccess/bigpush", standard=False, tap=tap, leaf="bigpush_success", failure={"leaf": "bigpush_nop"}, **ERR_PUSH_SIZE)
         add_spender(spenders, "opsuccess/1001push", standard=False, tap=tap, leaf="1001push_success", failure={"leaf": "1001push_nop"}, **ERR_STACK_SIZE)
         add_spender(spenders, "opsuccess/1001inputs", standard=False, tap=tap, leaf="bare_success", inputs=[b'']*1001, failure={"leaf": "bare_nop"}, **ERR_STACK_SIZE)
+        add_spender(spenders, "opsuccess/bigstackelem", standard=False, tap=tap, leaf="bare_success", inputs=[random.randbytes(MAX_SCRIPT_ELEMENT_SIZE+1)], failure={"leaf": "bare_nop"}, **ERR_PUSH_SIZE)
 
     # Non-OP_SUCCESSx (verify that those aren't accidentally treated as OP_SUCCESSx)
     for opval in range(0, 0x100):


### PR DESCRIPTION
BIP-342 specifies that the initial stack resource checks happen after OP_SUCCESSx processing, and explicitly notes the checks "can be bypassed using OP_SUCCESSx". Core implements this correctly, but there are currently no tests covering this behavior. This means a consensus-breaking change to the ordering could pass the test suite undetected. Verified this on local commit https://github.com/ViniciusCestarii/bitcoin/commit/68d24d74301fe01ff612535878cb2ae864e8183f, which mutates to incorrectly implement the order and CI still turns green.

Add a new test at feature_taproot.py to cover OP_SUCCESSx bypassing the initial stack element size limit.

Verified that the new test catches the mutant: https://github.com/ViniciusCestarii/bitcoin/commit/f8f42a13a8142ac50ee24b33e814d4f4a48ee53d.