### PR TITLE
test: avoid undersized Boost.Test signal stacks

### DIFF
--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -7,6 +7,8 @@
 #include <util/byte_units.h>
 #include <util/fs.h>
 
+// Boost.Test's SIGSTKSZ alternate stack can be smaller than Linux requires on musl.
+#define BOOST_TEST_DISABLE_ALT_STACK
 #define BOOST_TEST_MODULE Bitcoin Kernel Test Suite
 #include <boost/test/included/unit_test.hpp>
 

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -5,6 +5,8 @@
 /**
  * See https://www.boost.org/doc/libs/1_78_0/libs/test/doc/html/boost_test/adv_scenarios/single_header_customizations/multiple_translation_units.html
  */
+// Boost.Test's SIGSTKSZ alternate stack can be smaller than Linux requires on musl.
+#define BOOST_TEST_DISABLE_ALT_STACK
 #define BOOST_TEST_MODULE Bitcoin Core Test Suite
 
 #include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
**Problem:** Boost.Test can fail while an Alpine CI test binary is starting, before any tests run.
The required signal stack size depends on the runner's CPU features, while musl provides a fixed size.

**Fix:** Use the [regular process stack](https://www.boost.org/doc/libs/latest/libs/test/doc/html/boost_test/utf_reference/link_references/config_disable_alt_stack.html) for Boost.Test signal handling in both unit-test binaries.

Fixes #36026
