### PR TITLE
util: Replace !ContainsNoNUL() with ContainsNUL()

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -14,7 +14,7 @@
 
 #include <limits>
 
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 
 /** All alphanumeric characters except for "0", "I", "O", and "l" */
 static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -128,7 +128,7 @@ std::string EncodeBase58(std::span<const unsigned char> input)
 
 bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len)
 {
-    if (!ContainsNoNUL(str)) {
+    if (ContainsNUL(str)) {
         return false;
     }
     return DecodeBase58(str.c_str(), vchRet, max_ret_len);
@@ -162,7 +162,7 @@ std::string EncodeBase58Check(std::span<const unsigned char> input)
 
 bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret)
 {
-    if (!ContainsNoNUL(str)) {
+    if (ContainsNUL(str)) {
         return false;
     }
     return DecodeBase58Check(str.c_str(), vchRet, max_ret);

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -21,7 +21,7 @@
 #include <string_view>
 #include <tuple>
 
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 using util::HasPrefix;
 
 CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
@@ -211,7 +211,7 @@ static void Checksum(std::span<const uint8_t> addr_pubkey, uint8_t (&checksum)[C
 
 bool CNetAddr::SetSpecial(std::string_view addr)
 {
-    if (!ContainsNoNUL(addr)) {
+    if (ContainsNUL(addr)) {
         return false;
     }
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -27,7 +27,7 @@
 #include <sys/un.h>
 #endif
 
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 
 // Settings
 static GlobalMutex g_proxyinfo_mutex;
@@ -143,7 +143,7 @@ std::vector<std::string> GetNetworkNames(bool append_unroutable)
 
 static std::vector<CNetAddr> LookupIntern(const std::string& name, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function)
 {
-    if (!ContainsNoNUL(name)) return {};
+    if (ContainsNUL(name)) return {};
     {
         CNetAddr addr;
         // From our perspective, onion addresses are not hostnames but rather
@@ -172,7 +172,7 @@ static std::vector<CNetAddr> LookupIntern(const std::string& name, unsigned int 
 
 std::vector<CNetAddr> LookupHost(const std::string& name, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function)
 {
-    if (!ContainsNoNUL(name)) return {};
+    if (ContainsNUL(name)) return {};
     std::string strHost = name;
     if (strHost.empty()) return {};
     if (strHost.front() == '[' && strHost.back() == ']') {
@@ -190,7 +190,7 @@ std::optional<CNetAddr> LookupHost(const std::string& name, bool fAllowLookup, D
 
 std::vector<CService> Lookup(const std::string& name, uint16_t portDefault, bool fAllowLookup, unsigned int nMaxSolutions, DNSLookupFn dns_lookup_function)
 {
-    if (name.empty() || !ContainsNoNUL(name)) {
+    if (name.empty() || ContainsNUL(name)) {
         return {};
     }
     uint16_t port{portDefault};
@@ -215,7 +215,7 @@ std::optional<CService> Lookup(const std::string& name, uint16_t portDefault, bo
 
 CService LookupNumeric(const std::string& name, uint16_t portDefault, DNSLookupFn dns_lookup_function)
 {
-    if (!ContainsNoNUL(name)) {
+    if (ContainsNUL(name)) {
         return {};
     }
     // "1.2:345" will fail to resolve the ip, but will still set the port.
@@ -832,7 +832,7 @@ CSubNet LookupSubNet(const std::string& subnet_str)
 {
     CSubNet subnet;
     assert(!subnet.IsValid());
-    if (!ContainsNoNUL(subnet_str)) {
+    if (ContainsNUL(subnet_str)) {
         return subnet;
     }
 

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -40,7 +40,7 @@ using common::AmountErrMsg;
 using common::AmountHighWarn;
 using common::FeeModeFromString;
 using common::ResolveErrMsg;
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 using util::Join;
 using util::RemovePrefix;
 using util::SplitString;
@@ -100,7 +100,7 @@ FUZZ_TARGET(string)
     (void)TrimString(random_string_1);
     (void)TrimString(random_string_1, random_string_2);
     (void)UrlDecode(random_string_1);
-    (void)ContainsNoNUL(random_string_1);
+    (void)ContainsNUL(random_string_1);
     try {
         throw scriptnum_error{random_string_1};
     } catch (const std::runtime_error&) {

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <optional>
 
-using util::ContainsNoNUL;
+using util::ContainsNUL;
 using util::TrimString;
 
 std::string FormatMoney(const CAmount n)
@@ -44,7 +44,7 @@ std::string FormatMoney(const CAmount n)
 
 std::optional<CAmount> ParseMoney(const std::string& money_string)
 {
-    if (!ContainsNoNUL(money_string)) {
+    if (ContainsNUL(money_string)) {
         return std::nullopt;
     }
     const std::string str = TrimString(money_string);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -232,14 +232,14 @@ inline std::string MakeUnorderedList(const std::vector<std::string>& items)
 }
 
 /**
- * Check if a string does not contain any embedded NUL (\0) characters
+ * Check if a string contains any embedded NUL (\0) characters
  */
-[[nodiscard]] inline bool ContainsNoNUL(std::string_view str) noexcept
+[[nodiscard]] inline bool ContainsNUL(std::string_view str) noexcept
 {
     for (auto c : str) {
-        if (c == 0) return false;
+        if (c == 0) return true;
     }
-    return true;
+    return false;
 }
 
 /**


### PR DESCRIPTION
Avoids frequent double negation. See also fa7078d84fc2858a466bc1a85404f821df682538 when it was renamed from the previous name, "ValidAsCString()".

Found while reviewing #35041.