### PR TITLE
iwyu: Fix warnings in `src/init` and treat them as errors

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -234,7 +234,7 @@ fi
 
 if [[ "${RUN_IWYU}" == true ]]; then
   # TODO: Consider enforcing IWYU across the entire codebase.
-  FILES_WITH_ENFORCED_IWYU='/src/((bench|common|consensus|crypto|index|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\.cpp'
+  FILES_WITH_ENFORCED_IWYU='/src/((bench|common|consensus|crypto|index|init|kernel|primitives|script|univalue/(lib|test)|util|zmq)/.*|node/(blockstorage|interfaces|miner|mining_args|utxo_snapshot)|rpc/mining|clientversion|core_io|signet|init)\.cpp'
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns)))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_errors.json"
   jq --arg patterns "$FILES_WITH_ENFORCED_IWYU" 'map(select(.file | test($patterns) | not))' "${BASE_BUILD_DIR}/compile_commands.json" > "${BASE_BUILD_DIR}/compile_commands_iwyu_warnings.json"
 

--- a/src/init/basic.cpp
+++ b/src/init/basic.cpp
@@ -2,8 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <interfaces/init.h>
+#include <interfaces/init.h> // IWYU pragma: associated
+
 #include <interfaces/ipc.h>
+
+#include <memory>
 
 namespace init {
 namespace {

--- a/src/init/bitcoin-gui.cpp
+++ b/src/init/bitcoin-gui.cpp
@@ -2,10 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <interfaces/init.h> // IWYU pragma: associated
+
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
-#include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <interfaces/mining.h>
 #include <interfaces/node.h>

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -2,11 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <interfaces/init.h> // IWYU pragma: associated
+
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
-#include <interfaces/init.h>
 #include <interfaces/ipc.h>
+#include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/rpc.h>
 #include <interfaces/wallet.h>

--- a/src/init/bitcoin-qt.cpp
+++ b/src/init/bitcoin-qt.cpp
@@ -2,10 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <interfaces/init.h> // IWYU pragma: associated
+
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
-#include <interfaces/init.h>
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>

--- a/src/init/bitcoin-wallet.cpp
+++ b/src/init/bitcoin-wallet.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <interfaces/init.h>
+#include <interfaces/init.h> // IWYU pragma: associated
 
 #include <memory>
 

--- a/src/init/bitcoind.cpp
+++ b/src/init/bitcoind.cpp
@@ -2,10 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <interfaces/init.h> // IWYU pragma: associated
+
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
-#include <interfaces/init.h>
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -4,6 +4,8 @@
 
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
+#include <init/common.h>
+
 #include <clientversion.h>
 #include <common/args.h>
 #include <logging.h>
@@ -17,7 +19,7 @@
 #include <util/translation.h>
 
 #include <algorithm>
-#include <filesystem>
+#include <ranges>
 #include <string>
 #include <vector>
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -5,14 +5,21 @@
 #ifndef BITCOIN_INTERFACES_INIT_H
 #define BITCOIN_INTERFACES_INIT_H
 
+// This header is associated with several source files, and IWYU
+// reaches different conclusions across them about whether these
+// headers should be included or their classes forward-declared.
+// Keep the includes so the result is the same for every file.
+// IWYU pragma: begin_keep
 #include <interfaces/chain.h>
 #include <interfaces/echo.h>
 #include <interfaces/mining.h>
 #include <interfaces/node.h>
 #include <interfaces/rpc.h>
 #include <interfaces/wallet.h>
+// IWYU pragma: end_keep
 
 #include <memory>
+#include <stdexcept>
 
 namespace node {
 struct NodeContext;

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <typeindex>
+#include <utility>
 
 namespace ipc {
 struct Context;


### PR DESCRIPTION
This PR continues the ongoing effort to enforce IWYU warnings.

See [Developer Notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#using-iwyu).