### PR TITLE
util: Set Univalue to null after read failure

### DIFF
--- a/src/ipc/capnp/common-types.h
+++ b/src/ipc/capnp/common-types.h
@@ -27,6 +27,7 @@
 #include <mp/type-struct.h>
 #include <mp/type-threadmap.h>
 #include <mp/type-vector.h>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 
@@ -123,7 +124,9 @@ decltype(auto) CustomReadField(TypeList<UniValue>, Priority<1>, InvokeContext& i
 {
     return read_dest.update([&](auto& value) {
         auto data = input.get();
-        value.read(std::string_view{data.begin(), data.size()});
+        if (!value.read(std::string_view{data.begin(), data.size()})) {
+            throw std::runtime_error{"invalid JSON received over IPC"};
+        }
     });
 }
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -2,21 +2,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/data/bip341_wallet_vectors.json.h>
-
 #include <addresstype.h>
 #include <key.h>
 #include <key_io.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
 #include <script/solver.h>
+#include <test/data/bip341_wallet_vectors.json.h>
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
+#include <univalue.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
-
-#include <univalue.h>
 
 using namespace util::hex_literals;
 
@@ -461,7 +460,7 @@ BOOST_AUTO_TEST_CASE(bip341_spk_test_vectors)
     using control_set = decltype(TaprootSpendData::scripts)::mapped_type;
 
     UniValue tests;
-    tests.read(json_tests::bip341_wallet_vectors);
+    Assert(tests.read(json_tests::bip341_wallet_vectors));
 
     const auto& vectors = tests["scriptPubKey"];
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -24,6 +24,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <univalue.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -1632,7 +1633,7 @@ BOOST_AUTO_TEST_CASE(script_HasValidOps)
 BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
 {
     UniValue tests;
-    tests.read(json_tests::bip341_wallet_vectors);
+    Assert(tests.read(json_tests::bip341_wallet_vectors));
 
     const auto& vectors = tests["keyPathSpending"];
 

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -1,5 +1,5 @@
 // Copyright 2014 BitPay Inc.
-// Copyright 2015 Bitcoin Core Developers
+// Copyright (c) 2015-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -99,7 +99,8 @@ public:
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
 
-    bool read(std::string_view raw);
+    /// Parse JSON; set value to null on failure.
+    [[nodiscard]] bool read(std::string_view json);
 
 private:
     UniValue::VType typ;
@@ -111,6 +112,8 @@ private:
     bool findKey(const std::string& key, size_t& retIdx) const;
     void writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
+    /// Internal parser: May leave this value in an invalid state on failure.
+    [[nodiscard]] bool read_impl(std::string_view str_in);
 
 public:
     // Strict type-specific getters, these throw std::runtime_error if the

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -1,4 +1,5 @@
 // Copyright 2014 BitPay Inc.
+// Copyright (c) 2015-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -9,6 +10,7 @@
 #include <cstring>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 /*
@@ -259,7 +261,18 @@ enum expect_bits : unsigned {
 #define setExpect(bit) (expectMask |= EXP_##bit)
 #define clearExpect(bit) (expectMask &= ~EXP_##bit)
 
-bool UniValue::read(std::string_view str_in)
+bool UniValue::read(std::string_view json)
+{
+    UniValue parsed;
+    if (!parsed.read_impl(json)) {
+        setNull();
+        return false;
+    }
+    *this = std::move(parsed);
+    return true;
+}
+
+bool UniValue::read_impl(std::string_view str_in)
 {
     clear();
 
@@ -461,4 +474,3 @@ bool UniValue::read(std::string_view str_in)
 
     return true;
 }
-

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -457,10 +457,7 @@ void univalue_readwrite()
     {
         UniValue val{"previous value"};
         BOOST_CHECK(!val.read(R"({"key":)"));
-        // This should be null (XXX, TODO, FIXME):
-        BOOST_CHECK(val.isObject());
-        BOOST_CHECK_EQUAL(val.getKeys().size(), 1);
-        BOOST_CHECK_EQUAL(val.getValues().size(), 0);
+        BOOST_CHECK(val.isNull());
     }
 }
 

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -452,6 +452,16 @@ void univalue_readwrite()
     BOOST_CHECK(!v.read("[]{}"));
     BOOST_CHECK(!v.read("{}[]"));
     BOOST_CHECK(!v.read("{} 42"));
+
+    // Failed read clears value
+    {
+        UniValue val{"previous value"};
+        BOOST_CHECK(!val.read(R"({"key":)"));
+        // This should be null (XXX, TODO, FIXME):
+        BOOST_CHECK(val.isObject());
+        BOOST_CHECK_EQUAL(val.getKeys().size(), 1);
+        BOOST_CHECK_EQUAL(val.getValues().size(), 0);
+    }
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Currently, `UniValue::read()` may leave the value in a dirty/corrupt state after a read failure.

This is perfectly fine, because all production code-paths check the read return value and exit early.

However, it seems nicer and safer to discard the dirty and corrupt state. So do that here.

This refactor doesn't change any production behavior. However, it fixes a fuzz failure in the `rpc` target, which was recently reworked in commit fa895bb77a8a061734d6626fde40090ad231ad5d. Later, adding new fuzz inputs (e.g. `fuzz_corpora/rpc/fa1b0eeaa948a091f022c1ff2d0002a3fa6a631f `) and commit 747cff842481153357199bf9a81b5a4d82ea91fb made it hit this invalid UniValue code path.