### PR TITLE
test: refactor: Remove confusing ignore_errors=True

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -961,14 +961,13 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             self.stop_nodes()
             self.nodes = []
 
-            def cache_path(*paths):
-                return os.path.join(cache_node_dir, self.chain, *paths)
+            cache_path = cache_node_dir / self.chain
 
-            os.rmdir(cache_path('wallets'))  # Remove empty wallets dir
-            shutil.rmtree(cache_path('fees'), ignore_errors=True)
-            for entry in os.listdir(cache_path()):
-                if entry not in ['chainstate', 'blocks', 'indexes']:  # Only indexes, chainstate and blocks folders
-                    os.remove(cache_path(entry))
+            (cache_path / "wallets").rmdir()  # Do not cache empty wallets dir
+            shutil.rmtree(cache_path / "fees")  # Do not cache fees dat files
+            for entry in cache_path.iterdir():
+                if entry.name not in ["chainstate", "blocks", "indexes"]:  # Only keep indexes, chainstate and blocks folders
+                    entry.unlink()
 
         for i in range(self.num_nodes):
             self.log.debug("Copy cache directory {} to node {}".format(cache_node_dir, i))


### PR DESCRIPTION
There is an unexplained `ignore_errors=True` in the internal `_initialize_chain` helper:

```py

shutil.rmtree(cache_path('fees'), ignore_errors=True)
```

This is fine, because no error should happen. But it is a bit confusing, because an ignored error may lead to a later error anyway.

Fix that by failing early instead.

Also, re-write the simple block to `pathlib`.