### PR TITLE
fuzz: Use ImmediateBackgroundTaskRunner in process_messages

### DIFF
--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -34,7 +34,6 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/check.h>
-#include <util/task_runner.h>
 #include <util/time.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -48,7 +47,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -103,15 +101,6 @@ public:
     }
 };
 
-
-//! Used to run tasks in a std::thread to avoid DEBUG_LOCKORDER false positives.
-class ImmediateBackgroundTaskRunner : public util::TaskRunnerInterface
-{
-public:
-    void insert(std::function<void()> func) override { std::thread(std::move(func)).join(); }
-    void flush() override {}
-    size_t size() override { return 0; }
-};
 
 } // namespace
 

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -50,6 +50,8 @@ void initialize_process_messages()
             {}),
     };
     g_setup = testing_setup.get();
+    // Replace validation_signals before creating chainman and mempool so they use it.
+    g_setup->m_node.validation_signals = std::make_unique<ValidationSignals>(std::make_unique<ImmediateBackgroundTaskRunner>());
     ResetChainmanAndMempool(*g_setup, init_clock);
 }
 

--- a/src/test/util/validation.h
+++ b/src/test/util/validation.h
@@ -7,8 +7,12 @@
 
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
+#include <util/task_runner.h>
 #include <validation.h>
 
+#include <cstddef>
+#include <functional>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -18,6 +22,15 @@ class BlockManager;
 class CValidationInterface;
 class FakeNodeClock;
 struct TestingSetup;
+
+/// Runs callbacks synchronously and deterministically, while avoiding DEBUG_LOCKORDER false positives.
+class ImmediateBackgroundTaskRunner : public util::TaskRunnerInterface
+{
+public:
+    void insert(std::function<void()> func) override { std::thread(std::move(func)).join(); }
+    void flush() override {}
+    size_t size() override { return 0; }
+};
 
 struct TestBlockManager : public node::BlockManager {
     /** Test-only method to clear internal state for fuzzing */


### PR DESCRIPTION
The `process_messages` target may complain about false-positive debug lock-order issues:

```
echo 'Gv8uXPBdXV0QEP//dHVhxyoVKP////8A/0BrLmNrAEEAIP+MXHR0OQAAAAD+///txgIUADBgAAEC
fgAAAK0ArQEAAAD/AFwAQf9cdHf5XGhlYWRlcltbyzHIw8RcX2Jsb2NrAAAAAGNtcAAAADAftOvd
D0sFqXEx6US5VIknlsOJqZ5goMwtmwZBPdCxQZbatBsWPOR3FcUvSLLsKwcgKT8XdmjvDgskH5pK
iAUI/uVJTf//fyAAAAAAAQIAAAAAAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP//
//8DAskA/v///wIA+QKVAAAAAAFRAAAAAAAAAAAmaiSqIant4vYcP3HR3v0/qZnfo2lTdVxcaQaJ
eZlitIvr2DaXToz5ASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMgAAAD/XPB0eAD/
AgAAAAD9ABZqCwAAAAAEAAAAXPBhYVtbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tbW1tb
W1tb//9bW1tbW1tbW1sAAAAxNgAAADc5MzU5NDk2ODEwNzg3NAAAAAICAgL9a4jAhyQCAgICAQAA
AAAABSpvdGhlcir/8wICAgICAAAAeAL0AAAAAAAAaW52O///BAAAAAAAtbW1tWFbW2FhtbVhYWFh
YSkpW1tbW2QAJwAAAAAAAAAAMTYAAAA3OTM1OTQ5NjgxMDc4NzQAAAACAgIC/WuIwIckAgICAgEA
AAAAAAUAAAAAAv7///MAeAL0AAAAAAAAaW52Ow==' | base64 --decode > /tmp/fuzz.input

FUZZ=process_messages ./bld-cmake/bin/fuzz /tmp/fuzz.input --printtoconsole=1 | grep -A99 'POTENTIAL DEADLOCK DETECTED'
```

```
[test] [sync.cpp:108] [potential_deadlock_detected] [error] POTENTIAL DEADLOCK DETECTED
[test] [sync.cpp:109] [potential_deadlock_detected] [error] Previous lock order was:
[test] [sync.cpp:118] [potential_deadlock_detected] [error]  'NetEventsInterface::g_msgproc_mutex' in test/fuzz/process_messages.cpp:89 (in thread 'test')
[test] [sync.cpp:118] [potential_deadlock_detected] [error]  'm_chainstate_mutex' in validation.cpp:3351 (in thread 'test')
[test] [sync.cpp:118] [potential_deadlock_detected] [error]  'cs_main' in validation.cpp:3373 (in thread 'test') 
[test] [sync.cpp:118] [potential_deadlock_detected] [error]  (2) 'MempoolMutex()' in validation.cpp:3376 (in thread 'test')
[test] [sync.cpp:118] [potential_deadlock_detected] [error]  (1) 'm_tx_download_mutex' in net_processing.cpp:2216 (in thread 'test')
[test] [sync.cpp:122] [potential_deadlock_detected] [error] Current lock order is: 
[test] [sync.cpp:133] [potential_deadlock_detected] [error]  'NetEventsInterface::g_msgproc_mutex' in test/fuzz/process_messages.cpp:89 (in thread 'test')
[test] [sync.cpp:133] [potential_deadlock_detected] [error]  'cs_main' in net_processing.cpp:4725 (in thread 'test')
[test] [sync.cpp:133] [potential_deadlock_detected] [error]  (1) 'm_tx_download_mutex' in net_processing.cpp:4725 (in thread 'test')
[test] [sync.cpp:133] [potential_deadlock_detected] [error]  (2) 'cs' in txmempool.h:521 (in thread 'test')
```

Fix this by using the `ImmediateBackgroundTaskRunner` from `src/test/fuzz/cmpctblock.cpp`.