### PR TITLE
refactor: Enforce iwyu on src/init

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -234,7 +234,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU='/src/((bench|common|consensus|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\.cpp'
+  FILES_WITH_ENFORCED_IWYU='/src/((bench|common|consensus|crypto|index|init|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\.cpp'
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/init/basic.cpp
+++ b/src/init/basic.cpp
@@ -5,6 +5,8 @@
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 
+#include <memory>
+
 namespace init {
 namespace {
 class BitcoinBasicInit : public interfaces::Init

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -7,6 +7,7 @@
 #include <interfaces/echo.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/rpc.h>
 #include <interfaces/wallet.h>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -17,7 +17,7 @@
 #include <util/translation.h>
 
 #include <algorithm>
-#include <filesystem>
+#include <ranges>
 #include <string>
 #include <vector>
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -13,6 +13,7 @@
 #include <interfaces/wallet.h>
 
 #include <memory>
+#include <stdexcept>
 
 namespace node {
 struct NodeContext;

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <typeindex>
+#include <utility>
 
 namespace ipc {
 struct Context;

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -1,5 +1,5 @@
 // Copyright 2014 BitPay Inc.
-// Copyright 2015 Bitcoin Core Developers
+// Copyright (c) 2015-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -1,5 +1,5 @@
 // Copyright 2014 BitPay Inc.
-// Copyright 2015 Bitcoin Core Developers
+// Copyright (c) 2015-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
This PR continues the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).
