### PR TITLE
build: avoid embedding depends paths in build RPATH

### DIFF
--- a/depends/toolchain.cmake.in
+++ b/depends/toolchain.cmake.in
@@ -81,6 +81,9 @@ set(CMAKE_STRIP "@STRIP@")
 set(CMAKE_OBJCOPY "@OBJCOPY@")
 set(CMAKE_OBJDUMP "@OBJDUMP@")
 
+# Mark builds configured with the depends toolchain.
+set(BITCOIN_DEPENDS_BUILD TRUE)
+
 # Using our own built dependencies should not be
 # affected by a potentially random environment.
 set(CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH OFF)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -291,6 +291,17 @@ if(BUILD_GUI_TESTS)
   add_subdirectory(test)
 endif()
 
+# Avoid embedding absolute paths to shared depends libraries in GUI build binaries.
+if(BITCOIN_DEPENDS_BUILD AND NOT CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+  set_target_properties(bitcoin-qt PROPERTIES SKIP_BUILD_RPATH TRUE)
+  if(TARGET bitcoin-gui)
+    set_target_properties(bitcoin-gui PROPERTIES SKIP_BUILD_RPATH TRUE)
+  endif()
+  if(TARGET test_bitcoin-qt)
+    set_target_properties(test_bitcoin-qt PROPERTIES SKIP_BUILD_RPATH TRUE)
+  endif()
+endif()
+
 find_program(XGETTEXT_EXECUTABLE xgettext)
 if(NOT XGETTEXT_EXECUTABLE)
   add_custom_target(translate


### PR DESCRIPTION
After PR #33247 removed CMAKE_SKIP_BUILD_RPATH from the CMake build system as part of changes related to Guix binary checks, Linux builds using the depends toolchain could embed the absolute depends/<host>/lib path in build-tree binaries.

One user-visible consequence was incorrect font rendering in the Bitcoin Core Qt GUI. Instead of rendering the bundled RobotoMono-Bold.ttf font as intended, the GUI could fall back to a system-provided font and sizing, resulting in text that was unpleasant to read and, in some cases, difficult to read.

This PR restores build-RPATH suppression specifically for the depends toolchain, without reverting the broader changes from #33247 or affecting Guix builds. It also prevents Linux binaries built with depends from containing the absolute depends library path in their RPATH/RUNPATH.

Tested on Linux x86_64 with depends builds on v31.1 and current master. After this change, bitcoin-qt, bitcoin-gui, and test_bitcoin-qt contain no RPATH/RUNPATH, and their generated link commands contain no -Wl,-rpath.