### PR TITLE
ci: use ruff 0.16.x

### DIFF
--- a/ci/lint/requirements.txt
+++ b/ci/lint/requirements.txt
@@ -1,4 +1,4 @@
 # lief version should match the version used in Guix
 lief==0.17.5
-mypy==2.3.0
+mypy==2.3.1
 pyzmq==27.2.0

--- a/ci/lint/requirements.txt
+++ b/ci/lint/requirements.txt
@@ -1,4 +1,4 @@
 # lief version should match the version used in Guix
 lief==0.17.5
 mypy==2.3.0
-pyzmq==27.1.0
+pyzmq==27.2.0

--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -10,7 +10,7 @@ FROM mirror.gcr.io/ubuntu:26.04
 # https://docs.astral.sh/uv/reference/policies/versioning/
 # https://docs.astral.sh/ruff/versioning/
 COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
-COPY --from=ghcr.io/astral-sh/ruff:0.15 /ruff /bin/
+COPY --from=ghcr.io/astral-sh/ruff:0.16 /ruff /bin/
 
 COPY ./ci/retry/retry /ci_retry
 COPY ./.python-version /.python-version


### PR DESCRIPTION
Also use mypy `2.3.1` and pyzmq `27.2.0`.