### PR TITLE
build: check for SetThreadDescription() at configure time

### DIFF
--- a/cmake/bitcoin-build-config.h.in
+++ b/cmake/bitcoin-build-config.h.in
@@ -76,6 +76,9 @@
 /* Define this symbol if you have posix_fallocate */
 #cmakedefine HAVE_POSIX_FALLOCATE 1
 
+/* Define this symbol if you have SetThreadDescription */
+#cmakedefine HAVE_SETTHREADDESCRIPTION 1
+
 /* Define this symbol if platform supports unix domain sockets */
 #cmakedefine HAVE_SOCKADDR_UN 1
 

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -76,6 +76,10 @@ check_cxx_source_compiles("
   " HAVE_STRONG_GETAUXVAL
 )
 
+# Check for SetThreadDescription(), which is missing from mingw-w64 headers
+# before 12.0.0.
+check_cxx_symbol_exists(SetThreadDescription "windows.h" HAVE_SETTHREADDESCRIPTION)
+
 # Check for UNIX sockets.
 check_cxx_source_compiles("
   #include <sys/socket.h>

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
 #include <util/threadnames.h>
 #include <util/check.h>
 
@@ -18,7 +20,7 @@
 #include <sys/prctl.h>
 #endif
 
-#ifdef WIN32
+#ifdef HAVE_SETTHREADDESCRIPTION
 #include <windows.h>
 #endif
 
@@ -33,7 +35,7 @@ static void SetThreadName(const char* name)
     pthread_set_name_np(pthread_self(), name);
 #elif defined(__APPLE__)
     pthread_setname_np(name);
-#elif defined(WIN32)
+#elif defined(HAVE_SETTHREADDESCRIPTION)
     // Thread names are ASCII-only, so widening each character is sufficient as
     // a conversion to UTF-16.
     const std::wstring wname{name, name + std::strlen(name)};


### PR DESCRIPTION
SetThreadDescription() is missing from mingw-w64 headers before 12.0.0, so the Windows cross-compile fails on distro toolchains, e.g. Ubuntu 24.04. Reported by hebasto in https://github.com/bitcoin/bitcoin/pull/35884#issuecomment-5379490348.

Check for the symbol at configure time and guard its use with a new `HAVE_SETTHREADDESCRIPTION` guard, as cmake/introspection.cmake already does for other optional symbols. This avoids having to declare a minimum mingw-w64 version: toolchains that have the symbol get OS-level thread names, older ones build fine without them.