### PR TITLE
refactor: [test] Remove deprecated SetMockTime(i64) alias

### DIFF
--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -69,7 +69,7 @@ static RPCMethod setmocktime()
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Mocktime must be in the range [0, %s], not %s.", max_time, time));
     }
 
-    SetMockTime(time);
+    SetMockTime(std::chrono::seconds{time});
     const NodeContext& node_context{EnsureAnyNodeContext(request.context)};
     for (const auto& chain_client : node_context.chain_clients) {
         chain_client->setMockTime(time);

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -100,7 +100,7 @@ static void initialize()
     SeedRandomStateForTest(SeedRand::ZEROS);
 
     // Set time to the genesis block timestamp for deterministic initialization.
-    SetMockTime(1231006505);
+    SetMockTime(1231006505s);
 
     // Terminate immediately if a fuzzing harness ever tries to create a socket.
     // Individual tests can override this by pointing CreateSock to a mocked alternative.

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -805,7 +805,7 @@ BOOST_AUTO_TEST_CASE(http_server_socket_tests)
 {
     // Hard code the timestamp for the Date header in the HTTP response
     // Wed Dec 11 00:47:09 2024 UTC
-    SetMockTime(1733878029);
+    FakeNodeClock clock{1733878029s};
 
     // Prepare a request handler that just stores received requests so we can examine them.
     // Mutex is required to prevent a race between this test's main thread and the server's I/O loop.

--- a/src/test/mempool_fee_estimator_tests.cpp
+++ b/src/test/mempool_fee_estimator_tests.cpp
@@ -105,6 +105,7 @@ BOOST_AUTO_TEST_CASE(calculate_max_weight_percentiles)
 
 BOOST_AUTO_TEST_CASE(mempool_fee_rate_estimator_cache)
 {
+    FakeNodeClock clock{};
     MemPoolFeeRateEstimatorCache cache;
     const uint256 tip_hash{uint256::ONE};
     const uint256 next_tip_hash{uint256{2}};
@@ -122,10 +123,9 @@ BOOST_AUTO_TEST_CASE(mempool_fee_rate_estimator_cache)
     BOOST_CHECK(cached->m_economical == economical);
     BOOST_CHECK(!cache.GetCachedEstimate(next_tip_hash));
 
-    SetMockTime(GetTime<std::chrono::seconds>() + CACHE_LIFE + std::chrono::seconds{1});
+    clock += CACHE_LIFE + std::chrono::seconds{1};
     BOOST_CHECK(cache.IsStale());
     BOOST_CHECK(!cache.GetCachedEstimate(tip_hash));
-    SetMockTime(0);
 }
 
 BOOST_AUTO_TEST_CASE(MempoolFeeRateEstimator)

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -49,7 +49,6 @@ NodeClock::time_point NodeClock::now() noexcept
     return time_point{ret};
 };
 
-void SetMockTime(int64_t nMockTimeIn) { SetMockTime(std::chrono::seconds{nMockTimeIn}); }
 void SetMockTime(std::chrono::time_point<NodeClock, std::chrono::seconds> mock) { SetMockTime(mock.time_since_epoch()); }
 void SetMockTime(std::chrono::seconds mock_time_in)
 {

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -112,14 +112,6 @@ using MillisecondsDouble = std::chrono::duration<double, std::chrono::millisecon
  */
 int64_t GetTime();
 
-/**
- * DEPRECATED
- * Use SetMockTime with chrono type
- *
- * @param[in] nMockTimeIn Time in seconds.
- */
-void SetMockTime(int64_t nMockTimeIn);
-
 /** For testing. Set e.g. with the setmocktime rpc, or -mocktime argument */
 void SetMockTime(std::chrono::seconds mock_time_in);
 void SetMockTime(std::chrono::time_point<NodeClock, std::chrono::seconds> mock);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -562,7 +562,7 @@ public:
         return StartWallets(m_context);
     }
     void stop() override { return UnloadWallets(m_context); }
-    void setMockTime(int64_t time) override { return SetMockTime(time); }
+    void setMockTime(int64_t time) override { return SetMockTime(std::chrono::seconds{time}); }
     void schedulerMockForward(std::chrono::seconds delta) override { Assert(m_context.scheduler)->MockForward(delta); }
 
     //! WalletLoader methods


### PR DESCRIPTION
The deprecated test-only alias is only used in a few places and required in none.

In fact, it is incorrectly used in two unit tests, so first fixup those, and then remove it.