### PR TITLE
validation: Separate check-only version of ConnectBlock

### DIFF
--- a/src/test/fuzz/connect_block.cpp
+++ b/src/test/fuzz/connect_block.cpp
@@ -436,7 +436,7 @@ CBlock ConsumeBlock(FuzzedDataProvider& fuzzed_data_provider, const CBlock& prev
 }
 
 
-FUZZ_TARGET(connect_block, .init = initialize_connect_block)
+FUZZ_TARGET(test_connect_block, .init = initialize_connect_block)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
@@ -469,11 +469,10 @@ FUZZ_TARGET(connect_block, .init = initialize_connect_block)
 
     // Try to connect the block.
     BlockValidationState state;
-    bool connected = active_chainstate.ConnectBlock(block,
+    bool connected = active_chainstate.TestConnectBlock(block,
                                                     state,
-                                                    &new_index,
-                                                    active_coins,
-                                                    /*fJustCheck=*/true);
+                                                    new_index,
+                                                    active_coins);
     Assert(connected == state.IsValid());
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2291,8 +2291,9 @@ script_verify_flags GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
-bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
-                               CCoinsViewCache& view, bool fJustCheck)
+bool Chainstate::ConnectBlockChecks(const CBlock& block, BlockValidationState& state, const CBlockIndex* pindex,
+    CCoinsViewCache& view, bool fJustCheck, CBlockUndo& blockundo,
+    int& nInputs, int64_t& nSigOpsCost)
 {
     AssertLockHeld(cs_main);
     assert(pindex);
@@ -2336,8 +2337,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // Special case for the genesis block, skipping connection of its transactions
     // (its coinbase is unspendable)
     if (block_hash == params.GetConsensus().hashGenesisBlock) {
-        if (!fJustCheck)
-            view.SetBestBlock(pindex->GetBlockHash());
         return true;
     }
 
@@ -2503,8 +2502,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         m_last_script_check_reason_logged = script_check_reason;
     }
 
-    CBlockUndo blockundo;
-
     // Precomputed transaction data pointers must not be invalidated
     // until after `control` has run the script checks (potentially
     // in multiple threads). Preallocate the vector size so a new allocation
@@ -2516,8 +2513,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     std::vector<int> prevheights;
     CAmount nFees = 0;
-    int nInputs = 0;
-    int64_t nSigOpsCost = 0;
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
@@ -2628,9 +2623,34 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
              Ticks<SecondsDouble>(m_chainman.time_verify),
              Ticks<MillisecondsDouble>(m_chainman.time_verify) / m_chainman.num_blocks_total);
 
-    if (fJustCheck) {
+    return true;
+}
+
+bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex, CCoinsViewCache& view)
+{
+    AssertLockHeld(cs_main);
+    assert(pindex);
+
+    [[maybe_unused]] const auto time_start{SteadyClock::now()};
+
+    CBlockUndo blockundo;
+    int nInputs = 0;
+    int64_t nSigOpsCost = 0;
+    if (!ConnectBlockChecks(block, state, pindex, view, /*fJustCheck=*/false, blockundo, nInputs, nSigOpsCost)) {
+        return false;
+    }
+    const uint256& block_hash = pindex->GetBlockHash();
+
+    // Special case for the genesis block: its coinbase is unspendable, so
+    // ConnectBlockChecks() skipped connecting its transactions and there is
+    // no undo data or block index validity to update.
+    if (pindex->pprev == nullptr) {
+        // add this block to the view's block chain
+        view.SetBestBlock(block_hash);
         return true;
     }
+
+    const auto time_4{SteadyClock::now()};
 
     if (!m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
         return false;
@@ -2649,7 +2669,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     }
 
     // add this block to the view's block chain
-    view.SetBestBlock(pindex->GetBlockHash());
+    view.SetBestBlock(block_hash);
 
     const auto time_6{SteadyClock::now()};
     m_chainman.time_index += time_6 - time_5;
@@ -2668,6 +2688,17 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     );
 
     return true;
+}
+
+bool Chainstate::TestConnectBlock(const CBlock& block, BlockValidationState& state, const CBlockIndex& index,
+                                   CCoinsViewCache& view)
+{
+    AssertLockHeld(cs_main);
+
+    CBlockUndo blockundo;
+    int nInputs = 0;
+    int64_t nSigOpsCost = 0;
+    return ConnectBlockChecks(block, state, &index, view, /*fJustCheck=*/true, blockundo, nInputs, nSigOpsCost);
 }
 
 CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState()
@@ -4527,7 +4558,7 @@ BlockValidationState TestBlockValidity(
         return state;
     }
 
-    // We don't want ConnectBlock to update the actual chainstate, so create
+    // We don't want TestConnectBlock to update the actual chainstate, so create
     // a cache on top of it, along with a dummy block index.
     CBlockIndex index_dummy{block};
     uint256 block_hash(block.GetHash());
@@ -4536,8 +4567,8 @@ BlockValidationState TestBlockValidity(
     index_dummy.phashBlock = &block_hash;
     CCoinsViewCache view_dummy(&chainstate.CoinsTip());
 
-    // Set fJustCheck to true in order to update, and not clear, validation caches.
-    if(!chainstate.ConnectBlock(block, state, &index_dummy, view_dummy, /*fJustCheck=*/true)) {
+    // Call TestConnectBlock(), it updates, and does not clear, validation caches.
+    if (!chainstate.TestConnectBlock(block, state, index_dummy, view_dummy)) {
         if (state.IsValid()) NONFATAL_UNREACHABLE();
         return state;
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -786,8 +786,12 @@ public:
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    //! Connect a block to the chain, updating pindex and the block undo/index files on disk.
     bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
-                      CCoinsViewCache& view, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        CCoinsViewCache& view) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    //! Run the same validity checks as ConnectBlock() without mutating pindex or writing anything to disk.
+    bool TestConnectBlock(const CBlock& block, BlockValidationState& state, const CBlockIndex& index,
+        CCoinsViewCache& view) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Apply the effects of a block disconnection on the UTXO set.
     bool DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
@@ -860,6 +864,17 @@ public:
     std::pair<int, int> GetPruneRange(int last_height_can_prune) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 protected:
+    /**
+     * Shared implementation behind ConnectBlock() and TestConnectBlock().
+     * Performs all UTXO-set-dependent validity checks, without mutating pindex
+     * or writing anything to disk. On success, fills blockundo, nInputs and
+     * nSigOpsCost so that ConnectBlock() can use them to update the chainstate
+     * without recomputing them.
+     */
+    bool ConnectBlockChecks(const CBlock& block, BlockValidationState& state, const CBlockIndex* pindex,
+        CCoinsViewCache& view, bool fJustCheck, CBlockUndo& blockundo,
+        int& nInputs, int64_t& nSigOpsCost) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex& index_most_work, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, std::vector<ConnectedBlock>& connected_blocks) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     bool ConnectTip(
         BlockValidationState& state,

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -241,7 +241,7 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
         # of the UTXO set (see CoinsTip() of CCoinsViewCache). However, in some cases
         # temporary clones of the active cache are made. For example, during mining with
         # the generate RPC call, the block is first tested in TestBlockValidity(). There,
-        # a clone of the active cache is modified during a test ConnectBlock() call.
+        # a clone of the active cache is modified during a TestConnectBlock() call.
         # These are implementation details we don't want to test here. Thus, after
         # mining, we invalidate the block, start the tracing, and then trace the cache
         # changes to the active utxo cache.


### PR DESCRIPTION
This is a small code-hygiene refactor to `ConnectBlock` method.

Problem:  In the "check-only" mode of `ConnectBlock` the mutability of the `CBlockIndex` parameter is inconsistent with the semantics. In the default operation, `ConnectBlock` changes the provided `CBlockIndex`. However, it has a special "check-only" mode, where the provided chain is not changed. This mode is used from only one call site (`TestBlockValidity`), and is signaled by the `fJustCheck = true` flag.

Solution:  Provide two versions of `ConnectBlock`: one with mutable chain and one "check-only" with const chain. There is no need for the `fJustCheck` flag. Both reuse the same internal implementation.

Benefits:
- The mutability of the `pindex` parameter is in sync with the semantics
- One less feature flag (`fJustCheck`)
- Calling "check-only" mode is smoother, creating a dummy mutable `CBlockIndex` is now unnecessary

Additional details:
- This has been triggered by #35187, there is also a new usage of "check-only" `ConnectBlock`, with dummy `CBlockIndex`.
- The "check-only" mode was introduced as early as 3cd01fdf0e540c4e06cd27b6c0d6b6abc00767d1 .
- No behavior change (pure refactor).
- Some internal variables (`blockundo`,  `nInputs`, `nSigOpsCost`) are now outputs of the internal method, and used in the default outer method (`ConnectBlock`).
- `SetBestBlock` has been moved to the outer `ConnectBlock`. It was also present in the special genesis block early return, this is preserved.
- The tracepoints are in the outer methods
- Timing is present both in the inner method (logs) and the outer methods (logs, tracepoint)
