### PR TITLE
doc: Fix typos and grammatical phrasing in comments

### DIFF
--- a/contrib/tracing/log_raw_p2p_msgs.py
+++ b/contrib/tracing/log_raw_p2p_msgs.py
@@ -81,7 +81,7 @@ int trace_inbound_message(struct pt_regs *ctx) {
     void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL, *pmsg = NULL;
 
     // lookup() does not return a NULL pointer. However, the BPF verifier
-    // requires an explicit check that that the `msg` pointer isn't a NULL
+    // requires an explicit check that the `msg` pointer isn't a NULL
     // pointer. See https://github.com/iovisor/bcc/issues/2595
     if (msg == NULL) return 1;
 
@@ -107,7 +107,7 @@ int trace_outbound_message(struct pt_regs *ctx) {
     void *paddr = NULL, *pconn_type = NULL, *pmsg_type = NULL, *pmsg = NULL;
 
     // lookup() does not return a NULL pointer. However, the BPF verifier
-    // requires an explicit check that that the `msg` pointer isn't a NULL
+    // requires an explicit check that the `msg` pointer isn't a NULL
     // pointer. See https://github.com/iovisor/bcc/issues/2595
     if (msg == NULL) return 1;
 

--- a/src/bench/txgraph.cpp
+++ b/src/bench/txgraph.cpp
@@ -102,14 +102,14 @@ void BenchTxGraphTrim(benchmark::Bench& bench)
         // Determine the number of dependencies this transaction will have.
         int deps = std::min<int>(NUM_DEPS_PER_BOTTOM_TX, top_components.size());
         for (int dep = 0; dep < deps; ++dep) {
-            // Pick an transaction in top_components to attach to.
+            // Pick a transaction in top_components to attach to.
             auto idx = rng.randrange(top_components.size());
             // Add dependency.
             graph->AddDependency(/*parent=*/top_refs[top_components[idx]], /*child=*/bottom_tx);
             // Unless this is the last dependency being added, remove from top_components, as
             // the component will be merged with that one.
             if (dep < deps - 1) {
-                // Move entry top the back.
+                // Move entry to the back.
                 if (idx != top_components.size() - 1) std::swap(top_components.back(), top_components[idx]);
                 // And pop it.
                 top_components.pop_back();

--- a/src/common/pcp.cpp
+++ b/src/common/pcp.cpp
@@ -331,11 +331,11 @@ std::variant<MappingResult, MappingError> NATPMPRequestPortMap(const CNetAddr &g
         [&](const std::span<const uint8_t> response) -> bool {
             if (response.size() < NATPMP_GETEXTERNAL_RESPONSE_SIZE) {
                 LogWarning("natpmp: Response too small\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             if (response[NATPMP_HDR_VERSION_OFS] != NATPMP_VERSION || response[NATPMP_HDR_OP_OFS] != (NATPMP_RESPONSE | NATPMP_OP_GETEXTERNAL)) {
                 LogWarning("natpmp: Response to wrong command\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             return true;
         },
@@ -369,16 +369,16 @@ std::variant<MappingResult, MappingError> NATPMPRequestPortMap(const CNetAddr &g
         [&](const std::span<const uint8_t> response) -> bool {
             if (response.size() < NATPMP_MAP_RESPONSE_SIZE) {
                 LogWarning("natpmp: Response too small\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             if (response[0] != NATPMP_VERSION || response[1] != (NATPMP_RESPONSE | NATPMP_OP_MAP_TCP)) {
                 LogWarning("natpmp: Response to wrong command\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             uint16_t internal_port = ReadBE16(response.data() + NATPMP_MAP_RESPONSE_INTERNAL_PORT_OFS);
             if (internal_port != port) {
                 LogWarning("natpmp: Response port doesn't match request\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             return true;
         },
@@ -495,23 +495,23 @@ std::variant<MappingResult, MappingError> PCPRequestPortMap(const PCPMappingNonc
             }
             if (response.size() < (PCP_HDR_SIZE + PCP_MAP_SIZE)) {
                 LogWarning("pcp: Response too small\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             if (response[PCP_HDR_VERSION_OFS] != PCP_VERSION || response[PCP_HDR_OP_OFS] != (PCP_RESPONSE | PCP_OP_MAP)) {
                 LogWarning("pcp: Response to wrong command\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             // Handle MAP opcode response. See RFC6887 Figure 10.
             // Check that returned mapping nonce matches our request.
             if (!std::ranges::equal(response.subspan(PCP_HDR_SIZE + PCP_MAP_NONCE_OFS, PCP_MAP_NONCE_SIZE), nonce)) {
                 LogWarning("pcp: Mapping nonce mismatch\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             uint8_t protocol = response[PCP_HDR_SIZE + 12];
             uint16_t internal_port = ReadBE16(response.data() + PCP_HDR_SIZE + 16);
             if (protocol != PCP_PROTOCOL_TCP || internal_port != port) {
                 LogWarning("pcp: Response protocol or port doesn't match request\n");
-                return false; // Wasn't response to what we expected, try receiving next packet.
+                return false; // Not the response we expected, try receiving next packet.
             }
             return true;
         },

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -226,7 +226,7 @@ class HTTPServer
 {
 public:
     /**
-     * Each connection is assigned an unique id of this type.
+     * Each connection is assigned a unique id of this type.
      */
     using Id = uint64_t;
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -583,7 +583,7 @@ std::optional<BlockRef> WaitTipChanged(ChainstateManager& chainman, KernelNotifi
             return {};
         }
         // At this point TipBlock is set, so continue to wait until it is
-        // different then `current_tip` provided by caller.
+        // different from `current_tip` provided by caller.
         kernel_notifications.m_tip_block_cv.wait_until(lock, deadline, [&]() EXCLUSIVE_LOCKS_REQUIRED(kernel_notifications.m_tip_block_mutex) {
             return Assume(kernel_notifications.TipBlock()) != current_tip || chainman.m_interrupt || interrupt;
         });

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -761,7 +761,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 #ifdef ENABLE_WALLET
 void RPCConsole::addWallet(WalletModel * const walletModel)
 {
-    // use name for text and wallet model for internal data object (to allow to move to a wallet id later)
+    // use name for text and wallet model for internal data object (to allow moving to a wallet id later)
     ui->WalletSelector->addItem(walletModel->getDisplayName(), QVariant::fromValue(walletModel));
     if (ui->WalletSelector->count() == 2) {
         // First wallet added, set to default to match wallet RPC behavior
@@ -1015,7 +1015,7 @@ void RPCConsole::on_lineEdit_returnPressed()
         return;
     }
 
-    // A special case allows to request shutdown even a long-running command is executed.
+    // A special case allows requesting shutdown even while a long-running command is executing.
     if (cmd == QLatin1String("stop")) {
         std::string dummy;
         RPCExecuteCommandLine(m_node, dummy, cmd.toStdString());

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -84,7 +84,7 @@ WalletView::WalletView(WalletModel* wallet_model, const PlatformStyle* _platform
     // Highlight transaction after send
     connect(sendCoinsPage, &SendCoinsDialog::coinsSent, transactionView, qOverload<const Txid&>(&TransactionView::focusTransaction));
 
-    // Clicking on "Export" allows to export the transaction list
+    // Clicking on "Export" allows exporting the transaction list
     connect(exportButton, &QPushButton::clicked, transactionView, &TransactionView::exportClicked);
 
     // Pass through messages from sendCoinsPage

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2233,12 +2233,12 @@ bool FindScriptPubKey(std::atomic<int>& scan_progress, const std::atomic<bool>& 
         if (++count % 8192 == 0) {
             interruption_point();
             if (should_abort) {
-                // allow to abort the scan via the abort reference
+                // allow aborting the scan via the abort reference
                 return false;
             }
         }
         if (count % 256 == 0) {
-            // update progress reference every 256 item
+            // update progress reference every 256 items
             uint32_t high = 0x100 * *UCharCast(key.hash.begin()) + *(UCharCast(key.hash.begin()) + 1);
             scan_progress = (int)(high * 100.0 / 65536.0 + 0.5);
         }

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -428,7 +428,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_p2pubkey_only)
 
     // We should match the generation outpoint
     BOOST_CHECK(filter.contains(COutPoint{Txid{"147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"}, 0}));
-    // ... but not the 4th transaction's output (its not pay-2-pubkey)
+    // ... but not the 4th transaction's output (it's not pay-to-pubkey)
     BOOST_CHECK(!filter.contains(COutPoint{Txid{"02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"}, 0}));
 }
 

--- a/src/test/fuzz/parse_numbers.cpp
+++ b/src/test/fuzz/parse_numbers.cpp
@@ -24,7 +24,7 @@ FUZZ_TARGET(parse_numbers)
         const auto u32{ToIntegral<uint32_t>(random_string)};
         const auto i64{ToIntegral<int64_t>(random_string)};
         const auto u64{ToIntegral<uint64_t>(random_string)};
-        // Dont check any values, just that each success result must fit into
+        // Don't check any values, just that each success result must fit into
         // the one with the largest bit-width.
         if (i8) {
             assert(i8 == i64);

--- a/src/test/txgraph_tests.cpp
+++ b/src/test/txgraph_tests.cpp
@@ -229,14 +229,14 @@ BOOST_AUTO_TEST_CASE(txgraph_trim_huge)
         // Determine the number of dependencies this transaction will have.
         int deps = std::min<int>(NUM_DEPS_PER_BOTTOM_TX, top_components.size());
         for (int dep = 0; dep < deps; ++dep) {
-            // Pick an transaction in top_components to attach to.
+            // Pick a transaction in top_components to attach to.
             auto idx = rng.randrange(top_components.size());
             // Add dependency.
             graph->AddDependency(/*parent=*/top_refs[top_components[idx]], /*child=*/bottom_tx);
             // Unless this is the last dependency being added, remove from top_components, as
             // the component will be merged with that one.
             if (dep < deps - 1) {
-                // Move entry top the back.
+                // Move entry to the back.
                 if (idx != top_components.size() - 1) std::swap(top_components.back(), top_components[idx]);
                 // And pop it.
                 top_components.pop_back();
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(txgraph_chunk_chain)
     FeePerWeight feerateC{2, 10};
     FeePerWeight feerateD{4, 10};
 
-    // everytime adding a transaction, test the chunk status
+    // Every time a transaction is added, test the chunk status
     // [A]
     graph->AddTransaction(refs.emplace_back(), feerateA);
     BOOST_CHECK_EQUAL(graph->GetTransactionCount(TxGraph::Level::TOP), 1);
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(txgraph_staging)
     FeePerWeight feerateA{2, 10};
     FeePerWeight feerateB{1, 10};
 
-    // everytime adding a transaction, test the chunk status
+    // Every time a transaction is added, test the chunk status
     // [A]
     graph->AddTransaction(refs.emplace_back(), feerateA);
     BOOST_CHECK_EQUAL(graph->HaveStaging(), false);

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -435,7 +435,7 @@ public:
      *  + input fees are rounded individually and not collectively, which leads to small rounding errors
      *  - input counter size is always assumed to be 1vbyte
      *
-     * @param[in]  min_viable_change  Minimum amount for change output, if change would be less then we forgo change
+     * @param[in]  min_viable_change  Minimum amount for change output, if change would be less than this we forgo change
      * @param[in]  change_fee         Fees to include change output in the tx
      * @returns Amount for change output, 0 when there is no change.
      *

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -39,7 +39,7 @@ MinimumFeeRateResult GetMinimumFeeRate(const CWallet& wallet, const CCoinControl
     */
     if (coin_control.m_feerate) { // 1.
         CFeeRate fee_rate{*coin_control.m_feerate};
-        // Allow to override automatic min/max check over coin control instance
+        // Allow overriding automatic min/max check on the coin control instance
         if (coin_control.fOverrideFeeRate) return {fee_rate, FeeReason::USER_SPECIFIED, std::nullopt};
 
         CFeeRate required_feerate = GetRequiredFeeRate(wallet);
@@ -52,7 +52,7 @@ MinimumFeeRateResult GetMinimumFeeRate(const CWallet& wallet, const CCoinControl
     unsigned int target = coin_control.m_confirm_target ? *coin_control.m_confirm_target : wallet.m_confirm_target;
     // By default estimates are economical iff we are signaling opt-in-RBF
     bool conservative_estimate = !coin_control.m_signal_bip125_rbf.value_or(wallet.m_signal_rbf);
-    // Allow to override the default fee estimate mode over the CoinControl instance
+    // Allow overriding the default fee estimate mode on the CoinControl instance
     if (coin_control.m_fee_mode == FeeEstimateMode::CONSERVATIVE)
         conservative_estimate = true;
     else if (coin_control.m_fee_mode == FeeEstimateMode::ECONOMICAL)


### PR DESCRIPTION
Fix various minor typos, grammatical errors, and awkward phrasing in code comments and docstrings across the codebase:

- **miner.cpp**: Fix 'different then' to 'different from'.
- **coinselection.h**: Fix 'less then' in docstring comment.
- **httpserver.h**: Use 'a unique id' instead of 'an unique id'.
- **txgraph.cpp** & **txgraph_tests.cpp**: Fix 'an transaction', typo 'top the back' -> 'to the back', and compound 'everytime'.
- **log_raw_p2p_msgs.py**: Remove duplicated word 'that that'.
- **pcp.cpp**: Improve response error comment phrasing.
- **blockchain.cpp**: Improve 'allow to abort' and pluralize 'every 256 item'.
- **rpcconsole.cpp** & **walletview.cpp**: Improve phrasing to use gerunds and clearer clauses.
- **fees.cpp**: Improve 'Allow to override... over' to 'Allow overriding... on'.
- **bloom_tests.cpp** & **parse_numbers.cpp**: Add missing apostrophes ('Don\'t', 'it\'s').