### PR TITLE
rpc: handle createNewBlock() returning nullptr during shutdown

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -197,7 +197,8 @@ static UniValue generateBlocks(ChainstateManager& chainman, Mining& miner, const
     UniValue blockHashes(UniValue::VARR);
     while (nGenerate > 0 && !chainman.m_interrupt) {
         std::unique_ptr<BlockTemplate> block_template(miner.createNewBlock({ .coinbase_output_script = coinbase_output_script }, /*cooldown=*/false));
-        CHECK_NONFATAL(block_template);
+        // createNewBlock() returns nullptr only when the node is shutting down
+        if (!block_template) break;
 
         std::shared_ptr<const CBlock> block_out;
         if (!GenerateBlock(chainman, block_template->getBlock(), nMaxTries, block_out, /*process_new_block=*/true)) {
@@ -409,7 +410,8 @@ static RPCMethod generateblock()
         LOCK(chainman.GetMutex());
         {
             std::unique_ptr<BlockTemplate> block_template{miner.createNewBlock({.use_mempool = false, .coinbase_output_script = coinbase_output_script}, /*cooldown=*/false)};
-            CHECK_NONFATAL(block_template);
+            // createNewBlock() returns nullptr only when the node is shutting down
+            if (!block_template) throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");
 
             block = block_template->getBlock();
         }
@@ -907,7 +909,8 @@ static RPCMethod getblocktemplate()
         // long-lived IPC usage, where the overhead is paid only when creating
         // the initial template.
         block_template = miner.createNewBlock({}, /*cooldown=*/false);
-        CHECK_NONFATAL(block_template);
+        // createNewBlock() returns nullptr only when the node is shutting down
+        if (!block_template) throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");
 
 
         // Need to update only after we know createNewBlock succeeded

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -6,10 +6,14 @@
 
 import random
 import threading
+import time
 
 from test_framework.blocktools import NORMAL_GBT_REQUEST_PARAMS
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    JSONRPCException,
+    assert_equal,
+)
 from test_framework.wallet import MiniWallet
 
 
@@ -24,6 +28,18 @@ class LongpollThread(threading.Thread):
 
     def run(self):
         self.node.getblocktemplate({'longpollid': self.longpollid, **NORMAL_GBT_REQUEST_PARAMS})
+
+
+class LongpollShutdownThread(LongpollThread):
+    def __init__(self, node):
+        super().__init__(node)
+        self.error = None
+
+    def run(self):
+        try:
+            super().run()
+        except JSONRPCException as e:
+            self.error = e.error
 
 class GetBlockTemplateLPTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -70,6 +86,23 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         # after one minute, every 10 seconds the mempool is probed, so in 80 seconds it should have returned
         thr.join(60 + 20)
         assert not thr.is_alive()
+
+        self.log.info("Test that a longpoll interrupted by shutdown errors with 'Shutting down' (issue #34262)")
+        thr = LongpollShutdownThread(self.nodes[0])
+        with self.nodes[0].assert_debug_log(["ThreadRPCServer method=getblocktemplate"], timeout=3):
+            thr.start()
+        # Make the cached block template stale, so that the woken longpoll
+        # thread must call createNewBlock() instead of serving the cache: a
+        # mempool change plus a template older than 5 seconds (via mocktime,
+        # to avoid sleeping).
+        self.miniwallet.send_self_transfer(from_node=self.nodes[0])
+        self.nodes[0].setmocktime(int(time.time()) + 10)
+        self.stop_node(0)
+        thr.join(60 * self.options.timeout_factor)
+        assert not thr.is_alive()
+        assert thr.error is not None, "longpoll returned a template instead of an error during shutdown"
+        assert_equal(thr.error['message'], "Shutting down")
+        assert_equal(thr.error['code'], -9)
 
 if __name__ == '__main__':
     GetBlockTemplateLPTest(__file__).main()


### PR DESCRIPTION
### Problem
createNewBlock() returns nullptr only when the node is shutting down (WaitTipChanged returns nullopt on interrupt and nothing else). The mining RPCs wrapped the result in CHECK_NONFATAL, reporting an expected shutdown condition as "Internal bug detected".

### Fix
getblocktemplate and generateblock now throw "Shutting down" (RPC_CLIENT_NOT_CONNECTED), matching how getblocktemplate's longpoll path already reports the same condition. generateBlocks stops mining and returns the blocks found so far, matching its existing interrupt handling.

### Testing
Add regression coverage: a longpoll getblocktemplate interrupted by shutdown must error with "Shutting down". Without the fix this raced ~50/50 between the correct error and the internal-bug error, because the IsRPCRunning() check runs before RPC is disabled during shutdown.

Fixes #34262