### PR TITLE
rpc: add bestblockhash to getmininginfo

### DIFF
--- a/doc/release-notes-36081.md
+++ b/doc/release-notes-36081.md
@@ -1,0 +1,8 @@
+Updated RPCs
+------------
+
+- The `getmininginfo` RPC now returns a `bestblockhash` field. Together with
+  the existing `next` object this lets mining software obtain the tip hash and
+  the next block's `nBits` atomically from a single call, without a race
+  against a concurrent tip change between `getblockchaininfo` and
+  `getmininginfo`.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -454,6 +454,7 @@ static RPCMethod getmininginfo()
                     RPCResult::Type::OBJ, "", "",
                     {
                         {RPCResult::Type::NUM, "blocks", "The current block"},
+                        {RPCResult::Type::STR_HEX, "bestblockhash", "The hash of the current best block"},
                         {RPCResult::Type::NUM, "currentblockweight", /*optional=*/true, "The block weight (including reserved weight for block header, txs count and coinbase tx) of the last assembled block (only present if a block was ever assembled)"},
                         {RPCResult::Type::NUM, "currentblocktx", /*optional=*/true, "The number of block transactions (excluding coinbase) of the last assembled block (only present if a block was ever assembled)"},
                         {RPCResult::Type::STR_HEX, "bits", "The current nBits, compact representation of the block difficulty target"},
@@ -495,6 +496,7 @@ static RPCMethod getmininginfo()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("blocks", active_chain.Height());
+    obj.pushKV("bestblockhash", tip.GetBlockHash().GetHex());
     if (BlockAssembler::m_last_block_weight) obj.pushKV("currentblockweight", *BlockAssembler::m_last_block_weight);
     if (BlockAssembler::m_last_block_num_txs) obj.pushKV("currentblocktx", *BlockAssembler::m_last_block_num_txs);
     obj.pushKV("bits", strprintf("%08x", tip.nBits));

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -396,6 +396,7 @@ class MiningTest(BitcoinTestFramework):
         self.log.info('getmininginfo')
         mining_info = node.getmininginfo()
         assert_equal(mining_info['blocks'], 200)
+        assert_equal(mining_info['bestblockhash'], node.getbestblockhash())
         assert_equal(mining_info['chain'], self.chain)
         assert 'currentblocktx' not in mining_info
         assert 'currentblockweight' not in mining_info

--- a/test/functional/mining_mainnet.py
+++ b/test/functional/mining_mainnet.py
@@ -96,6 +96,7 @@ class MiningMainnetTest(BitcoinTestFramework):
 
         self.log.info("Check difficulty adjustment with getmininginfo")
         mining_info = node.getmininginfo()
+        assert_equal(mining_info['bestblockhash'], prev_hash)
         assert_equal(mining_info['difficulty'], 1)
         assert_equal(mining_info['bits'], nbits_str(DIFF_1_N_BITS))
         assert_equal(mining_info['target'], target_str(DIFF_1_TARGET))


### PR DESCRIPTION
I'm working with pool side mining software.

I noticed there is a race condition between obtaining bestblockhash and next block nbits.
The chaintips may change.

I thought it might be useful to include bestblockhash in `getmininginfo` rpc response.