### PR TITLE
node: track reannounced mempool transactions in unbroadcast set

### DIFF
--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -69,6 +69,9 @@ TransactionError BroadcastTransaction(NodeContext& node,
             // The mempool transaction may have the same or different witness (and
             // wtxid) as this transaction. Use the mempool's wtxid for reannouncement.
             wtxid = mempool_tx->GetWitnessHash();
+            if (broadcast_method == TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL) {
+                node.mempool->AddUnbroadcastTx(txid);
+            }
         } else {
             // Transaction is not already in the mempool.
             const bool check_max_fee{max_tx_fee > 0};

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -88,9 +88,15 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
         self.disconnect_nodes(0, 1)
         node.disconnect_p2ps()
 
-        self.log.info("Rebroadcast transaction and ensure it is not added to unbroadcast set when already in mempool")
+        self.log.info("Rebroadcast transaction and ensure it is added to unbroadcast set even when already in mempool")
         rpc_tx_hsh = node.sendrawtransaction(txFS["hex"])
+        assert node.getmempoolentry(rpc_tx_hsh)['unbroadcast']
+
+        conn2 = node.add_p2p_connection(P2PTxInvStore())
+        node.mockscheduler(MAX_INITIAL_BROADCAST_DELAY)
+        conn2.wait_for_broadcast([txFS["wtxid"]])
         assert not node.getmempoolentry(rpc_tx_hsh)['unbroadcast']
+        node.disconnect_p2ps()
 
     def test_txn_removal(self):
         self.log.info("Test that transactions removed from mempool are removed from unbroadcast set")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -315,6 +315,7 @@ BASE_SCRIPTS = [
     'rpc_uptime.py',
     'feature_discover.py',
     'wallet_resendwallettransactions.py',
+    'wallet_restart_mempool_unbroadcast.py',
     'wallet_fallbackfee.py',
     'rpc_dumptxoutset.py',
     'feature_minchainwork.py',

--- a/test/functional/wallet_restart_mempool_unbroadcast.py
+++ b/test/functional/wallet_restart_mempool_unbroadcast.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that wallet/RPC transactions submitted during or after restart while
+already in mempool (e.g. from mempool.dat) are added to unbroadcast set
+and properly delivered to peers on reconnection."""
+
+from test_framework.p2p import P2PTxInvStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+MAX_INITIAL_BROADCAST_DELAY = 15 * 60  # 15 minutes in seconds
+
+class WalletRestartMempoolUnbroadcastTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node0 = self.nodes[0]
+        node1 = self.nodes[1]
+
+        self.generate(node0, 101)
+
+        self.log.info("Submit transaction to node0 while disconnected from peers")
+        self.disconnect_nodes(0, 1)
+
+        # Generate a wallet transaction on node0
+        addr = node0.getnewaddress()
+        wallet_txid = node0.sendtoaddress(addr, 0.0001)
+
+        # Confirm transaction is in mempool and marked unbroadcast
+        assert wallet_txid in node0.getrawmempool()
+        assert node0.getmempoolentry(wallet_txid)['unbroadcast']
+
+        # Connect peer, fast-forward to trigger initial broadcast and simulate getdata which removes from unbroadcast
+        conn = node0.add_p2p_connection(P2PTxInvStore())
+        node0.mockscheduler(MAX_INITIAL_BROADCAST_DELAY)
+        conn.wait_for_broadcast([wallet_txid])
+        # After peer received tx via getdata, unbroadcast is false
+        assert not node0.getmempoolentry(wallet_txid)['unbroadcast']
+
+        node0.disconnect_p2ps()
+
+        self.log.info("Restart node0 with persisted mempool (tx loaded from mempool.dat without unbroadcast set)")
+        self.restart_node(0)
+        assert wallet_txid in node0.getrawmempool()
+        # Loaded from mempool.dat as regular entry:
+        assert not node0.getmempoolentry(wallet_txid)['unbroadcast']
+
+        self.log.info("Attempt to broadcast/send the transaction again while disconnected")
+        # In Bitcoin Core #35589, sending an existing transaction via RPC send/sendrawtransaction/sendtoaddress
+        # did NOT add it to the unbroadcast set if it was already in the mempool.
+        raw_hex = node0.getrawtransaction(wallet_txid)
+        node0.sendrawtransaction(raw_hex)
+
+        # INVARIANT: Transaction MUST be tracked in the unbroadcast set so that ReattemptInitialBroadcast
+        # will deliver it to newly connected peers.
+        assert_equal(node0.getmempoolentry(wallet_txid)['unbroadcast'], True)
+
+        self.log.info("Connect node1 and fast-forward scheduler to verify delivery")
+        self.connect_nodes(0, 1)
+        node0.mockscheduler(MAX_INITIAL_BROADCAST_DELAY)
+        self.sync_mempools(timeout=30)
+        assert wallet_txid in node1.getrawmempool()
+        assert not node0.getmempoolentry(wallet_txid)['unbroadcast']
+
+
+if __name__ == '__main__':
+    WalletRestartMempoolUnbroadcastTest(__file__).main()


### PR DESCRIPTION
### Problem
When `BroadcastTransaction` is invoked with `TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL` (via `send`, `sendtoaddress`, or `sendrawtransaction`) for a transaction that is already admitted to the mempool (for example, loaded from `mempool.dat` on node startup/restart, or resubmitted by wallet/RPC), it previously skipped tracking the transaction in `m_unbroadcast_txids`.

If initial P2P broadcast attempts failed because outbound peers had not yet established connections during node restart, the transaction was never retried via `ReattemptInitialBroadcast()`, leaving locally submitted wallet/RPC transactions in an unbroadcast state indefinitely even while appearing as `InMempool`.

### Solution
In `src/node/transaction.cpp`:
- When `mempool->get(txid)` succeeds during `BroadcastTransaction`, if `broadcast_method == TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL`, call `node.mempool->AddUnbroadcastTx(txid)`.

### Testing
- Added deterministic functional test `test/functional/wallet_restart_mempool_unbroadcast.py` reproducing the exact startup race with persisted mempool and verifying transaction delivery upon subsequent peer connection.
- Updated `test/functional/mempool_unbroadcast.py` to assert that rebroadcasting an existing transaction tracks it in the unbroadcast set until delivered to peers.
- Ran all 819 unit test cases (`test_bitcoin`) and relevant functional tests (`mempool_unbroadcast.py`, `wallet_restart_mempool_unbroadcast.py`, `mempool_persist.py`, `wallet_resendwallettransactions.py`, `mempool_packages.py`, `mempool_accept_wtxid.py`).

Fixes #35589.
