### PR TITLE
fees: validate persisted mempool policy estimator data after restoration

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -539,7 +539,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
     argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, up to %d, <0 = leave that many cores free, default: %d)",
         MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-prevoutfetchthreads=<n>", strprintf("Set the number of threads used to prefetch block input prevouts from the chainstate database (0 disables, up to %d, default: %d). Negative values are rejected.", MAX_PREVOUTFETCH_THREADS, DEFAULT_PREVOUTFETCH_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-persistmempool", strprintf("Whether to save and load the mempool and persist related mempool-policy estimator data across restarts (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempoolv1",
                    strprintf("Whether a mempool.dat file created by -persistmempool or the savemempool RPC will be written in the legacy format "
                              "(version 1) or the current format (version 2). This temporary option will be removed in the future. (default: %u)",
@@ -1960,7 +1960,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             return InitError(strprintf(_("acceptstalefeeestimates is not supported on %s chain."), chainparams.GetChainTypeString()));
         }
         MaybeMigrateLegacyFeeEstimates(args);
-        node.fee_estimator_man = std::make_unique<FeeRateEstimatorManager>(BlockPolicyFeeEstPath(args), read_stale_estimates, MempoolPolicyEstimatorPath(args), *Assert(node.mempool), chainman);
+        const fs::path mempool_estimator_path{
+            ShouldPersistMempool(args) ? MempoolPolicyEstimatorPath(args) : fs::path{}};
+        node.fee_estimator_man = std::make_unique<FeeRateEstimatorManager>(
+            BlockPolicyFeeEstPath(args), read_stale_estimates, mempool_estimator_path,
+            *Assert(node.mempool), chainman);
 
         // Flush estimates to disk periodically
         FeeRateEstimatorManager* fee_estimator_man = node.fee_estimator_man.get();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2133,7 +2133,21 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
         // Load mempool from disk
         if (auto* pool{chainman.ActiveChainstate().GetMempool()}) {
-            LoadMempool(*pool, ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{}, chainman.ActiveChainstate(), {});
+            const auto load_result{LoadMempool(
+                *pool,
+                ShouldPersistMempool(args) ? MempoolPath(args) : fs::path{},
+                chainman.ActiveChainstate(), {})};
+            if (node.fee_estimator_man && !chainman.m_interrupt) {
+                FeeRateEstimatorManager* const fee_estimator_man{node.fee_estimator_man.get()};
+                ValidationSignals& validation_signals{*Assert(node.validation_signals)};
+                // Queue completion after block notifications generated during
+                // startup so the mempool-policy estimator ignores them.
+                validation_signals.CallFunctionInValidationInterfaceQueue([fee_estimator_man,
+                                                                           load_result] {
+                    fee_estimator_man->MempoolLoadCompleted(load_result);
+                });
+                validation_signals.SyncWithValidationInterfaceQueue();
+            }
             pool->SetLoadTried(!chainman.m_interrupt);
         }
     });

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -6,6 +6,7 @@
 
 #include <clientversion.h>
 #include <consensus/amount.h>
+#include <consensus/validation.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <serialize.h>
@@ -30,7 +31,6 @@
 #include <memory>
 #include <set>
 #include <stdexcept>
-#include <utility>
 #include <vector>
 
 using fsbridge::FopenFn;
@@ -40,14 +40,14 @@ namespace node {
 static const uint64_t MEMPOOL_DUMP_VERSION_NO_XOR_KEY{1};
 static const uint64_t MEMPOOL_DUMP_VERSION{2};
 
-bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active_chainstate, ImportMempoolOptions&& opts)
+MempoolLoadResult LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active_chainstate, ImportMempoolOptions&& opts)
 {
-    if (load_path.empty()) return false;
+    if (load_path.empty()) return util::Unexpected{MempoolLoadError::NO_LOAD_PATH};
 
     AutoFile file{opts.mockable_fopen_function(load_path, "rb")};
     if (file.IsNull()) {
         LogInfo("Failed to open mempool file. Continuing anyway.\n");
-        return false;
+        return util::Unexpected{MempoolLoadError::FILE_OPEN_FAILED};
     }
 
     int64_t count = 0;
@@ -56,6 +56,7 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
     int64_t already_there = 0;
     int64_t unbroadcast = 0;
     const auto now{NodeClock::now()};
+    uint64_t snapshot_weight{0};
 
     try {
         uint64_t version;
@@ -68,7 +69,7 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             file >> obfuscation;
             file.SetObfuscation(obfuscation);
         } else {
-            return false;
+            return util::Unexpected{MempoolLoadError::UNSUPPORTED_VERSION};
         }
 
         uint64_t total_txns_to_load;
@@ -91,6 +92,7 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             file >> TX_WITH_WITNESS(tx);
             file >> nTime;
             file >> nFeeDelta;
+            snapshot_weight += static_cast<uint64_t>(GetTransactionWeight(*tx));
 
             if (opts.use_current_time) {
                 nTime = TicksSinceEpoch<std::chrono::seconds>(now);
@@ -119,8 +121,9 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             } else {
                 ++expired;
             }
-            if (active_chainstate.m_chainman.m_interrupt)
-                return false;
+            if (active_chainstate.m_chainman.m_interrupt) {
+                return util::Unexpected{MempoolLoadError::INTERRUPTED};
+            }
         }
         std::map<Txid, CAmount> mapDeltas;
         file >> mapDeltas;
@@ -143,11 +146,11 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
         }
     } catch (const std::exception& e) {
         LogInfo("Failed to deserialize mempool data on file: %s. Continuing anyway.\n", e.what());
-        return false;
+        return util::Unexpected{MempoolLoadError::DESERIALIZATION_FAILED};
     }
 
     LogInfo("Imported mempool transactions from file: %i succeeded, %i failed, %i expired, %i already there, %i waiting for initial broadcast\n", count, failed, expired, already_there, unbroadcast);
-    return true;
+    return snapshot_weight;
 }
 
 bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mockable_fopen_function, bool skip_file_commit)

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -14,6 +14,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/log.h>
@@ -39,6 +40,24 @@ namespace node {
 
 static const uint64_t MEMPOOL_DUMP_VERSION_NO_XOR_KEY{1};
 static const uint64_t MEMPOOL_DUMP_VERSION{2};
+
+std::string_view MempoolLoadErrorString(MempoolLoadError error)
+{
+    switch (error) {
+    case MempoolLoadError::NO_LOAD_PATH:
+        return "NO_LOAD_PATH";
+    case MempoolLoadError::FILE_OPEN_FAILED:
+        return "FILE_OPEN_FAILED";
+    case MempoolLoadError::UNSUPPORTED_VERSION:
+        return "UNSUPPORTED_VERSION";
+    case MempoolLoadError::INTERRUPTED:
+        return "INTERRUPTED";
+    case MempoolLoadError::DESERIALIZATION_FAILED:
+        return "DESERIALIZATION_FAILED";
+    }
+    Assume(false);
+    return "UNKNOWN";
+}
 
 MempoolLoadResult LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active_chainstate, ImportMempoolOptions&& opts)
 {

--- a/src/node/mempool_persist.h
+++ b/src/node/mempool_persist.h
@@ -9,6 +9,7 @@
 #include <util/fs.h>
 
 #include <cstdint>
+#include <string_view>
 
 class Chainstate;
 class CTxMemPool;
@@ -34,6 +35,9 @@ enum class MempoolLoadError {
     INTERRUPTED,
     DESERIALIZATION_FAILED,
 };
+
+/** Return a string representation for diagnostics. */
+std::string_view MempoolLoadErrorString(MempoolLoadError error);
 
 //! On success, contains the total weight of transactions in the persisted snapshot.
 using MempoolLoadResult = util::Expected<uint64_t, MempoolLoadError>;

--- a/src/node/mempool_persist.h
+++ b/src/node/mempool_persist.h
@@ -5,7 +5,10 @@
 #ifndef BITCOIN_NODE_MEMPOOL_PERSIST_H
 #define BITCOIN_NODE_MEMPOOL_PERSIST_H
 
+#include <util/expected.h>
 #include <util/fs.h>
+
+#include <cstdint>
 
 class Chainstate;
 class CTxMemPool;
@@ -23,10 +26,22 @@ struct ImportMempoolOptions {
     bool apply_fee_delta_priority{true};
     bool apply_unbroadcast_set{true};
 };
+
+enum class MempoolLoadError {
+    NO_LOAD_PATH,
+    FILE_OPEN_FAILED,
+    UNSUPPORTED_VERSION,
+    INTERRUPTED,
+    DESERIALIZATION_FAILED,
+};
+
+//! On success, contains the total weight of transactions in the persisted snapshot.
+using MempoolLoadResult = util::Expected<uint64_t, MempoolLoadError>;
+
 /** Import the file and attempt to add its contents to the mempool. */
-bool LoadMempool(CTxMemPool& pool, const fs::path& load_path,
-                 Chainstate& active_chainstate,
-                 ImportMempoolOptions&& opts);
+MempoolLoadResult LoadMempool(CTxMemPool& pool, const fs::path& load_path,
+                              Chainstate& active_chainstate,
+                              ImportMempoolOptions&& opts);
 
 } // namespace node
 

--- a/src/policy/fees/estimator_man.cpp
+++ b/src/policy/fees/estimator_man.cpp
@@ -59,13 +59,21 @@ util::Expected<FeeRateEstimation, FeeRateEstimationError> FeeRateEstimatorManage
 void FeeRateEstimatorManager::IntervalFlush()
 {
     m_block_policy_estimator->FlushFeeEstimates();
-    m_mempool_estimator->FlushMinedBlockStats();
+    if (m_mempool_load_completed) m_mempool_estimator->FlushMinedBlockStats();
 }
 
 void FeeRateEstimatorManager::ShutdownFlush()
 {
     m_block_policy_estimator->Flush();
-    m_mempool_estimator->FlushMinedBlockStats();
+    if (m_mempool_load_completed) m_mempool_estimator->FlushMinedBlockStats();
+}
+
+void FeeRateEstimatorManager::MempoolLoadCompleted(const node::MempoolLoadResult& load_result)
+{
+    if (load_result) {
+        m_mempool_estimator->MempoolRestored(*load_result);
+    }
+    m_mempool_load_completed = true;
 }
 
 std::vector<MinedBlockStats> FeeRateEstimatorManager::MempoolPolicyEstimatorBlocksStats() const
@@ -86,7 +94,9 @@ void FeeRateEstimatorManager::TransactionRemovedFromMempool(const CTransactionRe
 void FeeRateEstimatorManager::MempoolTransactionsRemovedForBlock(const std::shared_ptr<const CBlock>& block, const std::vector<RemovedMempoolTransactionInfo>& txs_removed_for_block, unsigned int block_height)
 {
     m_block_policy_estimator->processBlock(txs_removed_for_block, block_height);
-    m_mempool_estimator->MempoolTxsRemovedForBlock(block, txs_removed_for_block, block_height);
+    if (m_mempool_load_completed) {
+        m_mempool_estimator->MempoolTxsRemovedForBlock(block, txs_removed_for_block, block_height);
+    }
 }
 
 CFeeRate FeeRateEstimatorManager::BlockPolicyEstimateRawFee(unsigned int target, double threshold, FeeEstimateHorizon horizon, EstimationResult* buckets) const

--- a/src/policy/fees/estimator_man.cpp
+++ b/src/policy/fees/estimator_man.cpp
@@ -72,6 +72,11 @@ void FeeRateEstimatorManager::MempoolLoadCompleted(const node::MempoolLoadResult
 {
     if (load_result) {
         m_mempool_estimator->MempoolRestored(*load_result);
+    } else if (load_result.error() != node::MempoolLoadError::NO_LOAD_PATH) {
+        LogDebug(BCLog::ESTIMATEFEE,
+                 "%s: not loading persisted mined-block stats because mempool loading failed; error=%s",
+                 FeeRateEstimatorTypeToString(FeeRateEstimatorType::MEMPOOL_POLICY),
+                 node::MempoolLoadErrorString(load_result.error()));
     }
     m_mempool_load_completed = true;
 }

--- a/src/policy/fees/estimator_man.h
+++ b/src/policy/fees/estimator_man.h
@@ -33,7 +33,7 @@ public:
     /**
      * @param[in] block_policy_path    Path to the block policy fee estimates file.
      * @param[in] read_stale_estimates Whether to load stale estimates from disk.
-     * @param[in] mempool_estimator_path Path to the mempool policy estimator data file.
+     * @param[in] mempool_estimator_path Path to the mempool policy estimator data file, or empty to disable persistence.
      * @param[in] mempool              The mempool to use for the mempool fee rate estimator.
      * @param[in] chainman             The chainstate manager.
      */

--- a/src/policy/fees/estimator_man.h
+++ b/src/policy/fees/estimator_man.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_POLICY_FEES_ESTIMATOR_MAN_H
 #define BITCOIN_POLICY_FEES_ESTIMATOR_MAN_H
 
+#include <node/mempool_persist.h>
 #include <policy/fees/block_policy_estimator.h>
 #include <policy/fees/mempool_estimator.h>
 #include <primitives/transaction.h>
@@ -13,6 +14,7 @@
 #include <util/fs.h>
 #include <validationinterface.h>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 
@@ -68,6 +70,9 @@ public:
     /** Flush recorded data to disk as part of shutdown sequence. */
     void ShutdownFlush();
 
+    /** Complete mempool loading and conditionally restore persisted mempool health. */
+    void MempoolLoadCompleted(const node::MempoolLoadResult& load_result);
+
     /**
      * @brief Returns the maximum supported confirmation target from all fee rate estimators.
      */
@@ -97,6 +102,9 @@ protected:
 private:
     std::unique_ptr<CBlockPolicyEstimator> m_block_policy_estimator;
     std::unique_ptr<MemPoolFeeRateEstimator> m_mempool_estimator;
+    //! Whether the mempool load attempt completed without interruption. Until
+    //! then, mempool-policy block notifications and flushes are ignored.
+    std::atomic_bool m_mempool_load_completed{false};
 };
 
 #endif // BITCOIN_POLICY_FEES_ESTIMATOR_MAN_H

--- a/src/policy/fees/mempool_estimator.cpp
+++ b/src/policy/fees/mempool_estimator.cpp
@@ -167,7 +167,6 @@ MemPoolFeeRateEstimator::MemPoolFeeRateEstimator(fs::path mempool_estimator_file
       m_chainman(chainman),
       m_mempool_estimator_file_path(std::move(mempool_estimator_file_path))
 {
-    ReadFromDisk();
 }
 
 void MemPoolFeeRateEstimator::ReadFromDisk()
@@ -318,6 +317,25 @@ void MemPoolFeeRateEstimator::MempoolTxsRemovedForBlock(const std::shared_ptr<co
     AddMinedBlockStats(m_prev_mined_blocks, {block_height, removed_weight, block_weight});
     m_mined_blocks_tip_hash = block->GetHash();
     m_cache.Clear();
+}
+
+void MemPoolFeeRateEstimator::MempoolRestored(uint64_t snapshot_weight)
+{
+    const uint64_t post_load_mempool_weight{
+        WITH_LOCK(m_mempool.cs, return m_mempool.GetTotalTxWeight())};
+    const double retention_ratio{snapshot_weight == 0 ? 1.0 : static_cast<double>(post_load_mempool_weight) / snapshot_weight};
+    if (retention_ratio < MEMPOOL_SNAPSHOT_RETENTION_THRESHOLD) {
+        LogDebug(BCLog::ESTIMATEFEE,
+                 "%s: not loading persisted mined-block stats because post-load weight was insufficient; "
+                 "post_load_mempool_weight=%s snapshot_weight=%s retention_ratio=%.2f required_retention=%.2f",
+                 FeeRateEstimatorTypeToString(FeeRateEstimatorType::MEMPOOL_POLICY),
+                 post_load_mempool_weight,
+                 snapshot_weight,
+                 retention_ratio,
+                 MEMPOOL_SNAPSHOT_RETENTION_THRESHOLD);
+        return;
+    }
+    ReadFromDisk();
 }
 
 // Require at least one block worth of activity across the window before using

--- a/src/policy/fees/mempool_estimator.cpp
+++ b/src/policy/fees/mempool_estimator.cpp
@@ -172,6 +172,7 @@ MemPoolFeeRateEstimator::MemPoolFeeRateEstimator(fs::path mempool_estimator_file
 
 void MemPoolFeeRateEstimator::ReadFromDisk()
 {
+    if (m_mempool_estimator_file_path.empty()) return;
     AutoFile file{fsbridge::fopen(m_mempool_estimator_file_path, "rb")};
     if (file.IsNull()) {
         LogDebug(BCLog::ESTIMATEFEE, "%s: %s does not exist. Continuing anyway",
@@ -260,6 +261,7 @@ bool MemPoolFeeRateEstimator::Write(AutoFile& file) const
 
 void MemPoolFeeRateEstimator::FlushMinedBlockStats()
 {
+    if (m_mempool_estimator_file_path.empty()) return;
     if (!m_mempool_estimator_file_path.parent_path().empty()) {
         std::error_code error;
         fs::create_directories(m_mempool_estimator_file_path.parent_path(), error);

--- a/src/policy/fees/mempool_estimator.h
+++ b/src/policy/fees/mempool_estimator.h
@@ -36,6 +36,9 @@ constexpr std::chrono::seconds CACHE_LIFE{7};
 // Constants for mempool sanity checks.
 constexpr size_t MEMPOOL_HEALTH_WINDOW_BLOCKS = 6;
 constexpr double MEMPOOL_REPRESENTATION_THRESHOLD = 0.75;
+//! Minimum post-load mempool weight relative to the persisted snapshot weight
+//! required to retain persisted mined-block statistics.
+constexpr double MEMPOOL_SNAPSHOT_RETENTION_THRESHOLD{0.75};
 
 //! Weight statistics for a recently mined block, used to assess mempool coverage.
 struct MinedBlockStats {
@@ -122,6 +125,17 @@ public:
                                    const std::vector<RemovedMempoolTransactionInfo>& txs_removed_for_block,
                                    unsigned int block_height)
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    /**
+     * Read persisted health after a successful mempool restoration when the
+     * post-load mempool weight is sufficient relative to the persisted snapshot.
+     *
+     * This is intentionally permissive: transactions added independently by
+     * wallets, RPC, peers, or reorg handling before the post-load measurement
+     * contribute to post_load_mempool_weight. This biases the decision toward
+     * retaining potentially usable estimator history, but does not measure
+     * exact snapshot overlap.
+     */
+    void MempoolRestored(uint64_t snapshot_weight) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     //! Health of the recent mined-block window for fee rate estimation.
     enum class MempoolHealth {
         //! Recent blocks represent the mempool well enough to estimate a fee rate.

--- a/src/test/mempool_fee_estimator_tests.cpp
+++ b/src/test/mempool_fee_estimator_tests.cpp
@@ -2,8 +2,11 @@
 // Distributed under the MIT software license. See the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chainparams.h>
 #include <kernel/mempool_entry.h>
+#include <node/mempool_persist.h>
 #include <policy/fees/estimator_args.h>
+#include <policy/fees/estimator_man.h>
 #include <policy/fees/mempool_estimator.h>
 #include <policy/policy.h>
 #include <primitives/block.h>
@@ -15,6 +18,7 @@
 #include <util/feefrac.h>
 #include <util/fees.h>
 #include <util/time.h>
+#include <util/translation.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -22,6 +26,13 @@
 #include <string>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_fee_estimator_tests, TestingSetup)
+
+class TestFeeRateEstimatorManager final : public FeeRateEstimatorManager
+{
+public:
+    using FeeRateEstimatorManager::FeeRateEstimatorManager;
+    using FeeRateEstimatorManager::MempoolTransactionsRemovedForBlock;
+};
 
 static inline CTransactionRef MakeRandomTx()
 {
@@ -126,6 +137,84 @@ BOOST_AUTO_TEST_CASE(mempool_fee_rate_estimator_cache)
     clock += CACHE_LIFE + std::chrono::seconds{1};
     BOOST_CHECK(cache.IsStale());
     BOOST_CHECK(!cache.GetCachedEstimate(tip_hash));
+}
+
+BOOST_AUTO_TEST_CASE(mempool_post_load_weight_retention)
+{
+    const fs::path estimator_path{MempoolPolicyEstimatorPath(*m_node.args)};
+    const auto genesis{std::make_shared<CBlock>(Params().GenesisBlock())};
+    {
+        MemPoolFeeRateEstimator persisted_estimator{
+            estimator_path, *m_node.mempool, *m_node.chainman};
+        persisted_estimator.MempoolTxsRemovedForBlock(
+            genesis, /*txs_removed_for_block=*/{}, /*block_height=*/0);
+        persisted_estimator.FlushMinedBlockStats();
+    }
+
+    // Persisted stats are not read during construction, and block notifications
+    // received before mempool loading completes are ignored.
+    {
+        TestFeeRateEstimatorManager interrupted_manager{
+            BlockPolicyFeeEstPath(*m_node.args), /*read_stale_estimates=*/false,
+            estimator_path, *m_node.mempool, *m_node.chainman};
+        auto pre_load_block{std::make_shared<CBlock>(*genesis)};
+        ++pre_load_block->nNonce;
+        interrupted_manager.MempoolTransactionsRemovedForBlock(
+            pre_load_block, /*txs_removed_for_block=*/{}, /*block_height=*/1);
+        BOOST_CHECK(interrupted_manager.MempoolPolicyEstimatorBlocksStats().empty());
+
+        // Pre-load flushes must not replace persisted stats with the empty in-memory state.
+        interrupted_manager.IntervalFlush();
+        interrupted_manager.ShutdownFlush();
+    }
+
+    // A successful load of an empty snapshot reads the preserved stats.
+    TestFeeRateEstimatorManager empty_snapshot_manager{
+        BlockPolicyFeeEstPath(*m_node.args), /*read_stale_estimates=*/false,
+        estimator_path, *m_node.mempool, *m_node.chainman};
+    BOOST_CHECK(empty_snapshot_manager.MempoolPolicyEstimatorBlocksStats().empty());
+    empty_snapshot_manager.MempoolLoadCompleted(node::MempoolLoadResult{0});
+    const auto empty_snapshot_stats{empty_snapshot_manager.MempoolPolicyEstimatorBlocksStats()};
+    BOOST_REQUIRE_EQUAL(empty_snapshot_stats.size(), 1);
+    BOOST_CHECK_EQUAL(empty_snapshot_stats.front().m_height, 0);
+
+    bilingual_str mempool_error;
+    CTxMemPool populated_mempool{MemPoolOptionsForTest(m_node), mempool_error};
+    BOOST_REQUIRE(mempool_error.empty());
+    TestMemPoolEntryHelper entry;
+    const auto tx{MakeRandomTx()};
+    const uint64_t tx_weight{static_cast<uint64_t>(GetTransactionWeight(*tx))};
+    TryAddToMempool(populated_mempool, entry.FromTx(tx));
+    for (int i{0}; i < 2; ++i) {
+        const auto additional_tx{MakeRandomTx()};
+        BOOST_REQUIRE_EQUAL(GetTransactionWeight(*additional_tx), tx_weight);
+        TryAddToMempool(populated_mempool, entry.FromTx(additional_tx));
+    }
+    BOOST_REQUIRE_EQUAL(WITH_LOCK(populated_mempool.cs, return populated_mempool.GetTotalTxWeight()), 3 * tx_weight);
+
+    // Read persisted stats at the weight threshold. The post-load weight is
+    // deliberately permissive and may include transactions that were not in
+    // the snapshot.
+    TestFeeRateEstimatorManager threshold_manager{
+        BlockPolicyFeeEstPath(*m_node.args), /*read_stale_estimates=*/false,
+        estimator_path, populated_mempool, *m_node.chainman};
+    threshold_manager.MempoolLoadCompleted(node::MempoolLoadResult{4 * tx_weight});
+    BOOST_CHECK_EQUAL(threshold_manager.MempoolPolicyEstimatorBlocksStats().size(), 1);
+
+    // Falling below the separately defined retention threshold skips the read.
+    TestFeeRateEstimatorManager below_threshold_manager{
+        BlockPolicyFeeEstPath(*m_node.args), /*read_stale_estimates=*/false,
+        estimator_path, populated_mempool, *m_node.chainman};
+    below_threshold_manager.MempoolLoadCompleted(node::MempoolLoadResult{4 * tx_weight + 1});
+    BOOST_CHECK(below_threshold_manager.MempoolPolicyEstimatorBlocksStats().empty());
+
+    // A failed load skips the read even when the post-load mempool is nonempty.
+    TestFeeRateEstimatorManager failed_load_manager{
+        BlockPolicyFeeEstPath(*m_node.args), /*read_stale_estimates=*/false,
+        estimator_path, populated_mempool, *m_node.chainman};
+    failed_load_manager.MempoolLoadCompleted(
+        util::Unexpected{node::MempoolLoadError::FILE_OPEN_FAILED});
+    BOOST_CHECK(failed_load_manager.MempoolPolicyEstimatorBlocksStats().empty());
 }
 
 BOOST_AUTO_TEST_CASE(MempoolFeeRateEstimator)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -504,6 +504,18 @@ public:
         return totalTxSize;
     }
 
+    //! Sum of all mempool transaction weights (BIP 141). Computed by walking
+    //! the pool, so this method should not be called in hot paths.
+    uint64_t GetTotalTxWeight() const EXCLUSIVE_LOCKS_REQUIRED(cs)
+    {
+        AssertLockHeld(cs);
+        uint64_t total_weight{0};
+        for (const auto& entry : mapTx) {
+            total_weight += static_cast<uint64_t>(entry.GetTxWeight());
+        }
+        return total_weight;
+    }
+
     CAmount GetTotalFee() const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
         AssertLockHeld(cs);

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -31,6 +31,7 @@ SECONDS_PER_HOUR = 60 * 60
 MIN_BUCKET_FEERATE = Decimal(100) / Decimal(COIN)
 TXS_COUNT = 24
 BLOCK_POLICY_ESTIMATOR_ERROR = "Insufficient data or no feerate found"
+MEMPOOL_POLICY_ESTIMATOR_INSUFFICIENT_DATA_ERROR = "mempool_policy: Not enough recent block data for fee rate estimation"
 BLOCK_POLICY_ESTIMATOR_FILE_PATH = "fees/block_policy_estimates.dat"
 
 def small_txpuzzle_randfee(
@@ -570,6 +571,65 @@ class EstimateFeeTest(BitcoinTestFramework):
         combined_estimate = node0.estimatesmartfee(1, "economical", {"fee_rate_estimator": "none"})
         verify_estimate_response(combined_estimate, floor, [])
         assert_equal(combined_estimate["estimator"], "mempool_policy")
+
+        self.log.info("Test persisted mined-block statistics require sufficient post-load mempool weight")
+        # Save matching estimator and mempool snapshots with transactions in the
+        # mempool. Reuse them to exercise startup conditions where the post-load
+        # mempool may be too light while the persisted estimator window still
+        # matches the chain tip.
+        snapshot_utxos = [self.wallet.get_utxo(confirmed_only=True) for _ in range(2)]
+        snapshot_time = int(time.time())
+        node0.setmocktime(snapshot_time)
+        self.send_transactions(snapshot_utxos[:1], low_feerate, target_vsize=200)
+        latest_entry_time = snapshot_time + 2 * SECONDS_PER_HOUR
+        node0.setmocktime(latest_entry_time)
+        self.send_transactions(snapshot_utxos[1:], low_feerate, target_vsize)
+        mempool_policy_dat = node0.chain_path / "fees/mempool_policy_estimator.dat"
+        mempool_dat = node0.chain_path / "mempool.dat"
+        self.stop_node(0)
+        mempool_policy_snapshot = mempool_policy_dat.read_bytes()
+        mempool_snapshot = mempool_dat.read_bytes()
+
+        def start_from_snapshot(extra_args=None, *, remove_mempool=False):
+            mempool_policy_dat.write_bytes(mempool_policy_snapshot)
+            mempool_dat.write_bytes(mempool_snapshot)
+            if remove_mempool:
+                mempool_dat.unlink()
+            self.start_node(0, extra_args)
+
+        def assert_mempool_estimator_unavailable():
+            estimate = node0.estimatesmartfee(1, "economical", {"verbosity": 2, "fee_rate_estimator": "none"})
+            assert "feerate" not in estimate
+            verify_estimate_response(estimate, None, [MEMPOOL_POLICY_ESTIMATOR_INSUFFICIENT_DATA_ERROR])
+            assert_equal(estimate["mempool_health_statistics"], [])
+
+        self.log.info("Retain persisted mined-block statistics when post-load weight meets the threshold")
+        start_from_snapshot(extra_args=["-mempoolexpiry=1", f"-mocktime={latest_entry_time}"])
+        assert_equal(node0.getmempoolinfo()["size"], 1)
+        estimate = node0.estimatesmartfee(1, "economical", {"verbosity": 2, "fee_rate_estimator": "mempool_policy"})
+        assert "feerate" in estimate
+        assert_equal(len(estimate["mempool_health_statistics"]), 6)
+        self.stop_node(0)
+
+        self.log.info("Do not load persisted mined-block statistics when mempool persistence is disabled")
+        start_from_snapshot(extra_args=["-persistmempool=0"])
+        assert_equal(node0.getmempoolinfo()["size"], 0)
+        assert_mempool_estimator_unavailable()
+        self.stop_node(0)
+        assert_equal(mempool_policy_dat.read_bytes(), mempool_policy_snapshot)
+
+        self.log.info("Discard persisted mined-block statistics when mempool.dat is missing")
+        start_from_snapshot(remove_mempool=True)
+        assert_equal(node0.getmempoolinfo()["size"], 0)
+        assert_mempool_estimator_unavailable()
+        self.stop_node(0)
+
+        self.log.info("Discard persisted mined-block statistics when mempool.dat transactions are expired")
+        start_from_snapshot(extra_args=["-mempoolexpiry=1", f"-mocktime={latest_entry_time + 2 * SECONDS_PER_HOUR}"])
+        assert_equal(node0.getmempoolinfo()["size"], 0)
+        assert_mempool_estimator_unavailable()
+        self.restart_node(0)
+        assert_mempool_estimator_unavailable()
 
     def test_stale_mempool_block_stats_are_rejected_on_load(self):
         # Persisted mempool block stats must be tied to the best block hash,

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -612,14 +612,16 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.stop_node(0)
 
         self.log.info("Do not load persisted mined-block statistics when mempool persistence is disabled")
-        start_from_snapshot(extra_args=["-persistmempool=0"])
+        with node0.assert_debug_log(expected_msgs=[], unexpected_msgs=["mempool loading failed"]):
+            start_from_snapshot(extra_args=["-persistmempool=0"])
         assert_equal(node0.getmempoolinfo()["size"], 0)
         assert_mempool_estimator_unavailable()
         self.stop_node(0)
         assert_equal(mempool_policy_dat.read_bytes(), mempool_policy_snapshot)
 
         self.log.info("Discard persisted mined-block statistics when mempool.dat is missing")
-        start_from_snapshot(remove_mempool=True)
+        with node0.assert_debug_log(expected_msgs=["mempool loading failed; error=FILE_OPEN_FAILED"]):
+            start_from_snapshot(remove_mempool=True)
         assert_equal(node0.getmempoolinfo()["size"], 0)
         assert_mempool_estimator_unavailable()
         self.stop_node(0)


### PR DESCRIPTION
The mempool policy estimator reloads its mined-block statistics separately from `mempool.dat`. 
Currently, those statistics are retained even when mempool persistence is disabled, `mempool.dat` is missing, or most snapshot transactions are not restored. 
This could make an empty or unrepresentative mempool appear healthy and produce misleading fee estimates.

This PR tracks the snapshot’s total and restored transaction weights during loading. 
Persisted estimator data is retained only when loading succeeds and the restored weight meets the existing mempool representation threshold. 
The data is preserved when startup is interrupted, and is neither read nor written when `-persistmempool=0`.

Tests cover partial restoration, disabled persistence, a missing snapshot, and expired snapshot transactions.