### PR TITLE
fuzz: add corpus reachability checks

### DIFF
--- a/src/test/fuzz/cmpctblock.cpp
+++ b/src/test/fuzz/cmpctblock.cpp
@@ -25,6 +25,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/net.h>
 #include <test/util/random.h>
 #include <test/util/script.h>
@@ -55,6 +56,8 @@
 namespace {
 
 TestingSetup* g_setup;
+constexpr ReachabilityGoal CMPCTBLOCK_CHANGES_MEMPOOL{"cmpctblock changes the mempool"};
+constexpr ReachabilityGoal CMPCTBLOCK_CHANGES_BLOCK_INDEX{"cmpctblock changes the block index"};
 
 //! Fee each created tx will pay.
 const CAmount AMOUNT_FEE{1000};
@@ -119,6 +122,8 @@ extern void MakeRandDeterministicDANGEROUS(const uint256& seed) noexcept;
 
 void initialize_cmpctblock()
 {
+    RegisterReachabilityGoal(CMPCTBLOCK_CHANGES_MEMPOOL);
+    RegisterReachabilityGoal(CMPCTBLOCK_CHANGES_BLOCK_INDEX);
     FakeNodeClock init_clock{}; // Uses the existing mock time
     static const auto testing_setup = MakeNoLogFileContext<TestingSetup>();
     g_setup = testing_setup.get();
@@ -477,6 +482,8 @@ FUZZ_TARGET(cmpctblock, .init = initialize_cmpctblock)
     const size_t end_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
     const uint64_t end_sequence{WITH_LOCK(mempool.cs, return mempool.GetSequence())};
 
+    ObserveReachabilityGoal(initial_sequence != end_sequence, CMPCTBLOCK_CHANGES_MEMPOOL);
+    ObserveReachabilityGoal(initial_index_size != end_index_size, CMPCTBLOCK_CHANGES_BLOCK_INDEX);
     if (initial_index_size != end_index_size || initial_sequence != end_sequence) {
         MakeRandDeterministicDANGEROUS(uint256::ZERO);
         g_mature_coinbase = ResetChainmanAndMempool(*g_setup, node_clock);

--- a/src/test/fuzz/p2p_handshake.cpp
+++ b/src/test/fuzz/p2p_handshake.cpp
@@ -11,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
@@ -24,9 +25,11 @@
 
 namespace {
 TestingSetup* g_setup;
+constexpr ReachabilityGoal P2P_HANDSHAKE_COMPLETES{"p2p_handshake completes a handshake"};
 
 void initialize()
 {
+    RegisterReachabilityGoal(P2P_HANDSHAKE_COMPLETES);
     static const auto testing_setup = MakeNoLogFileContext<TestingSetup>(
         /*chain_type=*/ChainType::REGTEST);
     g_setup = testing_setup.get();
@@ -112,5 +115,10 @@ FUZZ_TARGET(p2p_handshake, .init = ::initialize)
         }
     }
 
+    bool completed_handshake{false};
+    for (const CNode* peer : peers) {
+        completed_handshake |= peer->fSuccessfullyConnected;
+    }
+    ObserveReachabilityGoal(completed_handshake, P2P_HANDSHAKE_COMPLETES);
     node.connman->StopNodes();
 }

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -10,6 +10,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/reachability.h>
 #include <util/chaintype.h>
 
 #include <algorithm>
@@ -22,12 +23,19 @@
 namespace {
 
 auto g_all_messages = ALL_NET_MESSAGE_TYPES;
+constexpr ReachabilityGoal V1_TRANSPORT_RECEIVES_COMPLETE_MESSAGE{"v1 transport receives a complete message"};
 
-void initialize_p2p_transport_serialization()
+void initialize_p2p_transport()
 {
     static ECC_Context ecc_context{};
     SelectParams(ChainType::REGTEST);
     std::sort(g_all_messages.begin(), g_all_messages.end());
+}
+
+void initialize_p2p_transport_serialization()
+{
+    RegisterReachabilityGoal(V1_TRANSPORT_RECEIVES_COMPLETE_MESSAGE);
+    initialize_p2p_transport();
 }
 
 } // namespace
@@ -73,11 +81,13 @@ FUZZ_TARGET(p2p_transport_serialization, .init = initialize_p2p_transport_serial
 
     mutable_msg_bytes.insert(mutable_msg_bytes.end(), payload_bytes.begin(), payload_bytes.end());
     std::span<const uint8_t> msg_bytes{mutable_msg_bytes};
+    bool received_complete_message{false};
     while (msg_bytes.size() > 0) {
         if (!recv_transport.ReceivedBytes(msg_bytes)) {
             break;
         }
         if (recv_transport.ReceivedMessageComplete()) {
+            received_complete_message = true;
             const auto time{NodeClock::time_point::max()};
             bool reject_message{false};
             CNetMessage msg = recv_transport.GetReceivedMessage(time, reject_message);
@@ -99,6 +109,7 @@ FUZZ_TARGET(p2p_transport_serialization, .init = initialize_p2p_transport_serial
             }
         }
     }
+    ObserveReachabilityGoal(received_complete_message, V1_TRANSPORT_RECEIVES_COMPLETE_MESSAGE);
 }
 
 namespace {
@@ -371,7 +382,7 @@ std::unique_ptr<Transport> MakeV2Transport(NodeId nodeid, bool initiator, RNG& r
 
 } // namespace
 
-FUZZ_TARGET(p2p_transport_bidirectional, .init = initialize_p2p_transport_serialization)
+FUZZ_TARGET(p2p_transport_bidirectional, .init = initialize_p2p_transport)
 {
     // Test with two V1 transports talking to each other.
     FuzzedDataProvider provider{buffer.data(), buffer.size()};
@@ -382,7 +393,7 @@ FUZZ_TARGET(p2p_transport_bidirectional, .init = initialize_p2p_transport_serial
     SimulationTest(*t1, *t2, rng, provider);
 }
 
-FUZZ_TARGET(p2p_transport_bidirectional_v2, .init = initialize_p2p_transport_serialization)
+FUZZ_TARGET(p2p_transport_bidirectional_v2, .init = initialize_p2p_transport)
 {
     // Test with two V2 transports talking to each other.
     FuzzedDataProvider provider{buffer.data(), buffer.size()};
@@ -393,7 +404,7 @@ FUZZ_TARGET(p2p_transport_bidirectional_v2, .init = initialize_p2p_transport_ser
     SimulationTest(*t1, *t2, rng, provider);
 }
 
-FUZZ_TARGET(p2p_transport_bidirectional_v1v2, .init = initialize_p2p_transport_serialization)
+FUZZ_TARGET(p2p_transport_bidirectional_v1v2, .init = initialize_p2p_transport)
 {
     // Test with a V1 initiator talking to a V2 responder.
     FuzzedDataProvider provider{buffer.data(), buffer.size()};

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -19,6 +19,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/mempool.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/mining.h>
 #include <test/util/random.h>
 #include <test/util/script.h>
@@ -52,6 +53,7 @@ namespace {
 
 const TestingSetup* g_setup;
 std::vector<COutPoint> g_outpoints_coinbase_init_mature;
+constexpr ReachabilityGoal EPHEMERAL_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE{"ephemeral_package_eval processes a valid package"};
 
 struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
@@ -78,6 +80,12 @@ void initialize_tx_pool()
         }
     }
     g_setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
+}
+
+void initialize_ephemeral_package_eval()
+{
+    RegisterReachabilityGoal(EPHEMERAL_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE);
+    initialize_tx_pool();
 }
 
 struct OutpointsUpdater final : public CValidationInterface {
@@ -212,7 +220,7 @@ std::optional<COutPoint> GetChildEvictingPrevout(const CTxMemPool& tx_pool)
     return std::nullopt;
 }
 
-FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
+FUZZ_TARGET(ephemeral_package_eval, .init = initialize_ephemeral_package_eval)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
@@ -236,6 +244,8 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
     MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(tx_pool_.get());
 
     chainstate.SetMempool(&tx_pool);
+
+    bool valid_package{false};
 
     LIMITED_WHILE (fuzzed_data_provider.remaining_bytes() > 0, 300) {
         Assert(!mempool_outpoints.empty());
@@ -343,6 +353,7 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
 
         const auto result_package = WITH_LOCK(::cs_main,
                                     return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, /*client_maxfeerate=*/{}));
+        valid_package |= result_package.m_state.IsValid();
 
         const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, txs.back(), GetTime(),
                                    /*bypass_limits=*/false, /*test_accept=*/!single_submit));
@@ -363,6 +374,7 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_tx_pool)
     node.validation_signals->UnregisterSharedValidationInterface(outpoints_updater);
 
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
+    ObserveReachabilityGoal(valid_package, EPHEMERAL_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE);
 }
 
 

--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -54,6 +54,7 @@ namespace {
 const TestingSetup* g_setup;
 std::vector<COutPoint> g_outpoints_coinbase_init_mature;
 constexpr ReachabilityGoal EPHEMERAL_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE{"ephemeral_package_eval processes a valid package"};
+constexpr ReachabilityGoal TX_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE{"tx_package_eval processes a valid package"};
 
 struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
@@ -85,6 +86,12 @@ void initialize_tx_pool()
 void initialize_ephemeral_package_eval()
 {
     RegisterReachabilityGoal(EPHEMERAL_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE);
+    initialize_tx_pool();
+}
+
+void initialize_tx_package_eval()
+{
+    RegisterReachabilityGoal(TX_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE);
     initialize_tx_pool();
 }
 
@@ -378,7 +385,7 @@ FUZZ_TARGET(ephemeral_package_eval, .init = initialize_ephemeral_package_eval)
 }
 
 
-FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
+FUZZ_TARGET(tx_package_eval, .init = initialize_tx_package_eval)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
@@ -402,6 +409,8 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
     MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(tx_pool_.get());
 
     chainstate.SetMempool(&tx_pool);
+
+    bool valid_package{false};
 
     LIMITED_WHILE (fuzzed_data_provider.remaining_bytes() > 0, 300) {
         Assert(!mempool_outpoints.empty());
@@ -529,6 +538,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
 
         const auto result_package = WITH_LOCK(::cs_main,
                                     return ProcessNewPackage(chainstate, tx_pool, txs, /*test_accept=*/single_submit, client_maxfeerate));
+        valid_package |= result_package.m_state.IsValid();
 
         // Always set bypass_limits to false because it is not supported in ProcessNewPackage and
         // can be a source of divergence.
@@ -569,5 +579,6 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
     node.validation_signals->UnregisterSharedValidationInterface(outpoints_updater);
 
     WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
+    ObserveReachabilityGoal(valid_package, TX_PACKAGE_EVAL_PROCESSES_VALID_PACKAGE);
 }
 } // namespace

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -11,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/mempool.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <test/util/txmempool.h>
@@ -29,10 +30,14 @@
 
 namespace {
 const TestingSetup* g_setup;
+constexpr ReachabilityGoal COMPACT_BLOCK_INITIALIZATION_SUCCEEDS{"compact block initialization succeeds"};
+constexpr ReachabilityGoal COMPACT_BLOCK_RECONSTRUCTION_SUCCEEDS{"compact block reconstruction succeeds"};
 } // namespace
 
 void initialize_pdb()
 {
+    RegisterReachabilityGoal(COMPACT_BLOCK_INITIALIZATION_SUCCEEDS);
+    RegisterReachabilityGoal(COMPACT_BLOCK_RECONSTRUCTION_SUCCEEDS);
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
 }
@@ -88,6 +93,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
     }
 
     auto init_status{pdb.InitData(cmpctblock, extra_txn)};
+    ObserveReachabilityGoal(init_status == READ_STATUS_OK, COMPACT_BLOCK_INITIALIZATION_SUCCEEDS);
 
     std::vector<CTransactionRef> missing;
     // Whether we skipped a transaction that should be included in `missing`.
@@ -120,6 +126,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
 
     CBlock reconstructed_block;
     auto fill_status{pdb.FillBlock(reconstructed_block, missing, segwit_active)};
+    ObserveReachabilityGoal(fill_status == READ_STATUS_OK, COMPACT_BLOCK_RECONSTRUCTION_SUCCEEDS);
     switch (fill_status) {
     case READ_STATUS_OK:
         assert(!skipped_missing);

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -9,16 +9,19 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/setup_common.h>
 
 #include <memory>
 
 namespace {
 const TestingSetup* g_setup;
+constexpr ReachabilityGoal BLOCK_POLICY_ESTIMATOR_READ_SUCCEEDS{"block policy estimator reading succeeds"};
 } // namespace
 
 void initialize_policy_estimator_io()
 {
+    RegisterReachabilityGoal(BLOCK_POLICY_ESTIMATOR_READ_SUCCEEDS);
     static const auto testing_setup{
         MakeNoLogFileContext<const TestingSetup>(ChainType::REGTEST, TestOpts{.setup_net = false})};
     g_setup = testing_setup.get();
@@ -31,9 +34,11 @@ FUZZ_TARGET(policy_estimator_io, .init = initialize_policy_estimator_io)
     // Reuse estimators across runs to avoid costly object creation.
     static CBlockPolicyEstimator block_policy_estimator{
         BlockPolicyFeeEstPath(*g_setup->m_node.args), DEFAULT_ACCEPT_STALE_FEE_ESTIMATES};
+    bool block_policy_read_success{false};
     {
         AutoFile fuzzed_auto_file_block_policy{fuzzed_file_provider.open()};
-        if (block_policy_estimator.Read(fuzzed_auto_file_block_policy)) {
+        block_policy_read_success = block_policy_estimator.Read(fuzzed_auto_file_block_policy);
+        if (block_policy_read_success) {
             block_policy_estimator.Write(fuzzed_auto_file_block_policy);
         }
         (void)fuzzed_auto_file_block_policy.fclose();
@@ -51,4 +56,5 @@ FUZZ_TARGET(policy_estimator_io, .init = initialize_policy_estimator_io)
         // have written to the fuzzed file.
         (void)fuzzed_auto_file_mempool_policy.fclose();
     }
+    ObserveReachabilityGoal(block_policy_read_success, BLOCK_POLICY_ESTIMATOR_READ_SUCCEEDS);
 }

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -15,6 +15,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/net.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
@@ -41,6 +42,8 @@
 namespace {
 TestingSetup* g_setup;
 std::string_view LIMIT_TO_MESSAGE_TYPE{};
+constexpr ReachabilityGoal PROCESS_MESSAGE_CHANGES_MEMPOOL{"process_message changes the mempool"};
+constexpr ReachabilityGoal PROCESS_MESSAGE_CHANGES_BLOCK_INDEX{"process_message changes the block index"};
 
 } // namespace
 
@@ -48,6 +51,8 @@ extern void MakeRandDeterministicDANGEROUS(const uint256& seed) noexcept;
 
 void initialize_process_message()
 {
+    RegisterReachabilityGoal(PROCESS_MESSAGE_CHANGES_MEMPOOL);
+    RegisterReachabilityGoal(PROCESS_MESSAGE_CHANGES_BLOCK_INDEX);
     FakeNodeClock init_clock{}; // Uses the existing mock time
     if (const auto val{std::getenv("LIMIT_TO_MESSAGE_TYPE")}) {
         LIMIT_TO_MESSAGE_TYPE = val;
@@ -72,7 +77,7 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     auto& connman{static_cast<ConnmanTestMsg&>(*node.connman)};
     connman.Reset();
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
-    const auto block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
+    const auto initial_block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
     const auto initial_sequence{WITH_LOCK(node.mempool->cs, return node.mempool->GetSequence())};
     FakeNodeClock node_clock{1610000000s}; // 2021-01-07, arbitrary
     FakeSteadyClock steady_clock;
@@ -134,7 +139,10 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     node.validation_signals->UnregisterValidationInterface(node.peerman.get());
     node.connman->StopNodes();
     const auto end_sequence{WITH_LOCK(node.mempool->cs, return node.mempool->GetSequence())};
-    if (block_index_size != WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size()) || initial_sequence != end_sequence) {
+    const auto end_block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
+    ObserveReachabilityGoal(initial_sequence != end_sequence, PROCESS_MESSAGE_CHANGES_MEMPOOL);
+    ObserveReachabilityGoal(initial_block_index_size != end_block_index_size, PROCESS_MESSAGE_CHANGES_BLOCK_INDEX);
+    if (initial_block_index_size != end_block_index_size || initial_sequence != end_sequence) {
         // Reuse the global chainman and mempool, but reset them when dirty.
         MakeRandDeterministicDANGEROUS(uint256::ZERO);
         ResetChainmanAndMempool(*g_setup, node_clock);

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -15,6 +15,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/net.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
@@ -36,6 +37,8 @@
 
 namespace {
 TestingSetup* g_setup;
+constexpr ReachabilityGoal PROCESS_MESSAGES_CHANGES_MEMPOOL{"process_messages changes the mempool"};
+constexpr ReachabilityGoal PROCESS_MESSAGES_CHANGES_BLOCK_INDEX{"process_messages changes the block index"};
 
 } // namespace
 
@@ -43,6 +46,8 @@ extern void MakeRandDeterministicDANGEROUS(const uint256& seed) noexcept;
 
 void initialize_process_messages()
 {
+    RegisterReachabilityGoal(PROCESS_MESSAGES_CHANGES_MEMPOOL);
+    RegisterReachabilityGoal(PROCESS_MESSAGES_CHANGES_BLOCK_INDEX);
     FakeNodeClock init_clock{}; // Uses the existing mock time
     static const auto testing_setup{
         MakeNoLogFileContext<TestingSetup>(
@@ -62,7 +67,7 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
     auto& connman{static_cast<ConnmanTestMsg&>(*node.connman)};
     connman.Reset();
     auto& chainman{static_cast<TestChainstateManager&>(*node.chainman)};
-    const auto block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
+    const auto initial_block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
     const auto initial_sequence{WITH_LOCK(node.mempool->cs, return node.mempool->GetSequence())};
     FakeNodeClock node_clock{1610000000s}; // 2021-01-07, arbitrary
     FakeSteadyClock steady_clock;
@@ -134,7 +139,10 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
     node.validation_signals->UnregisterValidationInterface(node.peerman.get());
     node.connman->StopNodes();
     const auto end_sequence{WITH_LOCK(node.mempool->cs, return node.mempool->GetSequence())};
-    if (block_index_size != WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size()) || initial_sequence != end_sequence) {
+    const auto end_block_index_size{WITH_LOCK(chainman.GetMutex(), return chainman.BlockIndex().size())};
+    ObserveReachabilityGoal(initial_sequence != end_sequence, PROCESS_MESSAGES_CHANGES_MEMPOOL);
+    ObserveReachabilityGoal(initial_block_index_size != end_block_index_size, PROCESS_MESSAGES_CHANGES_BLOCK_INDEX);
+    if (initial_block_index_size != end_block_index_size || initial_sequence != end_sequence) {
         // Reuse the global chainman and mempool, but reset them when dirty.
         MakeRandDeterministicDANGEROUS(uint256::ZERO);
         ResetChainmanAndMempool(*g_setup, node_clock);

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -21,6 +21,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/mempool.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/mining.h>
 #include <test/util/random.h>
 #include <test/util/script.h>
@@ -57,6 +58,7 @@ namespace {
 const TestingSetup* g_setup;
 std::vector<COutPoint> g_outpoints_coinbase_init_mature;
 std::vector<COutPoint> g_outpoints_coinbase_init_immature;
+constexpr ReachabilityGoal TX_POOL_STANDARD_ACCEPTS_TRANSACTION{"tx_pool_standard accepts a transaction"};
 
 struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
@@ -84,6 +86,12 @@ void initialize_tx_pool()
         outpoints.push_back(prevout);
     }
     g_setup->m_node.validation_signals->SyncWithValidationInterfaceQueue();
+}
+
+void initialize_tx_pool_standard()
+{
+    RegisterReachabilityGoal(TX_POOL_STANDARD_ACCEPTS_TRANSACTION);
+    initialize_tx_pool();
 }
 
 struct TransactionsDelta final : public CValidationInterface {
@@ -287,7 +295,7 @@ void CheckATMPInvariants(const MempoolAcceptResult& res, bool txid_in_mempool, b
     }
 }
 
-FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
+FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool_standard)
 {
     SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
@@ -313,6 +321,8 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
     MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(tx_pool_.get());
 
     chainstate.SetMempool(&tx_pool);
+
+    bool accepted_transaction{false};
 
     // Helper to query an amount
     const CCoinsViewMemPool amount_view{WITH_LOCK(::cs_main, return &chainstate.CoinsTip()), tx_pool};
@@ -418,6 +428,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 
         const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), /*bypass_limits=*/false, /*test_accept=*/false));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
+        accepted_transaction |= accepted;
         node.validation_signals->SyncWithValidationInterfaceQueue();
         node.validation_signals->UnregisterSharedValidationInterface(txr);
 
@@ -470,6 +481,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
             }
         }
     }
+    ObserveReachabilityGoal(accepted_transaction, TX_POOL_STANDARD_ACCEPTS_TRANSACTION);
     Finish(fuzzed_data_provider, tx_pool, chainstate);
 }
 

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -59,6 +59,7 @@ const TestingSetup* g_setup;
 std::vector<COutPoint> g_outpoints_coinbase_init_mature;
 std::vector<COutPoint> g_outpoints_coinbase_init_immature;
 constexpr ReachabilityGoal TX_POOL_STANDARD_ACCEPTS_TRANSACTION{"tx_pool_standard accepts a transaction"};
+constexpr ReachabilityGoal TX_POOL_ACCEPTS_TRANSACTION{"tx_pool accepts a transaction"};
 
 struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
@@ -69,7 +70,7 @@ struct MockedTxPool : public CTxMemPool {
     }
 };
 
-void initialize_tx_pool()
+void initialize_tx_pool_common()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
@@ -91,7 +92,13 @@ void initialize_tx_pool()
 void initialize_tx_pool_standard()
 {
     RegisterReachabilityGoal(TX_POOL_STANDARD_ACCEPTS_TRANSACTION);
-    initialize_tx_pool();
+    initialize_tx_pool_common();
+}
+
+void initialize_tx_pool()
+{
+    RegisterReachabilityGoal(TX_POOL_ACCEPTS_TRANSACTION);
+    initialize_tx_pool_common();
 }
 
 struct TransactionsDelta final : public CValidationInterface {
@@ -511,6 +518,8 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
 
     chainstate.SetMempool(&tx_pool);
 
+    bool accepted_transaction{false};
+
     // If we ever bypass limits, do not do TRUC invariants checks
     bool ever_bypassed_limits{false};
 
@@ -537,6 +546,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
         const auto tx = MakeTransactionRef(mut_tx);
         const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
+        accepted_transaction |= accepted;
         if (accepted) {
             txids.push_back(tx->GetHash());
             if (!ever_bypassed_limits) {
@@ -544,6 +554,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
             }
         }
     }
+    ObserveReachabilityGoal(accepted_transaction, TX_POOL_ACCEPTS_TRANSACTION);
     Finish(fuzzed_data_provider, tx_pool, chainstate);
 }
 } // namespace

--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
   descriptor.cpp
   mempool.cpp
   net.cpp
+  reachability.cpp
   threadinterrupt.cpp
   ../fuzz.cpp
   ../util.cpp

--- a/src/test/fuzz/util/reachability.cpp
+++ b/src/test/fuzz/util/reachability.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <sync.h>
+#include <test/fuzz/util/reachability.h>
+#include <util/check.h>
+
+#include <compare>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace {
+struct GoalId {
+    std::string_view file_name;
+    std::uint_least32_t line;
+    std::uint_least32_t column;
+
+    auto operator<=>(const GoalId&) const = default;
+};
+
+struct GoalState {
+    std::string message;
+    bool reached{false};
+
+    explicit GoalState(std::string_view message) : message{message} {}
+};
+
+class ReachabilityTracker
+{
+public:
+    ReachabilityTracker()
+    {
+        const char* enforce{std::getenv("FUZZ_ENFORCE_REACHABILITY")};
+        if (!enforce || std::string_view{enforce} == "0") return;
+        if (std::string_view{enforce} == "1") {
+            m_enforce = true;
+            return;
+        }
+        std::fputs("FUZZ_ENFORCE_REACHABILITY must be 0 or 1.\n", stderr);
+        std::abort();
+    }
+
+    ~ReachabilityTracker()
+    {
+        LOCK(m_mutex);
+        bool all_reached{true};
+        for (const auto& [id, goal] : m_goals) {
+            std::cerr << (goal.reached ? "PASS" : "FAIL") << " reachability goal \""
+                      << goal.message << "\" at " << id.file_name << ':' << id.line << ':' << id.column << '\n';
+            all_reached &= goal.reached;
+        }
+        if (m_enforce && !all_reached) {
+            std::cerr.flush();
+            std::_Exit(EXIT_FAILURE);
+        }
+    }
+
+    void Register(const ReachabilityGoal& goal) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        const GoalId id{
+            .file_name = goal.location.file_name(),
+            .line = goal.location.line(),
+            .column = goal.location.column(),
+        };
+        LOCK(m_mutex);
+        const bool inserted{m_goals.try_emplace(id, goal.message).second};
+        Assert(inserted);
+    }
+
+    void Observe(bool reached, const ReachabilityGoal& goal) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        const GoalId id{
+            .file_name = goal.location.file_name(),
+            .line = goal.location.line(),
+            .column = goal.location.column(),
+        };
+        LOCK(m_mutex);
+        const auto it{m_goals.find(id)};
+        Assert(it != m_goals.end());
+        it->second.reached |= reached;
+    }
+
+private:
+    Mutex m_mutex;
+    std::map<GoalId, GoalState> m_goals GUARDED_BY(m_mutex);
+    bool m_enforce{false};
+};
+
+ReachabilityTracker g_reachability_tracker;
+} // namespace
+
+void RegisterReachabilityGoal(const ReachabilityGoal& goal)
+{
+    g_reachability_tracker.Register(goal);
+}
+
+void ObserveReachabilityGoal(bool reached, const ReachabilityGoal& goal)
+{
+    g_reachability_tracker.Observe(reached, goal);
+}

--- a/src/test/fuzz/util/reachability.h
+++ b/src/test/fuzz/util/reachability.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_FUZZ_UTIL_REACHABILITY_H
+#define BITCOIN_TEST_FUZZ_UTIL_REACHABILITY_H
+
+#include <source_location>
+#include <string_view>
+
+/// A reachability condition explicitly registered by a fuzz target.
+///
+/// Goals are identified by their declaration location and aggregated across the
+/// lifetime of the fuzz process. Set FUZZ_ENFORCE_REACHABILITY=1 to fail at
+/// shutdown if a registered goal was never satisfied.
+struct ReachabilityGoal {
+    std::string_view message;
+    std::source_location location;
+
+    constexpr explicit ReachabilityGoal(
+        std::string_view message,
+        std::source_location location = std::source_location::current())
+        : message{message}, location{location}
+    {
+    }
+};
+
+/// Register a goal before executing any fuzz inputs.
+void RegisterReachabilityGoal(const ReachabilityGoal& goal);
+
+/// Record whether a registered goal is satisfied by at least one fuzz input.
+void ObserveReachabilityGoal(bool reached, const ReachabilityGoal& goal);
+
+#endif // BITCOIN_TEST_FUZZ_UTIL_REACHABILITY_H

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -19,6 +19,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
@@ -42,6 +43,7 @@ namespace {
 
 const std::vector<std::shared_ptr<CBlock>>* g_chain;
 TestingSetup* g_setup{nullptr};
+constexpr ReachabilityGoal UTXO_SNAPSHOT_ACTIVATION_SUCCEEDS{"UTXO snapshot activation succeeds"};
 
 /** Sanity check the assumeutxo values hardcoded in chainparams for the fuzz target. */
 void sanity_check_snapshot()
@@ -70,6 +72,9 @@ void sanity_check_snapshot()
 template <bool INVALID>
 void initialize_chain()
 {
+    if constexpr (!INVALID) {
+        RegisterReachabilityGoal(UTXO_SNAPSHOT_ACTIVATION_SUCCEEDS);
+    }
     const auto params{CreateChainParams(ArgsManager{}, ChainType::REGTEST)};
     static const auto chain{CreateBlockChain(2 * COINBASE_MATURITY, *params)};
     g_chain = &chain;
@@ -181,7 +186,8 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         }
     }
 
-    if (ActivateFuzzedSnapshot()) {
+    const bool snapshot_activated{ActivateFuzzedSnapshot()};
+    if (snapshot_activated) {
         LOCK(::cs_main);
         Assert(!chainman.ActiveChainstate().m_from_snapshot_blockhash->IsNull());
         const auto& coinscache{chainman.ActiveChainstate().CoinsTip()};
@@ -214,6 +220,9 @@ void utxo_snapshot_fuzz(FuzzBufferType buffer)
         setup.m_node.chainman.reset();
         setup.m_make_chainman();
         setup.LoadVerifyActivateChainstate();
+    }
+    if constexpr (!INVALID) {
+        ObserveReachabilityGoal(snapshot_activated, UTXO_SNAPSHOT_ACTIVATION_SUCCEEDS);
     }
 }
 

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -11,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/mempool.h>
+#include <test/fuzz/util/reachability.h>
 #include <test/util/setup_common.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
@@ -29,10 +30,12 @@ using node::MempoolPath;
 
 namespace {
 const TestingSetup* g_setup;
+constexpr ReachabilityGoal MEMPOOL_LOAD_SUCCEEDS{"mempool loading succeeds"};
 } // namespace
 
 void initialize_validation_load_mempool()
 {
+    RegisterReachabilityGoal(MEMPOOL_LOAD_SUCCEEDS);
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
 }
@@ -54,10 +57,12 @@ FUZZ_TARGET(validation_load_mempool, .init = initialize_validation_load_mempool)
     auto fuzzed_fopen = [&](const fs::path&, const char*) {
         return fuzzed_file_provider.open();
     };
-    (void)LoadMempool(pool, MempoolPath(g_setup->m_args), chainstate,
-                      {
-                          .mockable_fopen_function = fuzzed_fopen,
-                      });
+    const bool load_success{
+        LoadMempool(pool, MempoolPath(g_setup->m_args), chainstate,
+                    {
+                        .mockable_fopen_function = fuzzed_fopen,
+                    })};
     pool.SetLoadTried(true);
     (void)DumpMempool(pool, MempoolPath(g_setup->m_args), fuzzed_fopen, true);
+    ObserveReachabilityGoal(load_success, MEMPOOL_LOAD_SUCCEEDS);
 }


### PR DESCRIPTION
This is a follow-up to #35482.

Add `ReachabilityGoal()` to aggregate whether selected conditions are reached across all inputs processed by a fuzz target. Goals are identified by source location and reported at shutdown. Setting `FUZZ_ENFORCE_REACHABILITY=1` makes the process fail if any registered goal was not reached.

Add goals for selected high-value paths, including IBD and non-IBD message processing, completed P2P handshakes and transport messages, successful estimator/mempool/snapshot operations, transaction and package acceptance, and compact block reconstruction.

### Testing

Built the fuzz binary and replayed the current qa-assets corpora for all instrumented targets with `FUZZ_ENFORCE_REACHABILITY=1`.