### PR TITLE
test: cover outbound service flag filtering in ThreadOpenConnections

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -375,6 +375,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnodeaddresses", 0, "count"},
     { "addpeeraddress", 1, "port"},
     { "addpeeraddress", 2, "tried"},
+    { "addpeeraddress", 3, "services"},
     { "sendmsgtopeer", 0, "peer_id" },
     { "stop", 0, "wait" },
     { "addnode", 2, "v2transport" },

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1017,6 +1017,7 @@ static RPCMethod addpeeraddress()
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The IP address of the peer"},
             {"port", RPCArg::Type::NUM, RPCArg::Optional::NO, "The port of the peer"},
             {"tried", RPCArg::Type::BOOL, RPCArg::Default{false}, "If true, attempt to add the peer to the tried addresses table"},
+            {"services", RPCArg::Type::NUM, RPCArg::Default{(uint64_t)(NODE_NETWORK | NODE_WITNESS)}, "The service flags to record for the address"},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -1036,6 +1037,9 @@ static RPCMethod addpeeraddress()
     const std::string& addr_string{request.params[0].get_str()};
     const auto port{request.params[1].getInt<uint16_t>()};
     const bool tried{request.params[2].isNull() ? false : request.params[2].get_bool()};
+    const ServiceFlags services{request.params[3].isNull()
+        ? ServiceFlags{NODE_NETWORK | NODE_WITNESS}
+        : static_cast<ServiceFlags>(request.params[3].getInt<uint64_t>())};
 
     UniValue obj(UniValue::VOBJ);
     std::optional<CNetAddr> net_addr{LookupHost(addr_string, false)};
@@ -1046,7 +1050,7 @@ static RPCMethod addpeeraddress()
     bool success{false};
 
     CService service{net_addr.value(), port};
-    CAddress address{MaybeFlipIPv6toCJDNS(service), ServiceFlags{NODE_NETWORK | NODE_WITNESS}};
+    CAddress address{MaybeFlipIPv6toCJDNS(service), services};
     address.nTime = Now<NodeSeconds>();
     // The source address is set equal to the address. This is equivalent to the peer
     // announcing itself.

--- a/test/functional/p2p_outbound_service_flags.py
+++ b/test/functional/p2p_outbound_service_flags.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that automatic outbound connections skip addresses lacking desirable service flags.
+
+ThreadOpenConnections filters candidate addresses on
+HasAllDesirableServiceFlags before attempting a connection. This covers
+that filter: a node whose addrman holds only addresses without those
+flags should make no connection attempt, while a node whose addrman
+holds usable addresses should.
+
+Two nodes are used rather than two phases on one node, so that
+addresses left in the first case cannot influence the second. Both are
+given an unreachable proxy, so no attempt can succeed; what is observed
+is whether an attempt is made at all.
+"""
+
+import time
+
+from test_framework.messages import (
+    NODE_NETWORK,
+    NODE_NONE,
+    NODE_WITNESS,
+)
+from test_framework.netutil import UNREACHABLE_PROXY_ARG
+from test_framework.test_framework import BitcoinTestFramework
+
+# Logged by CConnman::ConnectNode for every attempt, under BCLog::NET.
+ATTEMPT_LOG = "trying v1 connection (outbound-full-relay)"
+
+# How long to watch for an attempt that should not happen. An attempt
+# against a usable addrman is observed in a few seconds, so this is
+# comfortably longer than the behaviour it is ruling out.
+QUIET_WINDOW = 20
+
+
+class P2POutboundServiceFlags(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        # The point of this test is the node's own addrman-driven outbound
+        # behaviour, which the framework's default connect=0 disables.
+        self.disable_autoconnect = False
+        self.extra_args = [["-dnsseed=0", "-fixedseeds=0", "-debug=net",
+                            UNREACHABLE_PROXY_ARG]] * 2
+
+    def setup_network(self):
+        # Deliberately unconnected: the node's own outbound behaviour is
+        # what is under test.
+        self.setup_nodes()
+
+    def fill_addrman(self, node, first_octet, services, count=32):
+        for i in range(count):
+            node.addpeeraddress(address=f"{first_octet}.{i + 1}.0.1", port=8333,
+                                tried=True, services=services)
+
+    def run_test(self):
+        undesirable, usable = self.nodes
+
+        self.log.info("A node whose addrman holds only addresses without desirable "
+                      "service flags makes no outbound attempt")
+        self.fill_addrman(undesirable, 10, NODE_NONE)
+        with undesirable.assert_debug_log(expected_msgs=[], unexpected_msgs=[ATTEMPT_LOG]):
+            time.sleep(QUIET_WINDOW)
+
+        self.log.info("A node whose addrman holds usable addresses does attempt")
+        with usable.assert_debug_log(expected_msgs=[ATTEMPT_LOG], timeout=60):
+            self.fill_addrman(usable, 11, NODE_NETWORK | NODE_WITNESS)
+
+
+if __name__ == '__main__':
+    P2POutboundServiceFlags(__file__).main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -13,6 +13,11 @@ import platform
 import time
 
 import test_framework.messages
+from test_framework.messages import (
+    NODE_NETWORK,
+    NODE_NONE,
+    NODE_WITNESS,
+)
 from test_framework.p2p import (
     P2PInterface,
     P2P_SERVICES,
@@ -342,6 +347,13 @@ class NetTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Address count out of range", self.nodes[0].getnodeaddresses, -1)
         assert_raises_rpc_error(-8, "Network not recognized: Foo", self.nodes[0].getnodeaddresses, 1, "Foo")
 
+    @staticmethod
+    def find_addrman_entry(table, address):
+        for entry in table.values():
+            if entry["address"] == address:
+                return entry
+        raise AssertionError(f"{address} not found in addrman table")
+
     def test_addpeeraddress(self):
         self.log.info("Test addpeeraddress")
         # The node has an existing, non-deterministic addrman from a previous test.
@@ -382,6 +394,7 @@ class NetTest(BitcoinTestFramework):
             assert_equal(node.addpeeraddress(address="1.0.0.0", tried=value, port=8333), {"success": False, "error": "failed-adding-to-new"})
         assert_equal(len(node.getnodeaddresses(count=0)), 1)
 
+
         self.log.debug("Test that adding a valid address to the tried table succeeds")
         assert_equal(node.addpeeraddress(address="1.2.3.4", tried=True, port=8333), {"success": True})
         addrman = node.getrawaddrman()
@@ -412,6 +425,20 @@ class NetTest(BitcoinTestFramework):
         assert_equal(addrman_info["all_networks"]["tried"], 1)
         assert_equal(addrman_info["all_networks"]["new"], 3)
         node.getnodeaddresses(count=0)  # getnodeaddresses re-runs the addrman checks
+
+        self.log.debug("Test that the default service flags are recorded")
+        assert_equal(self.find_addrman_entry(node.getrawaddrman()["new"], "1.0.0.0")["services"], NODE_NETWORK | NODE_WITNESS)
+
+        self.log.debug("Test that service flags can be set explicitly")
+        assert_equal(node.addpeeraddress(address="3.0.0.0", port=8333, services=NODE_NETWORK), {"success": True})
+        assert_equal(self.find_addrman_entry(node.getrawaddrman()["new"], "3.0.0.0")["services"], NODE_NETWORK)
+
+        self.log.debug("Test that an address lacking desirable service flags can be recorded")
+        assert_equal(node.addpeeraddress(address="4.0.0.0", port=8333, services=NODE_NONE), {"success": True})
+        assert_equal(self.find_addrman_entry(node.getrawaddrman()["new"], "4.0.0.0")["services"], NODE_NONE)
+
+        self.log.debug("Test that non-integer services fails")
+        assert_raises_rpc_error(-3, "JSON value of type string is not of expected type number", node.addpeeraddress, address="5.0.0.0", port=8333, services="NODE_NETWORK")
 
     def test_sendmsgtopeer(self):
         node = self.nodes[0]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -233,6 +233,7 @@ BASE_SCRIPTS = [
     'wallet_disable.py',
     'wallet_change_address.py',
     'p2p_addr_relay.py',
+    'p2p_outbound_service_flags.py',
     'p2p_getaddr_caching.py',
     'p2p_getdata.py',
     'p2p_addrfetch.py',


### PR DESCRIPTION
`ThreadOpenConnections` skips candidate addresses that fail `HasAllDesirableServiceFlags` before attempting a connection (`net.cpp`, in the addrman try loop). That filter has no functional test coverage today, and cannot have any: `addpeeraddress` hardcodes `NODE_NETWORK | NODE_WITNESS`, so every address a test can place into addrman already carries the desirable flags. There is no way to put an address there that the filter should skip.

`peerman_tests` covers `GetDesirableServiceFlags` itself, but not the selection path that consumes it.

Two commits:

1. **`test: allow addpeeraddress to set service flags`** adds an optional `services` argument, defaulting to the value that is currently hardcoded, so existing callers are unaffected. Covered in `rpc_net.py`: default flags are recorded, explicit flags round-trip through `getrawaddrman`, and an address lacking desirable flags can be placed.

2. **`test: cover outbound service flag filtering in ThreadOpenConnections`** uses it. Two otherwise identical nodes differ only in the service flags of the addresses in their addrman. The node holding only addresses without desirable flags makes no connection attempt; the node holding usable ones does. Both run with an unreachable proxy, so no attempt can succeed — what is observed is whether one is made at all.

The new test sets `disable_autoconnect = False`, since the behaviour under test is the node's own addrman-driven outbound connection logic.

Tested on macOS/arm64. `p2p_outbound_service_flags.py` passes on three consecutive runs; `rpc_net.py` (both transports), `p2p_dns_seeds.py`, `p2p_seednode.py`, `p2p_addr_relay.py` and `feature_asmap.py` also pass.
