### PR TITLE
refactor: fuzz: remove cost_of_change from coin-grinder fuzz target

### DIFF
--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -92,7 +92,6 @@ FUZZ_TARGET(coin_grinder)
     coin_params.m_effective_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
     coin_params.change_output_size = fuzzed_data_provider.ConsumeIntegralInRange<int>(10, 1000);
     coin_params.change_spend_size = fuzzed_data_provider.ConsumeIntegralInRange<int>(10, 1000);
-    coin_params.m_cost_of_change= coin_params.m_effective_feerate.GetFee(coin_params.change_output_size) + coin_params.m_long_term_feerate.GetFee(coin_params.change_spend_size);
     coin_params.m_change_fee = coin_params.m_effective_feerate.GetFee(coin_params.change_output_size);
     // For other results to be comparable to SRD, we must align the change_target with SRD’s hardcoded behavior
     coin_params.m_min_change_target = CHANGE_LOWER + coin_params.m_change_fee;


### PR DESCRIPTION
coin-grinder selection algorithm does not take cost_of_change as a parameter.

> CoinGrinder doesn’t use coin_params.m_cost_of_change and the comparison of selection results from CoinGrinder, SRD, and Knapsack does not need it either as only the weight of the selections is relevant. So, [line 96](https://github.com/bitcoin/bitcoin/blob/2990bd773551c835ab0b6b59d85730adab2fd428/src/wallet/test/fuzz/coinselection.cpp#L96) in that fuzz test is both incorrect and dead code. It should be removed.

cite: [stackexchange](https://bitcoin.stackexchange.com/questions/130861/difference-between-long-term-fee-rate-and-discard-fee-rate)

verified `coin_grinder` fuzz target still works after removal