### PR TITLE
build: respect CMAKE_INSTALL_BINDIR and CMAKE_INSTALL_LIBEXECDIR in the launcher

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -309,6 +309,13 @@ if(BUILD_BITCOIN_BIN)
     bitcoin-res.rc
   )
   add_windows_application_manifest(bitcoin)
+  # Tell the wrapper which directory install_binary_component() installs it to,
+  # and which directory install_binary_component(... INTERNAL) installs the
+  # executables it searches for to.
+  target_compile_definitions(bitcoin PRIVATE
+    BITCOIN_BINDIR="${CMAKE_INSTALL_BINDIR}"
+    BITCOIN_LIBEXECDIR="${CMAKE_INSTALL_LIBEXECDIR}"
+  )
   target_link_libraries(bitcoin core_interface bitcoin_common bitcoin_util)
   install_binary_component(bitcoin HAS_MANPAGE)
 endif()

--- a/src/bitcoin.cpp
+++ b/src/bitcoin.cpp
@@ -226,9 +226,13 @@ static void ExecCommand(const std::vector<const char*>& args, std::string_view w
     // (https://github.com/bitcoin/bitcoin/pull/31375#discussion_r1861814807)
     const bool fallback_os_search{!fs::PathFromString(std::string{wrapper_argv0}).has_parent_path()};
 
-    // If wrapper is installed in a bin/ directory, look for target executable
-    // in libexec/
-    (wrapper_dir.filename() == "bin" && try_exec(wrapper_dir.parent_path() / "libexec" / arg0.filename())) ||
+    // If wrapper is installed in the configured bin directory
+    // (CMAKE_INSTALL_BINDIR), look for target executable in the configured
+    // libexec directory (CMAKE_INSTALL_LIBEXECDIR). Only the last component of
+    // the bin directory is compared, since that is all the wrapper can see of
+    // the directory it was installed to.
+    (wrapper_dir.filename() == fs::PathFromString(BITCOIN_BINDIR).filename() &&
+     try_exec(wrapper_dir.parent_path() / BITCOIN_LIBEXECDIR / arg0.filename())) ||
 #ifdef WIN32
     // Otherwise check the "daemon" subdirectory in a windows install.
     (!wrapper_dir.empty() && try_exec(wrapper_dir / "daemon" / arg0.filename())) ||

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+# For CMAKE_INSTALL_BINDIR and CMAKE_INSTALL_LIBEXECDIR, which are substituted
+# into config.ini.
+include(GNUInstallDirs)
+
 function(create_test_config)
   set(abs_top_srcdir ${PROJECT_SOURCE_DIR})
   set(abs_top_builddir ${PROJECT_BINARY_DIR})

--- a/test/config.ini.in
+++ b/test/config.ini.in
@@ -11,6 +11,8 @@ CLIENT_BUGREPORT=@CLIENT_BUGREPORT@
 SRCDIR=@abs_top_srcdir@
 BUILDDIR=@abs_top_builddir@
 EXEEXT=@EXEEXT@
+BINDIR=@CMAKE_INSTALL_BINDIR@
+LIBEXECDIR=@CMAKE_INSTALL_LIBEXECDIR@
 RPCAUTH=@abs_top_srcdir@/share/rpcauth/rpcauth.py
 
 [components]

--- a/test/functional/tool_bitcoin.py
+++ b/test/functional/tool_bitcoin.py
@@ -12,8 +12,12 @@ from test_framework.util import (
     assert_equal,
 )
 
+import os
 import platform
 import re
+import shutil
+import subprocess
+from pathlib import Path
 
 
 class ToolBitcoinTest(BitcoinTestFramework):
@@ -85,6 +89,59 @@ class ToolBitcoinTest(BitcoinTestFramework):
             self.log.info("Ensure bitcoin recognizes -ipcbind in config file")
             append_config(node.datadir_path, ["ipcbind=unix"])
             self.test_args([], [], expect_exe="bitcoin-node")
+
+        self.test_install_dirs()
+
+    def test_install_dirs(self):
+        """Check that an installed wrapper uses CMAKE_INSTALL_BINDIR and CMAKE_INSTALL_LIBEXECDIR.
+
+        The tests above cannot detect where the wrapper searches, because every
+        executable is installed next to it in the build tree. Emulate an install
+        tree instead, so the bindir -> libexecdir lookup is the only way to find
+        the executable being invoked.
+        """
+        libexecdir = self.config["environment"]["LIBEXECDIR"]
+        if os.path.isabs(libexecdir):
+            # An absolute CMAKE_INSTALL_LIBEXECDIR is not looked up relative to
+            # the wrapper, so it cannot be emulated below.
+            self.log.info(f"Skipping install dir test, CMAKE_INSTALL_LIBEXECDIR '{libexecdir}' is absolute")
+            return
+        # The wrapper only compares the last component of CMAKE_INSTALL_BINDIR
+        # with the directory it is in, so that is all that needs emulating.
+        bindir = Path(self.config["environment"]["BINDIR"]).name
+
+        exeext = self.config["environment"]["EXEEXT"]
+        paths = self.get_binaries().paths
+
+        def run_wrapper(prefix_name, bin_dir, libexec_dir):
+            """Run `bitcoin node -version` from bin_dir in a prefix providing bitcoind in libexec_dir."""
+            prefix = Path(self.options.tmpdir) / prefix_name
+            (prefix / bin_dir).mkdir(parents=True)
+            (prefix / libexec_dir).mkdir(parents=True, exist_ok=True)
+            # The wrapper resolves symlinks to determine its own directory, so it
+            # needs to be copied, while bitcoind can just be symlinked.
+            wrapper = prefix / bin_dir / f"bitcoin{exeext}"
+            shutil.copy2(paths.bitcoin_bin, wrapper)
+            os.symlink(os.path.abspath(paths.bitcoind), prefix / libexec_dir / f"bitcoind{exeext}")
+            return subprocess.run([wrapper, "node", "-version"], capture_output=True, timeout=60)
+
+        self.log.info(f"Ensure bitcoin node command in {bindir}/ invokes bitcoind in {libexecdir}/")
+        result = run_wrapper("install", bindir, libexecdir)
+        assert_equal(result.stderr, b"")
+        assert_equal(result.returncode, 0)
+        assert_equal(get_exe_name(result.stdout), b"bitcoind")
+
+        unused_libexecdir = "libexec" if libexecdir != "libexec" else "lib"
+        self.log.info(f"Ensure bitcoin node command in {bindir}/ does not invoke bitcoind in {unused_libexecdir}/")
+        result = run_wrapper("unused-libexecdir", bindir, unused_libexecdir)
+        assert_equal(result.returncode, 1)
+        assert b"No such file or directory" in result.stderr
+
+        unused_bindir = "bin" if bindir != "bin" else "sbin"
+        self.log.info(f"Ensure bitcoin node command in {unused_bindir}/ does not invoke bitcoind in {libexecdir}/")
+        result = run_wrapper("unused-bindir", unused_bindir, libexecdir)
+        assert_equal(result.returncode, 1)
+        assert b"No such file or directory" in result.stderr
 
 
 def get_node_output(node):


### PR DESCRIPTION
Fixes #35785.

`install_binary_component()` installs the launcher to `CMAKE_INSTALL_BINDIR`, and `install_binary_component(... INTERNAL)` installs `bitcoin-node`, `bitcoin-gui`, `bitcoin-chainstate` (and the test/bench internals) to `CMAKE_INSTALL_LIBEXECDIR`, but the launcher looked for them in a hardcoded `libexec` directory next to a hardcoded `bin` directory. Those only agree for the default values, so an install configured with different ones (e.g. Arch's `-DCMAKE_INSTALL_LIBEXECDIR=lib`) cannot run any of them:

```
$ /usr/bin/bitcoin -m node --version
Error: execvp failed to execute '/usr/bin/bitcoin-node': No such file or directory
```

The first commit compiles the launcher with both configured directories. Only the last component of `CMAKE_INSTALL_BINDIR` is compared, because that is all the launcher can see of the directory it was installed to.

The second commit covers this in `tool_bitcoin.py`. The existing checks run out of the build tree, where every executable sits next to the launcher. The new check builds a layout that looks like an install prefix and only provides `bitcoind` under the configured directories, plus the cases of a different bin and a different libexec directory, so that neither is searched.

## Test plan
```sh
cmake -B build -DCMAKE_INSTALL_PREFIX=/tmp/btc -DCMAKE_INSTALL_BINDIR=sbin -DCMAKE_INSTALL_LIBEXECDIR=lib && cmake --build build && cmake --install build
/tmp/btc/sbin/bitcoin -m node --version
```
On master the last command prints the `execvp` error; with this branch it prints the version. The same holds with only `-DCMAKE_INSTALL_LIBEXECDIR=lib` and the default bindir.
