### PR TITLE
p2p: use header time for compact block recency

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4891,8 +4891,8 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             return;
         }
 
-        // If we're not close to tip yet, give up and let parallel block fetch work its magic
-        if (!already_in_flight && !CanDirectFetch()) {
+        // If this is not a recent block, give up and let parallel block fetch work its magic
+        if (!already_in_flight && pindex->Time() <= NodeClock::now() - m_chainparams.GetConsensus().PowTargetSpacing() * 20) {
             return;
         }
 
@@ -5018,7 +5018,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
             // our anti-DoS protections in AcceptBlock, which filters
             // unrequested blocks that might be trying to waste our resources
             // (eg disk space). Because we only try to reconstruct blocks when
-            // we're close to caught up (via the CanDirectFetch() requirement
+            // the announced block is recent (via the block-time requirement
             // above, combined with the behavior of not requesting blocks until
             // we have a chain with at least the minimum chain work), and we ignore
             // compact blocks with less work than our tip, it is safe to treat

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -61,6 +61,7 @@ from test_framework.test_node import TestNode
 from test_framework.util import (
     assert_not_equal,
     assert_equal,
+    assert_greater_than,
     softfork_active,
 )
 from test_framework.wallet import MiniWallet
@@ -994,10 +995,11 @@ class CompactBlocksTest(BitcoinTestFramework):
     def test_compact_blocks_ignored(self):
         node = self.nodes[0]
 
-        def build_compact_block():
+        def build_compact_block(utxo=None, num_transactions=10):
             # generate a compact block to send that will force a GETBLOCKTXN
-            utxo = self.utxos.pop(0)
-            block = self.build_block_with_transactions(node, utxo, 10)
+            if utxo is None:
+                utxo = self.utxos.pop(0)
+            block = self.build_block_with_transactions(node, utxo, num_transactions)
             cmpct_block = HeaderAndShortIDs()
             cmpct_block.initialize_from_block(block)
             msg = msg_cmpctblock(cmpct_block.to_p2p())
@@ -1007,8 +1009,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         # for whether or not the node processed the CMPCTBLOCK.
         # Note: since we never fulfill the GETBLOCKTXN, this will never change
         # the HB status of a connection.
-        def ignores_compact_block(conn, solicited=False):
-            block, msg = build_compact_block()
+        def ignores_compact_block(conn, solicited=False, compact_block=None):
+            block, msg = compact_block or build_compact_block()
             conn.clear_getblocktxn()
             if solicited:
                 conn.send_without_ping(msg_headers([block]))
@@ -1048,7 +1050,22 @@ class CompactBlocksTest(BitcoinTestFramework):
         hb_peer_idx = -2
         self.assert_highbandwidth_states(node, idx=hb_peer_idx, hb_to=True, hb_from=False)
         hb_peer = self.nodes[0].p2ps[hb_peer_idx]
-        assert not ignores_compact_block(hb_peer, solicited=False)
+        recency_utxo = self.utxos.pop(0)
+        stale_compact_block = build_compact_block(recency_utxo, num_transactions=9)
+
+        self.log.info("Test that an unsolicited CMPCTBLOCK is accepted based on its header's recency.")
+        stale_block, _ = stale_compact_block
+        stale_time = stale_block.nTime + 20 * 10 * 60 + 1
+        node.setmocktime(stale_time)
+        try:
+            assert ignores_compact_block(hb_peer, compact_block=stale_compact_block)
+
+            recent_compact_block = build_compact_block(recency_utxo, num_transactions=8)
+            recent_block, _ = recent_compact_block
+            assert_greater_than(recent_block.nTime, stale_block.nTime + 20 * 10 * 60)
+            assert not ignores_compact_block(hb_peer, compact_block=recent_compact_block)
+        finally:
+            node.setmocktime(0)
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])


### PR DESCRIPTION
## Summary

- use the announced block header's timestamp to check unsolicited compact-block recency
- preserve the existing 20-target-spacing cutoff
- leave `CanDirectFetch()` and its other callers unchanged
- add regression coverage for compact-block relay when the active tip is stale

`CanDirectFetch()` checks the active tip's timestamp. After 20 target spacings without a block, this causes a recent unsolicited compact block from a high-bandwidth peer to be ignored.

This change uses the announced block header's timestamp for that local check instead. Although header timestamps are miner-selected, this only affects whether reconstruction is attempted; existing proof-of-work, chain-work, peer, resource, and block-validation checks still apply.

Fixes #33578

## Test coverage

The functional test keeps the active tip stale and verifies that:

- an old unsolicited compact block is ignored
- a distinct compact block with a recent header triggers `GETBLOCKTXN`
- mock time is restored after the test

## Validation

`test/functional/p2p_compactblocks.py`
