### PR TITLE
streams: avoid termination on buffered write failure

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1012,7 +1012,7 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
                 // Write undo data & checksum
                 fileout << blockundo << hasher.GetHash();
             }
-            // BufferedWriter will flush pending data to file when fileout goes out of scope.
+            fileout.flush();
         }
 
         // Make sure that the file is closed before we call `FlushUndoFile`.
@@ -1168,6 +1168,7 @@ FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
         pos.nPos += STORAGE_HEADER_BYTES;
         // Write block
         fileout << TX_WITH_WITNESS(block);
+        fileout.flush();
     }
 
     if (file.fclose() != 0) {

--- a/src/streams.h
+++ b/src/streams.h
@@ -25,6 +25,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 /* Minimal stream for overwriting and/or appending to an existing byte vector
@@ -703,8 +704,9 @@ public:
 
     void flush()
     {
-        if (m_buf_pos) m_dst.write_buffer(std::span{m_buf}.first(m_buf_pos));
-        m_buf_pos = 0;
+        if (auto buf_pos{std::exchange(m_buf_pos, 0)}) {
+            m_dst.write_buffer(std::span{m_buf}.first(buf_pos));
+        }
     }
 
     void write(std::span<const std::byte> src)

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -757,6 +757,20 @@ BOOST_AUTO_TEST_CASE(buffered_writer_matches_autofile_random_content)
     fs::remove(test_buffered.FileName(pos));
 }
 
+BOOST_AUTO_TEST_CASE(buffered_writer_flush_failure)
+{
+    struct FailingStream {
+        int write_attempts{0};
+        void write_buffer(std::span<std::byte>) { if (++write_attempts == 1) throw std::ios_base::failure{"write failed"}; }
+    } stream;
+    BOOST_CHECK_EXCEPTION([&] {
+        BufferedWriter writer{stream};
+        writer.write("00"_hex);
+        writer.flush();
+        }(), std::ios_base::failure, HasReason{"write failed"});
+    BOOST_CHECK_EQUAL(stream.write_attempts, 2); // TODO: Do not retry a failed flush during exception unwinding.
+}
+
 BOOST_AUTO_TEST_CASE(buffered_writer_reader)
 {
     const uint32_t v1{m_rng.rand32()}, v2{m_rng.rand32()}, v3{m_rng.rand32()};

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -768,7 +768,7 @@ BOOST_AUTO_TEST_CASE(buffered_writer_flush_failure)
         writer.write("00"_hex);
         writer.flush();
         }(), std::ios_base::failure, HasReason{"write failed"});
-    BOOST_CHECK_EQUAL(stream.write_attempts, 2); // TODO: Do not retry a failed flush during exception unwinding.
+    BOOST_CHECK_EQUAL(stream.write_attempts, 1);
 }
 
 BOOST_AUTO_TEST_CASE(buffered_writer_reader)


### PR DESCRIPTION
**Problem:** Block and undo writers buffer serialized data, then rely on `BufferedWriter`'s destructor to write the remaining bytes.
`fwrite()` can report fewer bytes written than requested after a local storage error, e.g. if the filesystem fills up while a block is being written (my 1 TB benchmarking servers have recently been filling up, so I've been seeing these failures more often).
`AutoFile::write_buffer()` converts that result into an exception and because the destructor is implicitly non-throwing, the exception invokes `std::terminate` instead of reaching normal storage-error handling.
Calling `flush()` before destruction is insufficient on its own because a failed flush leaves the same bytes pending, so the destructor retries the write while the original exception unwinds.

I introduced this bug in #31551 when adding the `BufferedWriter`.

**Fix:** `BufferedWriter` now clears the pending byte count before writing, preventing a destructor retry after a failed explicit flush.
Block and undo writers flush before destruction, so write failures follow normal storage-error handling instead of terminating the process.

<details>
<summary>Manual short-write reproducer</summary>

```sh
sed -i '' '122s/src.size()/0/' src/streams.cpp
cmake -B build && cmake --build build -j && build/bin/bitcoind -regtest -datadir="$(mktemp -d)"; echo "exit=$?"
```

With implicit flushing, `bitcoind` aborts:
> libc++abi: terminating due to uncaught exception of type std::__1::ios_base::failure: AutoFile::write_buffer: write failed: unspecified iostream_category error
  zsh: abort      build/bin/bitcoind -regtest -datadir="$(mktemp -d)"
  exit=134

With explicit flushing, it reports `Failed to write genesis block` and exits 1 instead of terminating the process:
> Shutdown done
exit=1

</details>
