### PR TITLE
test: ipc should reject invalid json

### DIFF
--- a/test/functional/interface_ipc.py
+++ b/test/functional/interface_ipc.py
@@ -4,11 +4,13 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the IPC (multiprocess) interface."""
 import asyncio
+import json
 
 from contextlib import ExitStack
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.ipc_util import (
+    assert_capnp_raises,
     load_capnp_modules,
     make_capnp_init_ctx,
     make_mining_ctx,
@@ -49,6 +51,21 @@ class IPCInterfaceTest(BitcoinTestFramework):
                 assert_equal(s, result_eval)
             self.log.debug("Destroy the Echo object")
             echo.destroy(ctx)
+        asyncio.run(capnp.run(async_routine()))
+
+    def run_rpc_invalid_json_test(self):
+        self.log.info("Running RPC invalid JSON test")
+        async def async_routine():
+            ctx, init = await make_capnp_init_ctx(self)
+            self.log.debug("Create Rpc proxy object")
+            rpc = init.makeRpc(ctx).result
+            self.log.debug("Invalid JSON in an executeRpc request must be rejected")
+            await assert_capnp_raises(lambda: rpc.executeRpc(ctx, "invalid json", "/", ""),
+                                      "remote exception: std::exception: invalid JSON received over IPC")
+            self.log.debug("The connection still works after the failed call")
+            request = json.dumps({"method": "getblockcount", "params": [], "id": 1})
+            response = json.loads((await rpc.executeRpc(ctx, request, "/", "")).result)
+            assert_equal(response["result"], self.nodes[0].getblockcount())
         asyncio.run(capnp.run(async_routine()))
 
     def run_mining_test(self):
@@ -164,6 +181,7 @@ class IPCInterfaceTest(BitcoinTestFramework):
 
     def run_test(self):
         self.run_echo_test()
+        self.run_rpc_invalid_json_test()
         self.run_mining_test()
         self.run_deprecated_mining_test()
         self.run_unclean_disconnect_test()

--- a/test/functional/interface_ipc_mining.py
+++ b/test/functional/interface_ipc_mining.py
@@ -37,7 +37,7 @@ from test_framework.util import (
 from test_framework.wallet import MiniWallet
 from test_framework.p2p import P2PInterface
 from test_framework.ipc_util import (
-    assert_capnp_failed,
+    assert_capnp_raises,
     assert_create_new_block_fails,
     destroying,
     load_capnp_modules,
@@ -523,11 +523,8 @@ class IPCMiningTest(BitcoinTestFramework):
                 assert_equal(submitted, False)
 
                 self.log.debug("Submit solution that can't be deserialized")
-                try:
-                    await template.submitSolution(ctx, 0, 0, 0, b"\x00")
-                    raise AssertionError("submitSolution unexpectedly succeeded")
-                except capnp.lib.capnp.KjException as e:
-                    assert_capnp_failed(e, "remote exception: std::exception: SpanReader::read(): end of data:")
+                await assert_capnp_raises(lambda: template.submitSolution(ctx, 0, 0, 0, b"\x00"),
+                                          "remote exception: std::exception: SpanReader::read(): end of data:")
 
                 self.log.debug("Submit a block with a bad version")
                 block.nVersion = 0
@@ -712,18 +709,12 @@ class IPCMiningTest(BitcoinTestFramework):
                 )
 
             self.log.debug("Submit a malformed complete block")
-            try:
-                await mining2.submitBlock(ctx2, block.serialize()[:-15])
-                raise AssertionError("submitBlock unexpectedly succeeded")
-            except capnp.lib.capnp.KjException as e:
-                assert_capnp_failed(e, "remote exception: std::exception: SpanReader::read(): end of data:")
+            await assert_capnp_raises(lambda: mining2.submitBlock(ctx2, block.serialize()[:-15]),
+                                      "remote exception: std::exception: SpanReader::read(): end of data:")
 
             self.log.debug("Submit empty block data")
-            try:
-                await mining2.submitBlock(ctx2, b"")
-                raise AssertionError("submitBlock unexpectedly succeeded")
-            except capnp.lib.capnp.KjException as e:
-                assert_capnp_failed(e, "remote exception: std::exception: SpanReader::read(): end of data:")
+            await assert_capnp_raises(lambda: mining2.submitBlock(ctx2, b""),
+                                      "remote exception: std::exception: SpanReader::read(): end of data:")
             assert_equal(self.nodes[2].is_node_stopped(), False)
 
         asyncio.run(capnp.run(async_routine()))

--- a/test/functional/test_framework/ipc_util.py
+++ b/test/functional/test_framework/ipc_util.py
@@ -159,15 +159,17 @@ async def make_mining_ctx(self, node_index=0):
     mining = init.makeMining(ctx).result
     return ctx, mining
 
-def assert_capnp_failed(e, description_prefix):
-    assert e.description.startswith(description_prefix), f"Expected description starting with '{description_prefix}', got '{e.description}'"
-    assert_equal(e.type, "FAILED")
+
+async def assert_capnp_raises(fun, description_prefix):
+    try:
+        await fun()
+        raise AssertionError(f"Function unexpectedly succeeded without raising {description_prefix!r}")
+    except capnp.lib.capnp.KjException as e:
+        assert e.description.startswith(description_prefix), f"Expected description starting with '{description_prefix}', got '{e.description}'"
+        assert_equal(e.type, "FAILED")
 
 
 async def assert_create_new_block_fails(ctx, mining, opts, expected_msg):
     """Assert that mining.createNewBlock fails with the expected remote exception."""
-    try:
-        await mining.createNewBlock(ctx, opts)
-        raise AssertionError("createNewBlock unexpectedly succeeded")
-    except capnp.lib.capnp.KjException as e:
-        assert_capnp_failed(e, f"remote exception: std::exception: {expected_msg}")
+    await assert_capnp_raises(lambda: mining.createNewBlock(ctx, opts),
+                              f"remote exception: std::exception: {expected_msg}")


### PR DESCRIPTION
Suggested (by me) as a followup for #36088:
https://github.com/bitcoin/bitcoin/pull/36088#discussion_r3864044274

Reverting that PR will cause the test to fail.

The first refactor commit changes `assert_capnp_failed` to `assert_capnp_raises` to reduce repetition.