### PR TITLE
bitcoin wrapper: respect CMAKE_INSTALL_BINDIR/LIBEXECDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,6 +637,20 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
 endif()
 
+# Populate CMAKE_INSTALL_BINDIR, CMAKE_INSTALL_LIBEXECDIR, etc. before the
+# subdirectories below, which substitute these values into generated files
+# (test/config.ini and src/bitcoin-build-config.h).
+include(GNUInstallDirs)
+# GNUInstallDirs provides non-empty defaults; only explicit user overrides can
+# produce empty values, which would silently break the installed-layout lookup
+# in src/bitcoin.cpp. Catch that at configure time.
+if(NOT CMAKE_INSTALL_BINDIR)
+  message(FATAL_ERROR "CMAKE_INSTALL_BINDIR must not be empty")
+endif()
+if(NOT CMAKE_INSTALL_LIBEXECDIR)
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBEXECDIR must not be empty")
+endif()
+
 add_subdirectory(test)
 add_subdirectory(doc)
 

--- a/cmake/bitcoin-build-config.h.in
+++ b/cmake/bitcoin-build-config.h.in
@@ -100,6 +100,16 @@
 /* Define to the home page for this package. */
 #define CLIENT_URL "@PROJECT_HOMEPAGE_URL@"
 
+/* Install directory for public executables, relative to the install prefix
+   (e.g. "bin"). Used by the bitcoin wrapper to recognize when it is running
+   from an installed layout. */
+#define BITCOIN_BINDIR "@CMAKE_INSTALL_BINDIR@"
+
+/* Install directory for internal executables, relative to the install prefix
+   (e.g. "libexec"). Used by the bitcoin wrapper to locate bitcoind,
+   bitcoin-node, bitcoin-gui, etc. in an installed layout. */
+#define BITCOIN_INTERNAL_LIBEXECDIR "@CMAKE_INSTALL_LIBEXECDIR@"
+
 /* Define to the version of this package. */
 #define CLIENT_VERSION_STRING "@CLIENT_VERSION_STRING@"
 

--- a/cmake/module/InstallBinaryComponent.cmake
+++ b/cmake/module/InstallBinaryComponent.cmake
@@ -3,7 +3,6 @@
 # file COPYING or https://opensource.org/license/mit/.
 
 include_guard(GLOBAL)
-include(GNUInstallDirs)
 
 function(install_binary_component component)
   cmake_parse_arguments(PARSE_ARGV 1

--- a/src/bitcoin.cpp
+++ b/src/bitcoin.cpp
@@ -18,6 +18,16 @@
 #include <tinyformat.h>
 #include <vector>
 
+// Guard against empty install dir values; a missing GNUInstallDirs setting
+// would silently break ExecCommand()'s installed-layout lookup. BITCOIN_BINDIR
+// is also assumed to be a single path component (conventionally "bin"):
+// ExecCommand() compares wrapper_dir.filename() against it and derives the
+// install prefix as wrapper_dir.parent_path(), so a multi-component or
+// absolute value would silently never match. A configure-time check in
+// CMakeLists.txt catches this earlier; these static_asserts are a backstop.
+static_assert(BITCOIN_BINDIR[0] != '\0', "BITCOIN_BINDIR must not be empty");
+static_assert(BITCOIN_INTERNAL_LIBEXECDIR[0] != '\0', "BITCOIN_INTERNAL_LIBEXECDIR must not be empty");
+
 const TranslateFn G_TRANSLATION_FUN{nullptr};
 
 static constexpr auto HELP_USAGE = R"(Usage: %s [OPTIONS] COMMAND...
@@ -173,8 +183,8 @@ bool UseMultiprocess(const CommandLine& cmd)
 }
 
 //! Execute the specified bitcoind, bitcoin-qt or other command line in `args`
-//! using src, bin and libexec directory paths relative to this executable, where
-//! the path to this executable is specified in `wrapper_argv0`.
+//! using src, bin and the configured libexec directory paths relative to this
+//! executable, where the path to this executable is specified in `wrapper_argv0`.
 //!
 //! @param args Command line arguments to execute, where first argument should
 //!             be a relative path to a bitcoind, bitcoin-qt or other executable
@@ -226,9 +236,12 @@ static void ExecCommand(const std::vector<const char*>& args, std::string_view w
     // (https://github.com/bitcoin/bitcoin/pull/31375#discussion_r1861814807)
     const bool fallback_os_search{!fs::PathFromString(std::string{wrapper_argv0}).has_parent_path()};
 
-    // If wrapper is installed in a bin/ directory, look for target executable
-    // in libexec/
-    (wrapper_dir.filename() == "bin" && try_exec(wrapper_dir.parent_path() / "libexec" / arg0.filename())) ||
+    // If wrapper is installed in the bindir (e.g. bin/), look for the target
+    // executable in the configured internal-executable directory (libexecdir),
+    // as a sibling of the bindir under the same install prefix. BINDIR is
+    // assumed to be a single path component (conventionally "bin"), so the
+    // install prefix is the parent of the wrapper's directory.
+    (wrapper_dir.filename() == BITCOIN_BINDIR && try_exec(wrapper_dir.parent_path() / BITCOIN_INTERNAL_LIBEXECDIR / arg0.filename())) ||
 #ifdef WIN32
     // Otherwise check the "daemon" subdirectory in a windows install.
     (!wrapper_dir.empty() && try_exec(wrapper_dir / "daemon" / arg0.filename())) ||

--- a/test/config.ini.in
+++ b/test/config.ini.in
@@ -11,6 +11,8 @@ CLIENT_BUGREPORT=@CLIENT_BUGREPORT@
 SRCDIR=@abs_top_srcdir@
 BUILDDIR=@abs_top_builddir@
 EXEEXT=@EXEEXT@
+BINDIR=@CMAKE_INSTALL_BINDIR@
+LIBEXECDIR=@CMAKE_INSTALL_LIBEXECDIR@
 RPCAUTH=@abs_top_srcdir@/share/rpcauth/rpcauth.py
 
 [components]

--- a/test/functional/tool_bitcoin.py
+++ b/test/functional/tool_bitcoin.py
@@ -147,15 +147,8 @@ class ToolBitcoinTest(BitcoinTestFramework):
 
         self.log.info(f"Ensure installed wrapper finds internal binaries in configured {libexecdir}/")
         result = run_wrapper(make_layout("found", libexecdir))
-        if libexecdir == "libexec":
-            assert_equal(result.returncode, 0)
-            assert_equal(get_exe_name(result.stdout), b"bitcoind")
-        else:
-            # Bug #35785: the old wrapper hardcodes "libexec" instead of
-            # respecting CMAKE_INSTALL_LIBEXECDIR, so it fails to find
-            # internal executables when the configured directory differs
-            # (e.g. Arch Linux, which sets CMAKE_INSTALL_LIBEXECDIR=lib).
-            assert result.returncode != 0, f"wrapper unexpectedly found bitcoind despite non-default libexecdir: {result.stdout!r}"
+        assert_equal(result.returncode, 0)
+        assert_equal(get_exe_name(result.stdout), b"bitcoind")
 
         other_dir = libexecdir + "_notfound"
         self.log.info(f"Ensure installed wrapper does not find internal binaries in unconfigured {other_dir}/")

--- a/test/functional/tool_bitcoin.py
+++ b/test/functional/tool_bitcoin.py
@@ -12,8 +12,12 @@ from test_framework.util import (
     assert_equal,
 )
 
+import os
 import platform
 import re
+import shutil
+import subprocess
+from pathlib import Path
 
 
 class ToolBitcoinTest(BitcoinTestFramework):
@@ -85,6 +89,78 @@ class ToolBitcoinTest(BitcoinTestFramework):
             self.log.info("Ensure bitcoin recognizes -ipcbind in config file")
             append_config(node.datadir_path, ["ipcbind=unix"])
             self.test_args([], [], expect_exe="bitcoin-node")
+
+        self.test_installed_layout()
+
+    def test_installed_layout(self):
+        """Check how an installed bitcoin wrapper resolves internal executables.
+
+        When the wrapper is installed into a `bin/` directory, it looks for
+        internal executables (bitcoind, bitcoin-node, ...) in a sibling
+        directory under the same install prefix. The normal build-tree tests
+        never exercise this because every binary sits next to the wrapper, so
+        build a fake install prefix and invoke the wrapper by absolute path.
+        """
+        paths = self.get_binaries().paths
+        exeext = self.config["environment"]["EXEEXT"]
+        # Directory (relative to the install prefix) where the wrapper looks for
+        # internal executables, configured at build time via
+        # CMAKE_INSTALL_LIBEXECDIR. An absolute value is not relative to the
+        # prefix constructed here, so skip the check in that case.
+        bindir = self.config["environment"]["BINDIR"]
+        if os.path.isabs(bindir):
+            self.log.info("Skipping installed-layout check; CMAKE_INSTALL_BINDIR is absolute")
+            return
+        libexecdir = self.config["environment"]["LIBEXECDIR"]
+        if os.path.isabs(libexecdir):
+            self.log.info("Skipping installed-layout check; CMAKE_INSTALL_LIBEXECDIR is absolute")
+            return
+        prefix = Path(self.options.tmpdir) / "fake-prefix"
+        datadir = self.nodes[0].datadir_path / "wrapper-datadir"
+        datadir.mkdir()
+
+        def make_layout(name, internal_dir):
+            # Lay out <prefix>/<name>/<bindir>/bitcoin and <prefix>/<name>/<internal_dir>/bitcoind.
+            root = prefix / name
+            (root / bindir).mkdir(parents=True)
+            (root / internal_dir).mkdir(parents=True)
+            wrapper = root / bindir / f"bitcoin{exeext}"
+            shutil.copy2(paths.bitcoin_bin, wrapper)
+            # `bitcoin node` (with no -ipc* option) execs `bitcoind`. Placing
+            # bitcoind only in the internal directory, not next to the wrapper,
+            # forces the wrapper to resolve it through the bindir -> internal-dir
+            # lookup rather than finding it as a sibling.
+            shutil.copy2(paths.bitcoind, root / internal_dir / f"bitcoind{exeext}")
+            return wrapper
+
+        def run_wrapper(wrapper):
+            valgrind_cmd = self.nodes[0].binaries.valgrind_cmd
+            if valgrind_cmd:
+                # which(): PATH is blanked below, so resolve valgrind now.
+                valgrind_cmd = [shutil.which(valgrind_cmd[0]) or valgrind_cmd[0], *valgrind_cmd[1:]]
+            env = os.environ.copy()
+            # The wrapper is invoked by absolute path; blank out PATH so a lookup
+            # miss cannot be satisfied by an unrelated bitcoind on the system.
+            env["PATH"] = ""
+            return subprocess.run(valgrind_cmd + [wrapper, "node", f"-datadir={datadir}", "-version"],
+                                  capture_output=True, env=env, timeout=60)
+
+        self.log.info(f"Ensure installed wrapper finds internal binaries in configured {libexecdir}/")
+        result = run_wrapper(make_layout("found", libexecdir))
+        if libexecdir == "libexec":
+            assert_equal(result.returncode, 0)
+            assert_equal(get_exe_name(result.stdout), b"bitcoind")
+        else:
+            # Bug #35785: the old wrapper hardcodes "libexec" instead of
+            # respecting CMAKE_INSTALL_LIBEXECDIR, so it fails to find
+            # internal executables when the configured directory differs
+            # (e.g. Arch Linux, which sets CMAKE_INSTALL_LIBEXECDIR=lib).
+            assert result.returncode != 0, f"wrapper unexpectedly found bitcoind despite non-default libexecdir: {result.stdout!r}"
+
+        other_dir = libexecdir + "_notfound"
+        self.log.info(f"Ensure installed wrapper does not find internal binaries in unconfigured {other_dir}/")
+        result = run_wrapper(make_layout("notfound", other_dir))
+        assert result.returncode != 0, f"wrapper unexpectedly ran bitcoind from {other_dir}/: {result.stdout!r}"
 
 
 def get_node_output(node):


### PR DESCRIPTION
**Problem:** On Arch Linux the installed `bitcoin` command doesn't work: `bitcoin -m node`, `bitcoin chainstate`, and similar commands all fail with `execvp failed to execute ... No such file or directory` (#35785). Arch installs the programs the wrapper runs into a different directory than the wrapper looks in.

**Solution:** Make the wrapper look for those programs in the directory they were actually installed to, rather than a hardcoded one. Small change to the wrapper (`src/bitcoin.cpp`), plus build-system changes to pass it the configured install directories, and a functional test for the installed layout. Details are in the commit messages.

Fixes #35785. Built from earlier PRs #36037, #35789, and #36085.