### PR TITLE
fuzz: reuse one fuzzed wallet across inputs

### DIFF
--- a/src/test/fuzz/util/wallet.h
+++ b/src/test/fuzz/util/wallet.h
@@ -5,15 +5,24 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_WALLET_H
 #define BITCOIN_TEST_FUZZ_UTIL_WALLET_H
 
+#include <outputtype.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <policy/policy.h>
 #include <wallet/coincontrol.h>
 #include <wallet/fees.h>
+#include <wallet/scriptpubkeyman.h>
 #include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace wallet {
 
@@ -21,20 +30,108 @@ namespace wallet {
  * Wraps a descriptor wallet for fuzzing.
  */
 struct FuzzedWallet {
+    static constexpr size_t DESTINATION_POOL_SIZE{16};
+    static constexpr uint64_t REBUILD_INTERVAL{1000};
+
     std::shared_ptr<CWallet> wallet;
+
     FuzzedWallet(interfaces::Chain& chain, const std::string& name, const std::string& seed_insecure)
+        : m_chain{chain}, m_name{name}, m_seed_insecure{seed_insecure}
     {
-        wallet = std::make_shared<CWallet>(&chain, name, CreateMockableWalletDatabase());
+        Build();
+    }
+
+    void Reset()
+    {
+        if (++m_iterations >= REBUILD_INTERVAL) {
+            Build();
+            return;
+        }
+        m_cursors.fill(0);
+        m_change_cursors.fill(0);
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->ClearInMemoryTxStateForTest();
+            assert(wallet->mapWallet.empty());
+            assert(wallet->GetTXOs().empty());
+        }
+        // Deriving a change address advances one descriptor's next_index and
+        // extends its range. A single CreateTransaction() can do this more than
+        // once: the avoid-partial-spends retry reserves a second change key on
+        // the same descriptor when the first attempt was changeless. Rather
+        // than track the exact count, bound the total drift loosely at
+        // m_iterations * m_spkms.size() as a tripwire: growing faster than that
+        // means an iteration is leaving behind state this class does not know
+        // about.
+        const int64_t drift{RangeTotal() - m_baseline_range_total};
+        assert(drift >= 0);
+        assert(static_cast<uint64_t>(drift) <= m_iterations * m_spkms.size());
+    }
+
+    CTxDestination GetDestination(FuzzedDataProvider& fuzzed_data_provider)
+    {
+        const auto type{fuzzed_data_provider.PickValueInArray(OUTPUT_TYPES)};
+        const bool external{fuzzed_data_provider.ConsumeBool()};
+        const size_t i{TypeIndex(type)};
+        auto& pool{external ? m_dests : m_change_dests};
+        auto& cursor{external ? m_cursors.at(i) : m_change_cursors.at(i)};
+        const CTxDestination& dest{pool.at(i).at(cursor % DESTINATION_POOL_SIZE)};
+        ++cursor;
+        return dest;
+    }
+
+    CScript GetScriptPubKey(FuzzedDataProvider& fuzzed_data_provider) { return GetScriptForDestination(GetDestination(fuzzed_data_provider)); }
+
+private:
+    using DestinationPool = std::array<std::vector<CTxDestination>, OUTPUT_TYPES.size()>;
+
+    interfaces::Chain& m_chain;
+    const std::string m_name;
+    const std::string m_seed_insecure;
+
+    using PoolCursors = std::array<size_t, OUTPUT_TYPES.size()>;
+
+    DestinationPool m_dests;
+    DestinationPool m_change_dests;
+    PoolCursors m_cursors{};
+    PoolCursors m_change_cursors{};
+
+    static size_t TypeIndex(OutputType type)
+    {
+        for (size_t i = 0; i < OUTPUT_TYPES.size(); ++i) {
+            if (OUTPUT_TYPES.at(i) == type) return i;
+        }
+        assert(false);
+    }
+
+    std::vector<DescriptorScriptPubKeyMan*> m_spkms;
+    int64_t m_baseline_range_total{0};
+    uint64_t m_iterations{0};
+
+    void Build()
+    {
+        m_spkms.clear();
+        for (auto& pool : m_dests) pool.clear();
+        for (auto& pool : m_change_dests) pool.clear();
+        m_cursors.fill(0);
+        m_change_cursors.fill(0);
+
+        wallet = std::make_shared<CWallet>(&m_chain, m_name, CreateMockableWalletDatabase());
         {
             LOCK(wallet->cs_wallet);
             wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
-            auto height{*Assert(chain.getHeight())};
-            wallet->SetLastBlockProcessed(height, chain.getBlockHash(height));
+            auto height{*Assert(m_chain.getHeight())};
+            wallet->SetLastBlockProcessed(height, m_chain.getBlockHash(height));
         }
         wallet->m_keypool_size = 1; // Avoid timeout in TopUp()
         assert(wallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-        ImportDescriptors(seed_insecure);
+        ImportDescriptors(m_seed_insecure);
+        PrecomputeDestinations();
+
+        m_baseline_range_total = RangeTotal();
+        m_iterations = 0;
     }
+
     void ImportDescriptors(const std::string& seed_insecure)
     {
         const std::vector<std::string> DESCS{
@@ -61,20 +158,29 @@ struct FuzzedWallet {
                 LOCK(wallet->cs_wallet);
                 auto& spk_manager = Assert(wallet->AddWalletDescriptor(w_desc, keys, /*label=*/"", internal))->get();
                 wallet->AddActiveScriptPubKeyMan(spk_manager.GetID(), *Assert(w_desc.descriptor->GetOutputType()), internal);
+                m_spkms.push_back(&spk_manager);
             }
         }
     }
-    CTxDestination GetDestination(FuzzedDataProvider& fuzzed_data_provider)
+
+    void PrecomputeDestinations()
     {
-        auto type{fuzzed_data_provider.PickValueInArray(OUTPUT_TYPES)};
-        if (fuzzed_data_provider.ConsumeBool()) {
-            return *Assert(wallet->GetNewDestination(type, ""));
-        } else {
-            return *Assert(wallet->GetNewChangeDestination(type));
+        for (size_t i = 0; i < OUTPUT_TYPES.size(); ++i) {
+            const OutputType type{OUTPUT_TYPES.at(i)};
+            for (size_t j = 0; j < DESTINATION_POOL_SIZE; ++j) {
+                m_dests.at(i).push_back(*Assert(wallet->GetNewDestination(type, "")));
+                m_change_dests.at(i).push_back(*Assert(wallet->GetNewChangeDestination(type)));
+            }
         }
     }
-    CScript GetScriptPubKey(FuzzedDataProvider& fuzzed_data_provider) { return GetScriptForDestination(GetDestination(fuzzed_data_provider)); }
+
+    int64_t RangeTotal() const
+    {
+        int64_t total{0};
+        for (const DescriptorScriptPubKeyMan* spkm : m_spkms) total += spkm->GetEndRange();
+        return total;
+    }
 };
-}
+} // namespace wallet
 
 #endif // BITCOIN_TEST_FUZZ_UTIL_WALLET_H

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -23,11 +23,18 @@ using util::ToString;
 namespace wallet {
 namespace {
 const TestingSetup* g_setup;
+FuzzedWallet* g_wallet;
 
 void initialize_setup()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
+    static FuzzedWallet fuzzed_wallet{
+        *g_setup->m_node.chain,
+        "fuzzed_wallet_a",
+        "tprv8ZgxMBicQKsPd1QwsGgzfu2pcPYbBosZhJknqreRHgsWx32nNEhMjGQX2cgFL8n6wz9xdDYwLcs78N4nsCo32cxEX8RBtwGsEGgybLiQJfk",
+    };
+    g_wallet = &fuzzed_wallet;
 }
 
 FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
@@ -39,11 +46,8 @@ FUZZ_TARGET(wallet_create_transaction, .init = initialize_setup)
     Chainstate& chainstate{node.chainman->ActiveChainstate()};
     ArgsManager& args = *node.args;
     args.ForceSetArg("-dustrelayfee", ToString(fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, MAX_MONEY)));
-    FuzzedWallet fuzzed_wallet{
-        *g_setup->m_node.chain,
-        "fuzzed_wallet_a",
-        "tprv8ZgxMBicQKsPd1QwsGgzfu2pcPYbBosZhJknqreRHgsWx32nNEhMjGQX2cgFL8n6wz9xdDYwLcs78N4nsCo32cxEX8RBtwGsEGgybLiQJfk",
-    };
+    FuzzedWallet& fuzzed_wallet{*g_wallet};
+    fuzzed_wallet.Reset();
 
     CCoinControl coin_control;
     if (fuzzed_data_provider.ConsumeBool()) coin_control.m_version = fuzzed_data_provider.ConsumeIntegral<unsigned int>();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2493,6 +2493,17 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
     return {};
 }
 
+void CWallet::ClearInMemoryTxStateForTest()
+{
+    AssertLockHeld(cs_wallet);
+    mapWallet.clear();
+    wtxOrdered.clear();
+    mapTxSpends.clear();
+    m_txos.clear();
+    m_locked_coins.clear();
+    nOrderPosNext = 0;
+}
+
 bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& address, const std::string& strName, const std::optional<AddressPurpose>& new_purpose)
 {
     bool fUpdated = false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -809,6 +809,14 @@ public:
     util::Result<void> RemoveTxs(std::vector<Txid>& txs_to_remove) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     util::Result<void> RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs_to_remove) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    /**
+     * Drop all in-memory transaction state: the transactions themselves, the
+     * outputs derived from them, the spends index and any coin locks. The
+     * database, the wallet flags and the ScriptPubKeyMans are left untouched.
+     * This is test-only function for harnesses that reuse a single wallet.
+     */
+    void ClearInMemoryTxStateForTest() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::optional<AddressPurpose>& purpose);
 
     bool DelAddressBook(const CTxDestination& address);


### PR DESCRIPTION
FuzzedWallet was rebuilt for every input. That imports eight
descriptors, and each address it then hands out costs a BIP32
derivation plus three separate WalletBatch transactions (see
DescriptorScriptPubKeyMan::GetNewDestination) - all paid before the
target reaches the code under test.

This PR changes it to build the wallet once in the target's .init hook and 
reset it perinput instead. I benchmarked on my Ubuntu machine without
sanitizers and got a ~6x speedup.