### PR TITLE
coinstatsindex: guard input index against inconsistent undo data

### DIFF
--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -159,6 +159,11 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
             if (!is_coinbase) {
                 const auto& tx_undo{Assert(block.undo_data)->vtxundo.at(i - 1)};
 
+                if (tx_undo.vprevout.size() != tx->vin.size()) {
+                    LogError("transaction and undo data inconsistent");
+                    return false;
+                }
+
                 for (size_t j = 0; j < tx_undo.vprevout.size(); ++j) {
                     const Coin& coin{tx_undo.vprevout[j]};
                     const COutPoint outpoint{tx->vin[j].prevout.hash, tx->vin[j].prevout.n};
@@ -371,6 +376,11 @@ bool CoinStatsIndex::RevertBlock(const interfaces::BlockInfo& block)
         // The coinbase tx has no undo data since no former output is spent
         if (!is_coinbase) {
             const auto& tx_undo{block.undo_data->vtxundo.at(i - 1)};
+
+            if (tx_undo.vprevout.size() != tx->vin.size()) {
+                LogError("transaction and undo data inconsistent");
+                return false;
+            }
 
             for (size_t j = 0; j < tx_undo.vprevout.size(); ++j) {
                 const Coin& coin{tx_undo.vprevout[j]};


### PR DESCRIPTION
CustomAppend and RevertBlock walk each transaction's spent inputs using the block undo data read from disk, bounding the loop by tx_undo.vprevout.size() while indexing the transaction's own inputs with tx->vin[j]. If an undo record holds more prevouts than the transaction has inputs, that reads past the end of vin; DisconnectBlock already rejects the same vprevout/vin mismatch before restoring inputs, but the two coinstatsindex callbacks skip that check. This adds the matching size check to both so they fail the index cleanly instead of reading out of bounds.