### PR TITLE
scripted-diff: [test] Add util/check.h includes for assertions

### DIFF
--- a/ci/lint/01_install.sh
+++ b/ci/lint/01_install.sh
@@ -11,16 +11,13 @@ set -o errexit -o pipefail -o xtrace
 export DEBIAN_FRONTEND=noninteractive
 export CI_RETRY_EXE="/ci_retry"
 
-pushd "/"
-
 ${CI_RETRY_EXE} apt-get update
-# Lint dependencies:
-# - cargo (used to run the lint tests)
-# - curl/xz-utils (to install shellcheck)
-# - git (used in many lint scripts)
-# - gpg (used by verify-commits)
-# - moreutils (used by scripted-diff)
-${CI_RETRY_EXE} apt-get install -y cargo curl xz-utils git gpg moreutils
+${CI_RETRY_EXE} apt-get install -y \
+  cargo  `# to run the lint tests` \
+  curl xz-utils  `# to install shellcheck` \
+  git  `# used in many lint scripts` \
+  gpg  `# used by verify-commits` \
+  moreutils clang-format  `# used by scripted-diff`
 
 # Install Python and create venv using uv (reads version from .python-version)
 uv venv /python_env
@@ -39,5 +36,3 @@ mv "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
 MLC_VERSION=v1.2.0
 curl --fail -L "https://github.com/becheran/mlc/releases/download/${MLC_VERSION}/mlc-$(uname --machine)-linux" -o "/usr/bin/mlc"
 chmod +x /usr/bin/mlc
-
-popd || exit

--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -2,21 +2,21 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <primitives/transaction.h>
 #include <capnp/capability.h>
 #include <capnp/rpc.h>
+#include <ipc/test/fuzz/ipc_fuzz.capnp.h>
+#include <ipc/test/fuzz/ipc_fuzz.capnp.proxy.h>
+#include <ipc/test/fuzz/ipc_fuzz.h>
 #include <ipc/util.h>
 #include <kj/memory.h>
 #include <mp/proxy-io.h>
 #include <mp/proxy.h>
+#include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
-#include <ipc/test/fuzz/ipc_fuzz.capnp.h>
-#include <ipc/test/fuzz/ipc_fuzz.capnp.proxy.h>
-#include <ipc/test/fuzz/ipc_fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 
 #include <future>
 #include <memory>

--- a/src/ipc/test/fuzz/ipc.cpp
+++ b/src/ipc/test/fuzz/ipc.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <primitives/transaction.h>
 #include <capnp/capability.h>
 #include <capnp/rpc.h>

--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <interfaces/init.h>
 #include <ipc/capnp/mining.capnp.h>
 #include <ipc/capnp/protocol.h>
@@ -11,21 +10,22 @@
 #include <ipc/test/ipc_test.capnp.h>
 #include <ipc/test/ipc_test.capnp.proxy.h>
 #include <ipc/test/ipc_test.h>
+#include <kj/common.h>
+#include <kj/memory.h>
+#include <kj/test.h>
 #include <mp/proxy-types.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/log.h>
 #include <validation.h>
 
-#include <future>
-#include <thread>
-#include <kj/common.h>
-#include <kj/memory.h>
-#include <kj/test.h>
-#include <stdexcept>
-
 #include <boost/test/unit_test.hpp>
+
+#include <future>
+#include <stdexcept>
+#include <thread>
 
 static_assert(ipc::capnp::messages::MAX_MONEY == MAX_MONEY);
 static_assert(ipc::capnp::messages::MAX_DOUBLE == std::numeric_limits<double>::max());

--- a/src/ipc/test/ipc_tests.cpp
+++ b/src/ipc/test/ipc_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <interfaces/init.h>
 #include <ipc/capnp/mining.capnp.h>
 #include <ipc/capnp/protocol.h>

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -2,34 +2,33 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <qt/test/addressbooktests.h>
-#include <qt/test/util.h>
-#include <test/util/setup_common.h>
 
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
+#include <key.h>
+#include <key_io.h>
 #include <qt/addressbookpage.h>
 #include <qt/clientmodel.h>
 #include <qt/editaddressdialog.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
 #include <qt/qvalidatedlineedit.h>
+#include <qt/test/util.h>
 #include <qt/walletmodel.h>
-
-#include <key.h>
-#include <key_io.h>
-#include <wallet/wallet.h>
+#include <test/util/setup_common.h>
+#include <util/check.h>
 #include <wallet/test/util.h>
+#include <wallet/wallet.h>
 #include <walletinitinterface.h>
-
-#include <chrono>
 
 #include <QApplication>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QTableView>
 #include <QTimer>
+
+#include <chrono>
 
 using wallet::AddWallet;
 using wallet::CWallet;

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <qt/test/addressbooktests.h>
 #include <qt/test/util.h>
 #include <test/util/setup_common.h>

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <qt/test/apptests.h>
 
 #include <chainparams.h>
@@ -13,6 +12,7 @@
 #include <qt/networkstyle.h>
 #include <qt/rpcconsole.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <QAction>
@@ -24,8 +24,8 @@
 #include <QTest>
 #include <QTextEdit>
 #include <QtGlobal>
-#include <QtTest/QtTestWidgets>
 #include <QtTest/QtTestGui>
+#include <QtTest/QtTestWidgets>
 
 namespace {
 //! Regex find a string group inside of the console output

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <qt/test/apptests.h>
 
 #include <chainparams.h>

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <qt/test/wallettests.h>
 #include <qt/test/util.h>
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -2,11 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <qt/test/wallettests.h>
-#include <qt/test/util.h>
 
-#include <wallet/coincontrol.h>
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
 #include <key_io.h>
@@ -22,30 +19,33 @@
 #include <qt/recentrequeststablemodel.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/sendcoinsentry.h>
+#include <qt/test/util.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
 #include <script/solver.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <validation.h>
+#include <wallet/coincontrol.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
-
-#include <chrono>
-#include <memory>
 
 #include <QAbstractButton>
 #include <QAction>
 #include <QApplication>
 #include <QCheckBox>
 #include <QClipboard>
+#include <QDialogButtonBox>
+#include <QListView>
 #include <QObject>
 #include <QPushButton>
+#include <QTextEdit>
 #include <QTimer>
 #include <QVBoxLayout>
-#include <QTextEdit>
-#include <QListView>
-#include <QDialogButtonBox>
+
+#include <chrono>
+#include <memory>
 
 using wallet::AddWallet;
 using wallet::CWallet;

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chain.h>
 #include <node/blockstorage.h>
 #include <rpc/blockchain.h>

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chain.h>
 #include <node/blockstorage.h>
 #include <rpc/blockchain.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/string.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -2,17 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <blockencodings.h>
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <pow.h>
 #include <streams.h>
-#include <test/util/random.h>
-#include <test/util/txmempool.h>
-
 #include <test/util/common.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
+#include <util/check.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <blockencodings.h>
 #include <chainparams.h>
 #include <consensus/merkle.h>

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -2,17 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <test/data/blockfilters.json.h>
-#include <test/util/common.h>
-
 #include <blockfilter.h>
 #include <core_io.h>
 #include <primitives/block.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/data/blockfilters.json.h>
+#include <test/util/common.h>
 #include <undo.h>
 #include <univalue.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/data/blockfilters.json.h>
 #include <test/util/common.h>
 

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <clientversion.h>

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -2,22 +2,22 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <clientversion.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/kernel_notifications.h>
-#include <script/solver.h>
 #include <primitives/block.h>
-#include <util/chaintype.h>
-#include <validation.h>
-
-#include <boost/test/unit_test.hpp>
+#include <script/solver.h>
 #include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
+#include <util/chaintype.h>
+#include <util/check.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
 
 using kernel::CBlockFileInfo;
 using node::STORAGE_HEADER_BYTES;

--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/util/setup_common.h>
 #include <util/btcsignals.h>
 

--- a/src/test/btcsignals_tests.cpp
+++ b/src/test/btcsignals_tests.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/util/setup_common.h>
 #include <util/btcsignals.h>
+#include <util/check.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <validation.h>

--- a/src/test/chainstate_write_tests.cpp
+++ b/src/test/chainstate_write_tests.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <checkqueue.h>
 #include <common/args.h>
 #include <sync.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <checkqueue.h>
 #include <common/args.h>
 #include <sync.h>

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <compressor.h>
 #include <script/script.h>
 #include <test/util/random.h>

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -2,15 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <compressor.h>
 #include <script/script.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
-
-#include <cstdint>
+#include <util/check.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <cstdint>
 
 // amounts 0.00000001 .. 0.00100000
 #define NUM_MULTIPLES_UNIT 100000

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/aes.h>
 #include <crypto/chacha20.h>
 #include <crypto/chacha20poly1305.h>

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -2,31 +2,31 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/aes.h>
 #include <crypto/chacha20.h>
 #include <crypto/chacha20poly1305.h>
 #include <crypto/hkdf_sha256_32.h>
 #include <crypto/hmac_sha256.h>
 #include <crypto/hmac_sha512.h>
+#include <crypto/muhash.h>
 #include <crypto/poly1305.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
 #include <crypto/sha3.h>
 #include <crypto/sha512.h>
-#include <crypto/muhash.h>
 #include <random.h>
 #include <streams.h>
 #include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <algorithm>
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
 
 using namespace util::hex_literals;
 

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <cuckoocache.h>
 #include <random.h>
 #include <script/sigcache.h>

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <cuckoocache.h>
 #include <random.h>
 #include <script/sigcache.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <clientversion.h>
 #include <common/args.h>
 #include <flatfile.h>

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <clientversion.h>
 #include <common/args.h>
 #include <flatfile.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/fuzz/addition_overflow.cpp
+++ b/src/test/fuzz/addition_overflow.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 #include <util/overflow.h>
 
 #include <cstdint>

--- a/src/test/fuzz/addition_overflow.cpp
+++ b/src/test/fuzz/addition_overflow.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <addrdb.h>
 #include <addrman.h>
+
+#include <addrdb.h>
 #include <addrman_impl.h>
 #include <chainparams.h>
 #include <common/args.h>
@@ -18,6 +18,7 @@
 #include <test/util/time.h>
 #include <util/asmap.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <ctime>

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addrdb.h>
 #include <addrman.h>
 #include <addrman_impl.h>
@@ -18,7 +19,6 @@
 #include <util/asmap.h>
 #include <util/chaintype.h>
 
-#include <cassert>
 #include <cstdint>
 #include <ctime>
 #include <optional>

--- a/src/test/fuzz/asmap.cpp
+++ b/src/test/fuzz/asmap.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <util/asmap.h>
+
 #include <netaddress.h>
 #include <netgroup.h>
 #include <test/fuzz/fuzz.h>
-#include <util/asmap.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <cstdint>

--- a/src/test/fuzz/asmap.cpp
+++ b/src/test/fuzz/asmap.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <netaddress.h>
 #include <netgroup.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <netaddress.h>
-#include <util/asmap.h>
 #include <test/fuzz/fuzz.h>
+#include <util/asmap.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <netaddress.h>
 #include <util/asmap.h>
 #include <test/fuzz/fuzz.h>
@@ -10,7 +11,6 @@
 #include <optional>
 #include <vector>
 
-#include <cassert>
 
 std::vector<std::byte> BitsToBytes(std::span<const uint8_t> bits) noexcept
 {

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <banman.h>
 #include <common/args.h>
 #include <netaddress.h>
@@ -14,7 +15,6 @@
 #include <util/fs.h>
 #include <util/readwritefile.h>
 
-#include <cassert>
 #include <cstdint>
 #include <limits>
 #include <string>

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <banman.h>
+
 #include <common/args.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -12,6 +12,7 @@
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/readwritefile.h>
 

--- a/src/test/fuzz/base_encode_decode.cpp
+++ b/src/test/fuzz/base_encode_decode.cpp
@@ -2,19 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <test/fuzz/fuzz.h>
-
 #include <base58.h>
 #include <psbt.h>
 #include <span.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
+#include <ranges>
 #include <string>
 #include <vector>
-#include <ranges>
 
 using util::TrimStringView;
 

--- a/src/test/fuzz/base_encode_decode.cpp
+++ b/src/test/fuzz/base_encode_decode.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/fuzz.h>
 
 #include <base58.h>
@@ -11,7 +12,6 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 
-#include <cassert>
 #include <string>
 #include <vector>
 #include <ranges>

--- a/src/test/fuzz/bech32.cpp
+++ b/src/test/fuzz/bech32.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <bech32.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <util/strencodings.h>
 
-#include <cassert>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/bech32.cpp
+++ b/src/test/fuzz/bech32.cpp
@@ -2,10 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <bech32.h>
-#include <test/fuzz/fuzz.h>
+
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <cstdint>

--- a/src/test/fuzz/bip324.cpp
+++ b/src/test/fuzz/bip324.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <bip324.h>
+
 #include <chainparams.h>
 #include <random.h>
 #include <span.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/src/test/fuzz/bip324.cpp
+++ b/src/test/fuzz/bip324.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <bip324.h>
 #include <chainparams.h>
 #include <random.h>

--- a/src/test/fuzz/bitdeque.cpp
+++ b/src/test/fuzz/bitdeque.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/bitdeque.cpp
+++ b/src/test/fuzz/bitdeque.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <util/bitdeque.h>
+
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>
-#include <util/bitdeque.h>
+#include <util/check.h>
 
 #include <deque>
 #include <vector>

--- a/src/test/fuzz/bitset.cpp
+++ b/src/test/fuzz/bitset.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <random.h>
 #include <span.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/bitset.cpp
+++ b/src/test/fuzz/bitset.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <util/bitset.h>
+
 #include <random.h>
 #include <span.h>
 #include <test/fuzz/util.h>
-#include <util/bitset.h>
+#include <util/check.h>
 
 #include <bitset>
 #include <vector>

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
@@ -14,7 +15,6 @@
 #include <util/chaintype.h>
 #include <validation.h>
 
-#include <cassert>
 #include <string>
 
 void initialize_block()

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -2,17 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <primitives/block.h>
+
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <core_memusage.h>
-#include <primitives/block.h>
 #include <pubkey.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <string>

--- a/src/test/fuzz/block_header.cpp
+++ b/src/test/fuzz/block_header.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <primitives/block.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <uint256.h>
 
-#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/src/test/fuzz/block_header.cpp
+++ b/src/test/fuzz/block_header.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <primitives/block.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <uint256.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <node/blockstorage.h>

--- a/src/test/fuzz/block_index.cpp
+++ b/src/test/fuzz/block_index.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <node/blockstorage.h>
@@ -12,6 +11,7 @@
 #include <test/util/setup_common.h>
 #include <txdb.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 #include <validation.h>
 
 using kernel::CBlockFileInfo;

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
-#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <flatfile.h>
@@ -15,6 +14,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <test/util/validation.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <ranges>

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
+#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <flatfile.h>

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <common/bloom.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <uint256.h>
+#include <util/check.h>
 
 #include <limits>
 #include <optional>

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/bloom.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -9,7 +10,6 @@
 #include <test/fuzz/util.h>
 #include <uint256.h>
 
-#include <cassert>
 #include <limits>
 #include <optional>
 #include <vector>

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <cluster_linearize.h>
+
 #include <random.h>
 #include <serialize.h>
 #include <streams.h>
@@ -11,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/util/cluster_linearize.h>
 #include <util/bitset.h>
+#include <util/check.h>
 #include <util/feefrac.h>
 
 #include <algorithm>

--- a/src/test/fuzz/cluster_linearize.cpp
+++ b/src/test/fuzz/cluster_linearize.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <cluster_linearize.h>
 #include <random.h>
 #include <serialize.h>

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <coins.h>
 #include <consensus/amount.h>
 #include <consensus/tx_check.h>
@@ -20,6 +19,7 @@
 #include <test/util/coins.h>
 #include <test/util/setup_common.h>
 #include <txdb.h>
+#include <util/check.h>
 #include <util/hasher.h>
 #include <util/threadpool.h>
 

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <coins.h>
 #include <consensus/amount.h>
 #include <consensus/tx_check.h>
@@ -22,7 +23,6 @@
 #include <util/hasher.h>
 #include <util/threadpool.h>
 
-#include <cassert>
 #include <algorithm>
 #include <cstdint>
 #include <functional>

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <coins.h>
 #include <crypto/sha256.h>
 #include <kernel/chainstatemanager_opts.h>
@@ -12,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/threadpool.h>
 
 #include <cstdint>

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <coins.h>
 #include <crypto/sha256.h>
 #include <kernel/chainstatemanager_opts.h>
@@ -13,7 +14,6 @@
 #include <test/util/setup_common.h>
 #include <util/threadpool.h>
 
-#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <optional>

--- a/src/test/fuzz/connect_block.cpp
+++ b/src/test/fuzz/connect_block.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addresstype.h>
 #include <chain.h>
 #include <consensus/amount.h>

--- a/src/test/fuzz/connect_block.cpp
+++ b/src/test/fuzz/connect_block.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <addresstype.h>
 #include <chain.h>
 #include <consensus/amount.h>
@@ -24,6 +23,7 @@
 #include <test/util/time.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addrman.h>
 #include <chainparams.h>
 #include <common/args.h>

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <addrman.h>
 #include <chainparams.h>
 #include <common/args.h>
@@ -17,6 +16,7 @@
 #include <test/fuzz/util/threadinterrupt.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <util/translation.h>
 
 #include <cstdint>

--- a/src/test/fuzz/crypto_aes256.cpp
+++ b/src/test/fuzz/crypto_aes256.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/aes.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cassert>
 #include <cstdint>
 #include <vector>
 

--- a/src/test/fuzz/crypto_aes256.cpp
+++ b/src/test/fuzz/crypto_aes256.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/aes.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/crypto_aes256cbc.cpp
+++ b/src/test/fuzz/crypto_aes256cbc.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/aes.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cassert>
 #include <cstdint>
 #include <vector>
 

--- a/src/test/fuzz/crypto_aes256cbc.cpp
+++ b/src/test/fuzz/crypto_aes256cbc.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/aes.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/crypto_chacha20.cpp
+++ b/src/test/fuzz/crypto_chacha20.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/chacha20.h>
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/crypto_chacha20.cpp
+++ b/src/test/fuzz/crypto_chacha20.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/chacha20.h>
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <array>
 #include <cstddef>

--- a/src/test/fuzz/crypto_chacha20poly1305.cpp
+++ b/src/test/fuzz/crypto_chacha20poly1305.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/chacha20poly1305.h>
 #include <random.h>
 #include <span.h>

--- a/src/test/fuzz/crypto_chacha20poly1305.cpp
+++ b/src/test/fuzz/crypto_chacha20poly1305.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/chacha20poly1305.h>
 #include <random.h>
 #include <span.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/test/fuzz/crypto_common.cpp
+++ b/src/test/fuzz/crypto_common.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/common.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <array>
-#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <vector>

--- a/src/test/fuzz/crypto_common.cpp
+++ b/src/test/fuzz/crypto_common.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/common.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <array>
 #include <cstdint>

--- a/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
+++ b/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/chacha20.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
+++ b/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/chacha20.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/crypto_poly1305.cpp
+++ b/src/test/fuzz/crypto_poly1305.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/poly1305.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/crypto_poly1305.cpp
+++ b/src/test/fuzz/crypto_poly1305.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <crypto/poly1305.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/cuckoocache.cpp
+++ b/src/test/fuzz/cuckoocache.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <cuckoocache.h>
 #include <script/sigcache.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/cuckoocache.cpp
+++ b/src/test/fuzz/cuckoocache.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <cuckoocache.h>
+
 #include <script/sigcache.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/dbwrapper.cpp
+++ b/src/test/fuzz/dbwrapper.cpp
@@ -19,7 +19,6 @@
 #include <leveldb/helpers/memenv/memenv.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <deque>
 #include <functional>

--- a/src/test/fuzz/decode_tx.cpp
+++ b/src/test/fuzz/decode_tx.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <core_io.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <cstdint>

--- a/src/test/fuzz/decode_tx.cpp
+++ b/src/test/fuzz/decode_tx.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <core_io.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/fuzz.h>
 #include <util/strencodings.h>
 
-#include <cassert>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chainparams.h>
 #include <key_io.h>
 #include <pubkey.h>
@@ -10,6 +9,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util/descriptor.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 //! The converter of mocked descriptors, needs to be initialized when the target is.

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <key_io.h>
 #include <pubkey.h>

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addrdb.h>
 #include <addrman.h>
 #include <addrman_impl.h>

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <addrdb.h>
 #include <addrman.h>
 #include <addrman_impl.h>
@@ -30,6 +29,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <undo.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <exception>

--- a/src/test/fuzz/difference_formatter.cpp
+++ b/src/test/fuzz/difference_formatter.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <blockencodings.h>
 #include <streams.h>
 #include <random.h>

--- a/src/test/fuzz/difference_formatter.cpp
+++ b/src/test/fuzz/difference_formatter.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <blockencodings.h>
-#include <streams.h>
 #include <random.h>
+#include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 
 #include <vector>
 

--- a/src/test/fuzz/fee_rate.cpp
+++ b/src/test/fuzz/fee_rate.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/amount.h>
 #include <policy/feerate.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/fee_rate.cpp
+++ b/src/test/fuzz/fee_rate.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <consensus/amount.h>
 #include <policy/feerate.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <limits>

--- a/src/test/fuzz/feefrac.cpp
+++ b/src/test/fuzz/feefrac.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <arith_uint256.h>
 #include <policy/feerate.h>
 #include <util/feefrac.h>

--- a/src/test/fuzz/feefrac.cpp
+++ b/src/test/fuzz/feefrac.cpp
@@ -2,16 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <util/feefrac.h>
+
 #include <arith_uint256.h>
 #include <policy/feerate.h>
-#include <util/feefrac.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
-#include <compare>
 #include <cmath>
+#include <compare>
 #include <cstdint>
 #include <iostream>
 

--- a/src/test/fuzz/feeratediagram.cpp
+++ b/src/test/fuzz/feeratediagram.cpp
@@ -2,16 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <cstdint>
-
-#include <vector>
-
-#include <util/feefrac.h>
 #include <policy/rbf.h>
-
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
+#include <util/feefrac.h>
+
+#include <cstdint>
+#include <vector>
 
 
 namespace {

--- a/src/test/fuzz/feeratediagram.cpp
+++ b/src/test/fuzz/feeratediagram.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <cstdint>
 
 #include <vector>
@@ -12,7 +13,6 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cassert>
 
 namespace {
 

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/messages.h>
 #include <consensus/amount.h>
 #include <policy/fees/block_policy_estimator.h>

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <util/fees.h>
+
 #include <common/messages.h>
 #include <consensus/amount.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <util/fees.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/flatfile.cpp
+++ b/src/test/fuzz/flatfile.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <flatfile.h>
+
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/flatfile.cpp
+++ b/src/test/fuzz/flatfile.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <flatfile.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/src/test/fuzz/float.cpp
+++ b/src/test/fuzz/float.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <memusage.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/serfloat.h>
 
-#include <cassert>
 #include <cmath>
 #include <limits>
 #include <optional>

--- a/src/test/fuzz/float.cpp
+++ b/src/test/fuzz/float.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <memusage.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 #include <util/serfloat.h>
 
 #include <cmath>

--- a/src/test/fuzz/golomb_rice.cpp
+++ b/src/test/fuzz/golomb_rice.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <blockfilter.h>
 #include <serialize.h>
 #include <streams.h>
@@ -11,6 +10,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/random.h>
 #include <util/bytevectorhash.h>
+#include <util/check.h>
 #include <util/golombrice.h>
 
 #include <algorithm>

--- a/src/test/fuzz/golomb_rice.cpp
+++ b/src/test/fuzz/golomb_rice.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <blockfilter.h>
 #include <serialize.h>
 #include <streams.h>
@@ -13,7 +14,6 @@
 #include <util/golombrice.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <iosfwd>
 #include <unordered_set>

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit.
 
+#include <util/check.h>
 #include <arith_uint256.h>
 #include <chain.h>
 #include <chainparams.h>

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -2,17 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit.
 
-#include <util/check.h>
+#include <headerssync.h>
+
 #include <arith_uint256.h>
 #include <chain.h>
 #include <chainparams.h>
-#include <headerssync.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/time.h>
 #include <validation.h>
 

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <core_io.h>
 #include <primitives/block.h>
 #include <primitives/transaction_identifier.h>
@@ -13,7 +14,6 @@
 #include <util/strencodings.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <core_io.h>
 #include <primitives/block.h>
 #include <primitives/transaction_identifier.h>
@@ -11,6 +10,7 @@
 #include <test/fuzz/fuzz.h>
 #include <uint256.h>
 #include <univalue.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <algorithm>

--- a/src/test/fuzz/http_request.cpp
+++ b/src/test/fuzz/http_request.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <httpserver.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -10,7 +11,6 @@
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 
-#include <cassert>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/http_request.cpp
+++ b/src/test/fuzz/http_request.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <httpserver.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 #include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -34,7 +34,6 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 
-#include <cassert>
 #include <chrono>
 #include <limits>
 #include <set>

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <key.h>
 #include <key_io.h>
@@ -23,7 +24,6 @@
 #include <util/strencodings.h>
 
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <numeric>

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <chainparams.h>
 #include <key.h>
+
+#include <chainparams.h>
 #include <key_io.h>
 #include <outputtype.h>
 #include <policy/policy.h>
@@ -21,6 +21,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/random.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <array>

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <key_io.h>
 #include <test/fuzz/fuzz.h>
 #include <util/chaintype.h>
 
-#include <cassert>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <chainparams.h>
 #include <key_io.h>
+
+#include <chainparams.h>
 #include <test/fuzz/fuzz.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/kitchen_sink.cpp
+++ b/src/test/fuzz/kitchen_sink.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/messages.h>
 #include <merkleblock.h>
 #include <node/types.h>

--- a/src/test/fuzz/kitchen_sink.cpp
+++ b/src/test/fuzz/kitchen_sink.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <common/messages.h>
 #include <merkleblock.h>
 #include <node/types.h>
@@ -11,6 +10,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 #include <util/translation.h>
 
 #include <array>

--- a/src/test/fuzz/locale.cpp
+++ b/src/test/fuzz/locale.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
-#include <cassert>
 #include <clocale>
 #include <cstdint>
 #include <locale>

--- a/src/test/fuzz/locale.cpp
+++ b/src/test/fuzz/locale.cpp
@@ -2,16 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <locale>
+
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
 #include <clocale>
 #include <cstdint>
-#include <locale>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/merkle.cpp
+++ b/src/test/fuzz/merkle.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <consensus/merkle.h>
-#include <test/fuzz/fuzz.h>
+
+#include <hash.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/str.h>
+#include <util/check.h>
 #include <util/strencodings.h>
-#include <hash.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/merkle.cpp
+++ b/src/test/fuzz/merkle.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/merkle.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -10,7 +11,6 @@
 #include <util/strencodings.h>
 #include <hash.h>
 
-#include <cassert>
 #include <cstdint>
 #include <vector>
 

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chainparams.h>
 #include <common/signmessage.h>
 #include <key_io.h>
@@ -10,6 +9,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <cstdint>

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <common/signmessage.h>
 #include <key_io.h>
@@ -11,7 +12,6 @@
 #include <util/chaintype.h>
 #include <util/strencodings.h>
 
-#include <cassert>
 #include <cstdint>
 #include <iostream>
 #include <string>

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <core_io.h>
 #include <hash.h>
 #include <key.h>

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -2,17 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <script/miniscript.h>
+
 #include <core_io.h>
 #include <hash.h>
 #include <key.h>
-#include <script/miniscript.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/descriptor.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <algorithm>

--- a/src/test/fuzz/muhash.cpp
+++ b/src/test/fuzz/muhash.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <arith_uint256.h>
 #include <crypto/muhash.h>
+
+#include <arith_uint256.h>
 #include <span.h>
-#include <uint256.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <uint256.h>
+#include <util/check.h>
 
 #include <algorithm>
 #include <array>

--- a/src/test/fuzz/muhash.cpp
+++ b/src/test/fuzz/muhash.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <arith_uint256.h>
 #include <crypto/muhash.h>
 #include <span.h>

--- a/src/test/fuzz/multiplication_overflow.cpp
+++ b/src/test/fuzz/multiplication_overflow.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/multiplication_overflow.cpp
+++ b/src/test/fuzz/multiplication_overflow.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <chainparams.h>
 #include <net.h>
+
+#include <chainparams.h>
 #include <net_permissions.h>
 #include <netaddress.h>
 #include <protocol.h>
@@ -18,6 +18,7 @@
 #include <test/util/time.h>
 #include <util/asmap.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <cstdint>

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <net.h>
 #include <net_permissions.h>

--- a/src/test/fuzz/net_permissions.cpp
+++ b/src/test/fuzz/net_permissions.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <net_permissions.h>
 #include <netbase.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -10,7 +11,6 @@
 #include <test/fuzz/util/net.h>
 #include <util/translation.h>
 
-#include <cassert>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/net_permissions.cpp
+++ b/src/test/fuzz/net_permissions.cpp
@@ -2,13 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <net_permissions.h>
+
 #include <netbase.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
+#include <util/check.h>
 #include <util/translation.h>
 
 #include <cstdint>

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util/net.h>
 #include <test/util/random.h>
 
-#include <cassert>
 #include <cstdint>
 #include <vector>
 

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -2,12 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <netaddress.h>
+
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util/net.h>
 #include <test/util/random.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/netbase_dns_lookup.cpp
+++ b/src/test/fuzz/netbase_dns_lookup.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/netbase_dns_lookup.cpp
+++ b/src/test/fuzz/netbase_dns_lookup.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util/net.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <net.h>
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -10,7 +11,6 @@
 #include <test/fuzz/util/net.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <vector>

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <net.h>
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
+#include <util/check.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <arith_uint256.h>
 #include <blockencodings.h>
 #include <net.h>
@@ -17,6 +16,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
 
 namespace {

--- a/src/test/fuzz/p2p_headers_presync.cpp
+++ b/src/test/fuzz/p2p_headers_presync.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <arith_uint256.h>
 #include <blockencodings.h>
 #include <net.h>

--- a/src/test/fuzz/p2p_private_broadcast.cpp
+++ b/src/test/fuzz/p2p_private_broadcast.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <banman.h>
 #include <net.h>
 #include <net_processing.h>
@@ -16,6 +15,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <test/util/validation.h>
+#include <util/check.h>
 #include <util/time.h>
 #include <validationinterface.h>
 

--- a/src/test/fuzz/p2p_private_broadcast.cpp
+++ b/src/test/fuzz/p2p_private_broadcast.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <banman.h>
 #include <net.h>
 #include <net_processing.h>

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chainparams.h>
 #include <hash.h>
 #include <net.h>
@@ -12,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <hash.h>
 #include <net.h>
@@ -13,7 +14,6 @@
 #include <util/chaintype.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <limits>
 #include <optional>

--- a/src/test/fuzz/parse_hd_keypath.cpp
+++ b/src/test/fuzz/parse_hd_keypath.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/bip32.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/parse_hd_keypath.cpp
+++ b/src/test/fuzz/parse_hd_keypath.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/bip32.h>
 
-#include <cassert>
 #include <cstdint>
 #include <vector>
 

--- a/src/test/fuzz/parse_iso8601.cpp
+++ b/src/test/fuzz/parse_iso8601.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <cstdint>

--- a/src/test/fuzz/parse_iso8601.cpp
+++ b/src/test/fuzz/parse_iso8601.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <util/time.h>
 
-#include <cassert>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/parse_numbers.cpp
+++ b/src/test/fuzz/parse_numbers.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/fuzz.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
-#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/src/test/fuzz/parse_numbers.cpp
+++ b/src/test/fuzz/parse_numbers.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/test/fuzz/poolresource.cpp
+++ b/src/test/fuzz/poolresource.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <random.h>
 #include <span.h>
 #include <support/allocators/pool.h>
@@ -11,6 +10,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/poolresourcetester.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <tuple>

--- a/src/test/fuzz/poolresource.cpp
+++ b/src/test/fuzz/poolresource.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <random.h>
 #include <span.h>
 #include <support/allocators/pool.h>

--- a/src/test/fuzz/prevector.cpp
+++ b/src/test/fuzz/prevector.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <prevector.h>
 #include <serialize.h>
 #include <streams.h>

--- a/src/test/fuzz/prevector.cpp
+++ b/src/test/fuzz/prevector.cpp
@@ -2,12 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <prevector.h>
+
 #include <serialize.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 
 #include <ranges>
 #include <vector>

--- a/src/test/fuzz/primitives_transaction.cpp
+++ b/src/test/fuzz/primitives_transaction.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/primitives_transaction.cpp
+++ b/src/test/fuzz/primitives_transaction.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/private_broadcast.cpp
+++ b/src/test/fuzz/private_broadcast.cpp
@@ -2,18 +2,19 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <private_broadcast.h>
+
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
 #include <net.h>
 #include <primitives/transaction.h>
-#include <private_broadcast.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <util/overflow.h>
 #include <util/time.h>
 

--- a/src/test/fuzz/private_broadcast.cpp
+++ b/src/test/fuzz/private_broadcast.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
 #include <net.h>

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/bloom.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -9,7 +10,6 @@
 #include <test/util/random.h>
 #include <uint256.h>
 
-#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <common/bloom.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/random.h>
 #include <uint256.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <base58.h>
 #include <key.h>
 #include <key_io.h>
@@ -25,7 +26,6 @@
 #include <util/time.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <base58.h>
 #include <key.h>
 #include <key_io.h>
@@ -21,6 +20,7 @@
 #include <tinyformat.h>
 #include <uint256.h>
 #include <univalue.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -2,7 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <script/script.h>
+
 #include <chainparams.h>
 #include <compressor.h>
 #include <core_io.h>
@@ -13,7 +14,6 @@
 #include <rpc/util.h>
 #include <script/descriptor.h>
 #include <script/interpreter.h>
-#include <script/script.h>
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
@@ -24,6 +24,7 @@
 #include <test/fuzz/util.h>
 #include <univalue.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <compressor.h>
 #include <core_io.h>
@@ -25,7 +26,6 @@
 #include <util/chaintype.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/src/test/fuzz/script_descriptor_cache.cpp
+++ b/src/test/fuzz/script_descriptor_cache.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <pubkey.h>
 #include <script/descriptor.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/script_descriptor_cache.cpp
+++ b/src/test/fuzz/script_descriptor_cache.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <pubkey.h>
 #include <script/descriptor.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -10,7 +11,6 @@
 #include <test/fuzz/fuzz.h>
 #include <test/util/script.h>
 
-#include <cassert>
 #include <ios>
 #include <utility>
 #include <vector>

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -10,6 +9,7 @@
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
 #include <test/util/script.h>
+#include <util/check.h>
 
 #include <ios>
 #include <utility>

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <key.h>
 #include <psbt.h>
@@ -17,7 +18,6 @@
 #include <util/chaintype.h>
 #include <util/translation.h>
 
-#include <cassert>
 #include <cstdint>
 #include <iostream>
 #include <map>

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chainparams.h>
 #include <key.h>
 #include <psbt.h>
@@ -16,6 +15,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/transaction_utils.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/translation.h>
 
 #include <cstdint>

--- a/src/test/fuzz/scriptnum_ops.cpp
+++ b/src/test/fuzz/scriptnum_ops.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <script/script.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <limits>

--- a/src/test/fuzz/scriptnum_ops.cpp
+++ b/src/test/fuzz/scriptnum_ops.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <script/script.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cassert>
 #include <cstdint>
 #include <limits>
 #include <vector>

--- a/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
+++ b/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <key.h>
 #include <secp256k1.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
+++ b/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <key.h>
 #include <secp256k1.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/span.cpp
+++ b/src/test/fuzz/span.cpp
@@ -7,7 +7,6 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -2,7 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <util/string.h>
+
 #include <blockfilter.h>
 #include <clientversion.h>
 #include <common/args.h>
@@ -24,9 +25,9 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/check.h>
 #include <util/fees.h>
 #include <util/strencodings.h>
-#include <util/string.h>
 #include <util/translation.h>
 
 #include <cstdint>

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <blockfilter.h>
 #include <clientversion.h>
 #include <common/args.h>
@@ -28,7 +29,6 @@
 #include <util/string.h>
 #include <util/translation.h>
 
-#include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <ios>

--- a/src/test/fuzz/threadpool.cpp
+++ b/src/test/fuzz/threadpool.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <logging.h>
 #include <util/threadpool.h>
 
+#include <logging.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 
 #include <atomic>
 #include <future>

--- a/src/test/fuzz/threadpool.cpp
+++ b/src/test/fuzz/threadpool.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <logging.h>
 #include <util/threadpool.h>
 

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <coins.h>
 #include <consensus/tx_check.h>
@@ -20,7 +21,6 @@
 #include <util/rbf.h>
 #include <validation.h>
 
-#include <cassert>
 
 void initialize_transaction()
 {

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -2,7 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <primitives/transaction.h>
+
 #include <chainparams.h>
 #include <coins.h>
 #include <consensus/tx_check.h>
@@ -12,12 +13,12 @@
 #include <core_memusage.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
-#include <primitives/transaction.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
 #include <test/util/random.h>
 #include <univalue.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/rbf.h>
 #include <validation.h>
 

--- a/src/test/fuzz/tx_in.cpp
+++ b/src/test/fuzz/tx_in.cpp
@@ -9,7 +9,6 @@
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
 
-#include <cassert>
 
 FUZZ_TARGET(tx_in)
 {

--- a/src/test/fuzz/tx_out.cpp
+++ b/src/test/fuzz/tx_out.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/validation.h>
 #include <core_memusage.h>
 #include <policy/feerate.h>

--- a/src/test/fuzz/tx_out.cpp
+++ b/src/test/fuzz/tx_out.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <consensus/validation.h>
 #include <core_memusage.h>
 #include <policy/feerate.h>
@@ -10,6 +9,7 @@
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 
 FUZZ_TARGET(tx_out)
 {

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/validation.h>
 #include <node/context.h>
 #include <node/mempool_args.h>

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <node/txdownloadman.h>
+
 #include <consensus/validation.h>
 #include <node/context.h>
 #include <node/mempool_args.h>
 #include <node/miner.h>
-#include <node/txdownloadman.h>
 #include <node/txdownloadman_impl.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -19,6 +19,7 @@
 #include <test/util/time.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
+#include <util/check.h>
 #include <util/hasher.h>
 #include <util/rbf.h>
 #include <util/time.h>

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <txgraph.h>
+
 #include <cluster_linearize.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/util/cluster_linearize.h>
 #include <test/util/random.h>
-#include <txgraph.h>
 #include <util/bitset.h>
+#include <util/check.h>
 #include <util/feefrac.h>
 
 #include <algorithm>

--- a/src/test/fuzz/txgraph.cpp
+++ b/src/test/fuzz/txgraph.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <cluster_linearize.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/txrequest.cpp
+++ b/src/test/fuzz/txrequest.cpp
@@ -2,13 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <txrequest.h>
+
 #include <crypto/common.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/fuzz.h>
-#include <txrequest.h>
+#include <util/check.h>
 
 #include <bitset>
 #include <cstdint>

--- a/src/test/fuzz/txrequest.cpp
+++ b/src/test/fuzz/txrequest.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <crypto/common.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_H
 #define BITCOIN_TEST_FUZZ_UTIL_H
 
+#include <util/check.h>
 #include <addresstype.h>
 #include <arith_uint256.h>
 #include <coins.h>

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_H
 #define BITCOIN_TEST_FUZZ_UTIL_H
 
-#include <util/check.h>
 #include <addresstype.h>
 #include <arith_uint256.h>
 #include <coins.h>
@@ -22,6 +21,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <algorithm>

--- a/src/test/fuzz/util/mempool.cpp
+++ b/src/test/fuzz/util/mempool.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <kernel/mempool_entry.h>
@@ -10,7 +11,6 @@
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/mempool.h>
 
-#include <cassert>
 #include <cstdint>
 #include <limits>
 

--- a/src/test/fuzz/util/mempool.cpp
+++ b/src/test/fuzz/util/mempool.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <test/fuzz/util/mempool.h>
+
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <kernel/mempool_entry.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>
-#include <test/fuzz/util/mempool.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <limits>

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/fuzz/util/net.h>
 
 #include <compat/compat.h>
@@ -12,6 +11,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>
 #include <test/util/net.h>
+#include <util/check.h>
 #include <util/sock.h>
 #include <util/time.h>
 

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/util/net.h>
 
 #include <compat/compat.h>
@@ -15,7 +16,6 @@
 #include <util/time.h>
 
 #include <array>
-#include <cassert>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>

--- a/src/test/fuzz/util/wallet.h
+++ b/src/test/fuzz/util/wallet.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_WALLET_H
 #define BITCOIN_TEST_FUZZ_UTIL_WALLET_H
 
-#include <util/check.h>
+#include <policy/policy.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <policy/policy.h>
+#include <util/check.h>
 #include <wallet/coincontrol.h>
 #include <wallet/fees.h>
 #include <wallet/spend.h>

--- a/src/test/fuzz/util/wallet.h
+++ b/src/test/fuzz/util/wallet.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_WALLET_H
 #define BITCOIN_TEST_FUZZ_UTIL_WALLET_H
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/vecdeque.cpp
+++ b/src/test/fuzz/vecdeque.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <random.h>
 #include <span.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/vecdeque.cpp
+++ b/src/test/fuzz/vecdeque.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <util/vecdeque.h>
+
 #include <random.h>
 #include <span.h>
 #include <test/fuzz/util.h>
-#include <util/vecdeque.h>
+#include <util/check.h>
 
 #include <cstdint>
 #include <deque>

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -2,20 +2,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <versionbits.h>
+
 #include <chain.h>
 #include <chainparams.h>
 #include <common/args.h>
 #include <consensus/params.h>
 #include <primitives/block.h>
-#include <util/chaintype.h>
-#include <versionbits.h>
-#include <versionbits_impl.h>
-
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/versionbits.h>
+#include <util/chaintype.h>
+#include <util/check.h>
+#include <versionbits_impl.h>
 
 #include <cstdint>
 #include <limits>

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <common/args.h>

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/params.h>

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/params.h>
@@ -12,12 +11,13 @@
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <validation.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <cstddef>
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
 
 using State = HeadersSyncState::State;
 

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <httpserver.h>
 #include <rpc/protocol.h>
 #include <test/util/common.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/string.h>
 #include <util/threadpool.h>
 

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <httpserver.h>
 #include <rpc/protocol.h>
 #include <test/util/common.h>

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
+#include <script/solver.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
-#include <script/solver.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -2,17 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <test/data/key_io_invalid.json.h>
-#include <test/data/key_io_valid.json.h>
-
 #include <key.h>
 #include <key_io.h>
 #include <script/script.h>
+#include <test/data/key_io_invalid.json.h>
+#include <test/data/key_io_valid.json.h>
 #include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/data/key_io_invalid.json.h>
 #include <test/data/key_io_valid.json.h>
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <init/common.h>
 #include <logging.h>
 #include <logging/timer.h>
@@ -11,9 +10,12 @@
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/string.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <chrono>
 #include <fstream>
@@ -25,8 +27,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
 
 using util::SplitString;
 using util::TrimString;

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <init/common.h>
 #include <logging.h>
 #include <logging/timer.h>

--- a/src/test/mempool_fee_estimator_tests.cpp
+++ b/src/test/mempool_fee_estimator_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license. See the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <kernel/mempool_entry.h>
 #include <policy/fees/estimator_args.h>
 #include <policy/fees/mempool_estimator.h>

--- a/src/test/mempool_fee_estimator_tests.cpp
+++ b/src/test/mempool_fee_estimator_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license. See the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <kernel/mempool_entry.h>
 #include <policy/fees/estimator_args.h>
 #include <policy/fees/mempool_estimator.h>
@@ -13,6 +12,7 @@
 #include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/feefrac.h>
 #include <util/fees.h>
 #include <util/time.h>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -2,17 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <common/system.h>
 #include <policy/policy.h>
+#include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
+#include <util/check.h>
 #include <util/time.h>
 
-#include <test/util/setup_common.h>
-
 #include <boost/test/unit_test.hpp>
+
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/system.h>
 #include <policy/policy.h>
 #include <test/util/time.h>

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <util/check.h>
 #include <node/mini_miner.h>
 #include <random.h>
 #include <txmempool.h>

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -1,16 +1,16 @@
 // Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include <util/check.h>
 #include <node/mini_miner.h>
 #include <random.h>
-#include <txmempool.h>
-#include <util/time.h>
-
 #include <test/util/setup_common.h>
 #include <test/util/txmempool.h>
+#include <txmempool.h>
+#include <util/check.h>
+#include <util/time.h>
 
 #include <boost/test/unit_test.hpp>
+
 #include <optional>
 #include <vector>
 

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <boost/test/unit_test.hpp>

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -2,22 +2,22 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <test/util/random.h>
-#include <test/util/setup_common.h>
-#include <boost/test/unit_test.hpp>
-
 #include <addresstype.h>
 #include <core_io.h>
-#include <hash.h>
-#include <pubkey.h>
-#include <uint256.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha256.h>
+#include <hash.h>
+#include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/miniscript.h>
 #include <script/script_error.h>
 #include <script/signingprovider.h>
+#include <test/util/random.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/check.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <algorithm>
 #include <cstdint>

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addrman.h>
 #include <bip324.h>
 #include <chainparams.h>

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <addrman.h>
 #include <bip324.h>
 #include <chainparams.h>
@@ -23,6 +22,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <validation.h>

--- a/src/test/node_init_tests.cpp
+++ b/src/test/node_init_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <init.h>
 #include <interfaces/init.h>
 #include <logging.h>

--- a/src/test/node_init_tests.cpp
+++ b/src/test/node_init_tests.cpp
@@ -2,15 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <init.h>
 #include <interfaces/init.h>
 #include <logging.h>
 #include <rpc/server.h>
-
-#include <boost/test/unit_test.hpp>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
+
+#include <boost/test/unit_test.hpp>
 
 using node::NodeContext;
 

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <arith_uint256.h>
 #include <consensus/validation.h>
 #include <node/txorphanage.h>
@@ -16,11 +15,12 @@
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <test/util/transaction_utils.h>
+#include <util/check.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <array>
 #include <cstdint>
-
-#include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(orphanage_tests, BasicTestingSetup)
 

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <arith_uint256.h>
 #include <consensus/validation.h>
 #include <node/txorphanage.h>

--- a/src/test/pcp_tests.cpp
+++ b/src/test/pcp_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/pcp.h>
 #include <netbase.h>
 #include <test/util/logging.h>

--- a/src/test/pcp_tests.cpp
+++ b/src/test/pcp_tests.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <common/pcp.h>
 #include <netbase.h>
-#include <test/util/logging.h>
 #include <test/util/common.h>
+#include <test/util/logging.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -2,16 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <primitives/transaction.h>
 #include <private_broadcast.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <util/time.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <algorithm>
 #include <ostream>
-#include <boost/test/unit_test.hpp>
 
 std::ostream& operator<<(std::ostream& os, PrivateBroadcast::AddResult r)
 {

--- a/src/test/private_broadcast_tests.cpp
+++ b/src/test/private_broadcast_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <primitives/transaction.h>
 #include <private_broadcast.h>
 #include <test/util/setup_common.h>

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -2,11 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <random.h>
-
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <random.h>
 
 #include <test/util/random.h>

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <util/check.h>
 #include <common/system.h>
 #include <policy/rbf.h>
 #include <random.h>

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -1,17 +1,17 @@
 // Copyright (c) 2021-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include <util/check.h>
 #include <common/system.h>
 #include <policy/rbf.h>
 #include <random.h>
+#include <test/util/setup_common.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
+#include <util/check.h>
 #include <util/time.h>
 
-#include <test/util/setup_common.h>
-
 #include <boost/test/unit_test.hpp>
+
 #include <optional>
 #include <vector>
 

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <random.h>
 #include <scheduler.h>
 #include <util/time.h>

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <random.h>
 #include <scheduler.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -7,6 +7,7 @@
 #define BITCOIN_TEST_SCRIPTNUM10_H
 
 #include <util/check.h>
+
 #include <cstdint>
 #include <limits>
 #include <stdexcept>

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_TEST_SCRIPTNUM10_H
 #define BITCOIN_TEST_SCRIPTNUM10_H
 
-#include <cassert>
+#include <util/check.h>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <addresstype.h>
 #include <coins.h>
 #include <consensus/consensus.h>
@@ -14,10 +13,11 @@
 #include <script/solver.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
-
-#include <vector>
+#include <util/check.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <vector>
 
 // Helpers:
 static std::vector<unsigned char>

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addresstype.h>
 #include <coins.h>
 #include <consensus/consensus.h>

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
 

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <test/util/common.h>
@@ -11,7 +12,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <cassert>
 #include <thread>
 
 using namespace std::chrono_literals;

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <flatfile.h>
 #include <node/blockstorage.h>
 #include <streams.h>

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <flatfile.h>
 #include <node/blockstorage.h>
 #include <streams.h>
 #include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/obfuscation.h>
 #include <util/strencodings.h>

--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <common/system.h>
 #include <logging.h>
 #include <random.h>

--- a/src/test/threadpool_tests.cpp
+++ b/src/test/threadpool_tests.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <common/system.h>
 #include <logging.h>
 #include <random.h>
 #include <test/util/common.h>
+#include <util/check.h>
 #include <util/string.h>
 #include <util/threadpool.h>
 #include <util/time.h>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -2,11 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <test/data/tx_invalid.json.h>
-#include <test/data/tx_valid.json.h>
-#include <test/util/setup_common.h>
-
 #include <checkqueue.h>
 #include <clientversion.h>
 #include <consensus/amount.h>
@@ -27,22 +22,25 @@
 #include <script/signingprovider.h>
 #include <script/solver.h>
 #include <streams.h>
+#include <test/data/tx_invalid.json.h>
+#include <test/data/tx_valid.json.h>
 #include <test/util/common.h>
 #include <test/util/json.h>
 #include <test/util/random.h>
 #include <test/util/script.h>
+#include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <univalue.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <validation.h>
 
+#include <boost/test/unit_test.hpp>
+
 #include <functional>
 #include <map>
 #include <string>
-
-#include <boost/test/unit_test.hpp>
-
-#include <univalue.h>
 
 using namespace util::hex_literals;
 using util::SplitString;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/data/tx_invalid.json.h>
 #include <test/data/tx_valid.json.h>
 #include <test/util/setup_common.h>

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <addresstype.h>
 #include <consensus/validation.h>
 #include <net_processing.h>
@@ -12,11 +11,12 @@
 #include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <validation.h>
 
-#include <array>
-
 #include <boost/test/unit_test.hpp>
+
+#include <array>
 
 BOOST_AUTO_TEST_SUITE(txdownload_tests)
 

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addresstype.h>
 #include <consensus/validation.h>
 #include <net_processing.h>

--- a/src/test/txrequest_tests.cpp
+++ b/src/test/txrequest_tests.cpp
@@ -3,18 +3,17 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
-#include <util/check.h>
-#include <txrequest.h>
-#include <uint256.h>
-
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <txrequest.h>
+#include <uint256.h>
+#include <util/check.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include <algorithm>
 #include <functional>
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
 
 namespace {
 

--- a/src/test/txrequest_tests.cpp
+++ b/src/test/txrequest_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
+#include <util/check.h>
 #include <txrequest.h>
 #include <uint256.h>
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/validation.h>
 #include <key_io.h>
 #include <policy/packages.h>

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -2,12 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <consensus/validation.h>
 #include <key_io.h>
+#include <policy/ephemeral_policy.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
-#include <policy/ephemeral_policy.h>
 #include <policy/truc_policy.h>
 #include <primitives/transaction.h>
 #include <random.h>
@@ -15,6 +14,7 @@
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <test/util/txmempool.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_UTIL_CHAINSTATE_H
 #define BITCOIN_TEST_UTIL_CHAINSTATE_H
 
+#include <util/check.h>
 #include <clientversion.h>
 #include <node/context.h>
 #include <node/utxo_snapshot.h>

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -5,18 +5,17 @@
 #ifndef BITCOIN_TEST_UTIL_CHAINSTATE_H
 #define BITCOIN_TEST_UTIL_CHAINSTATE_H
 
-#include <util/check.h>
 #include <clientversion.h>
 #include <node/context.h>
 #include <node/utxo_snapshot.h>
 #include <rpc/blockchain.h>
 #include <test/util/setup_common.h>
+#include <univalue.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/log.h>
 #include <validation.h>
-
-#include <univalue.h>
 
 inline constexpr auto NoMalleation = [](AutoFile& file, node::SnapshotMetadata& meta){};
 

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -5,12 +5,12 @@
 #ifndef BITCOIN_TEST_UTIL_CLUSTER_LINEARIZE_H
 #define BITCOIN_TEST_UTIL_CLUSTER_LINEARIZE_H
 
-#include <util/check.h>
 #include <cluster_linearize.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
 #include <util/bitset.h>
+#include <util/check.h>
 #include <util/feefrac.h>
 
 #include <cstdint>

--- a/src/test/util/cluster_linearize.h
+++ b/src/test/util/cluster_linearize.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_UTIL_CLUSTER_LINEARIZE_H
 #define BITCOIN_TEST_UTIL_CLUSTER_LINEARIZE_H
 
+#include <util/check.h>
 #include <cluster_linearize.h>
 #include <serialize.h>
 #include <span.h>

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/util/net.h>
 
 #include <net.h>
@@ -16,6 +15,7 @@
 #include <serialize.h>
 #include <span.h>
 #include <sync.h>
+#include <util/check.h>
 
 #include <chrono>
 #include <optional>

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/util/net.h>
 
 #include <net.h>

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_UTIL_NET_H
 #define BITCOIN_TEST_UTIL_NET_H
 
+#include <util/check.h>
 #include <attributes.h>
 #include <compat/compat.h>
 #include <netmessagemaker.h>
@@ -20,7 +21,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -5,18 +5,18 @@
 #ifndef BITCOIN_TEST_UTIL_NET_H
 #define BITCOIN_TEST_UTIL_NET_H
 
-#include <util/check.h>
 #include <attributes.h>
 #include <compat/compat.h>
-#include <netmessagemaker.h>
 #include <net.h>
 #include <net_permissions.h>
 #include <net_processing.h>
 #include <netaddress.h>
+#include <netmessagemaker.h>
 #include <node/connection_types.h>
 #include <node/eviction.h>
 #include <span.h>
 #include <sync.h>
+#include <util/check.h>
 #include <util/sock.h>
 
 #include <algorithm>

--- a/src/test/util/poolresourcetester.h
+++ b/src/test/util/poolresourcetester.h
@@ -9,7 +9,6 @@
 #include <util/check.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <vector>

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <test/util/transaction_utils.h>
+
 #include <coins.h>
 #include <consensus/validation.h>
 #include <script/signingprovider.h>
-#include <test/util/transaction_utils.h>
+#include <util/check.h>
 
 CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, CAmount nValue)
 {

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <coins.h>
 #include <consensus/validation.h>
 #include <script/signingprovider.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <clientversion.h>
 #include <common/signmessage.h>
 #include <compat/compat.h>
@@ -11,6 +10,7 @@
 #include <script/parsing.h>
 #include <span.h>
 #include <sync.h>
+#include <sys/types.h>
 #include <test/util/common.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
@@ -19,6 +19,7 @@
 #include <univalue.h>
 #include <util/bitdeque.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/moneystr.h>
@@ -43,8 +44,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include <sys/types.h>
 
 #ifndef WIN32
 #include <sys/wait.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <clientversion.h>
 #include <common/signmessage.h>
 #include <compat/compat.h>

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <util/check.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <kernel/disconnected_transactions.h>
@@ -18,18 +17,18 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <util/byte_units.h>
+#include <util/check.h>
 #include <util/result.h>
 #include <util/vector.h>
 #include <validation.h>
 #include <validationinterface.h>
 
-#include <tinyformat.h>
+#include <boost/test/unit_test.hpp>
 
 #include <vector>
-
-#include <boost/test/unit_test.hpp>
 
 using node::BlockManager;
 using node::KernelNotifications;

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
+#include <util/check.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <kernel/disconnected_transactions.h>

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>
@@ -10,15 +9,15 @@
 #include <hash.h>
 #include <net.h>
 #include <signet.h>
+#include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <validation.h>
 
-#include <string>
-
-#include <test/util/setup_common.h>
-
 #include <boost/test/unit_test.hpp>
+
+#include <string>
 
 BOOST_FIXTURE_TEST_SUITE(validation_tests, BasicTestingSetup)
 

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/amount.h>
 #include <node/context.h>
 #include <policy/policy.h>

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <consensus/amount.h>
 #include <node/context.h>
 #include <policy/policy.h>
@@ -10,6 +9,7 @@
 #include <random.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/coinselection.h>
@@ -18,8 +18,9 @@
 #include <wallet/test/wallet_test_fixture.h>
 #include <wallet/wallet.h>
 
-#include <algorithm>
 #include <boost/test/unit_test.hpp>
+
+#include <algorithm>
 #include <random>
 
 namespace wallet {

--- a/src/wallet/test/fuzz/coincontrol.cpp
+++ b/src/wallet/test/fuzz/coincontrol.cpp
@@ -2,12 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <wallet/coincontrol.h>
+
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <wallet/coincontrol.h>
+#include <util/check.h>
 #include <wallet/test/util.h>
 
 namespace wallet {

--- a/src/wallet/test/fuzz/coincontrol.cpp
+++ b/src/wallet/test/fuzz/coincontrol.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -2,7 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <wallet/coinselection.h>
+
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
@@ -10,7 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <wallet/coinselection.h>
+#include <util/check.h>
 
 #include <numeric>
 #include <span>

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <addresstype.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/wallet/test/fuzz/spend.cpp
+++ b/src/wallet/test/fuzz/spend.cpp
@@ -2,7 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
+#include <wallet/spend.h>
+
 #include <addresstype.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -11,11 +12,11 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
+#include <util/check.h>
 #include <util/time.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/context.h>
-#include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/time.h>
 #include <util/translation.h>

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <test/util/setup_common.h>
 
 #include <wallet/coinselection.h>

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -2,9 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <test/util/setup_common.h>
-
+#include <util/check.h>
 #include <wallet/coinselection.h>
 #include <wallet/spend.h>
 #include <wallet/test/util.h>

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <key.h>
 #include <key_io.h>
 #include <node/context.h>

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -2,17 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <key.h>
 #include <key_io.h>
 #include <node/context.h>
 #include <script/script.h>
-#include <script/solver.h>
 #include <script/signingprovider.h>
+#include <script/solver.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
+#include <wallet/test/util.h>
 #include <wallet/types.h>
 #include <wallet/wallet.h>
-#include <wallet/test/util.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <key_io.h>
 #include <node/types.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <wallet/test/wallet_test_fixture.h>
 #include <wallet/wallet.h>

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <key_io.h>
 #include <node/types.h>
 #include <test/util/setup_common.h>

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <consensus/amount.h>
 #include <key.h>
 #include <script/solver.h>

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <consensus/amount.h>
 #include <key.h>
 #include <script/solver.h>
+#include <util/check.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/spend.h>

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -2,19 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
 #include <wallet/test/util.h>
 
 #include <chain.h>
 #include <key.h>
 #include <key_io.h>
+#include <sqlite3.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <validationinterface.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
-
-#include <sqlite3.h>
 
 #include <memory>
 

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <wallet/test/util.h>
 
 #include <chain.h>

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <wallet/test/util.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 #include <scheduler.h>
 #include <util/chaintype.h>
+#include <util/check.h>
+#include <wallet/test/util.h>
 
 namespace wallet {
 WalletTestingSetup::WalletTestingSetup(const ChainType chainType)

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <wallet/test/util.h>
 #include <wallet/test/wallet_test_fixture.h>
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <wallet/wallet.h>
 
 #include <cstdint>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -2,14 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/check.h>
-#include <wallet/wallet.h>
-
-#include <cstdint>
-#include <future>
-#include <memory>
-#include <vector>
-
 #include <addresstype.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
@@ -22,6 +14,8 @@
 #include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <univalue.h>
+#include <util/check.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -31,9 +25,14 @@
 #include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/test/wallet_test_fixture.h>
+#include <wallet/wallet.h>
 
 #include <boost/test/unit_test.hpp>
-#include <univalue.h>
+
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <vector>
 
 using node::MAX_BLOCKFILE_SIZE;
 


### PR DESCRIPTION
In test code, `assert` is used. This is perfectly fine, but sometimes confusion arises, when it is unclear whether `NDEBUG` can disable the assertions, or whether to use `assert` or `Assert`.

Avoid that confusion in test code with a scripted replacement to add the util/check.h include. The changes here will also make it easier to run IWYU.

Scope: This change is only about test code (bench, fuzz, unit), other code can be done later, if there is need to.