### PR TITLE
refactor: remove unused client streams

### DIFF
--- a/src/ipc/libmultiprocess/src/mp/gen.cpp
+++ b/src/ipc/libmultiprocess/src/mp/gen.cpp
@@ -527,9 +527,6 @@ static void Generate(kj::StringPtr src_prefix,
             server << "    using ProxyServerCustom::ProxyServerCustom;\n";
             server << "    ~ProxyServer();\n";
 
-            const std::ostringstream client_construct;
-            const std::ostringstream client_destroy;
-
             int method_ordinal = 0;
             ForEachMethod(interface, [&] (const capnp::InterfaceSchema& method_interface, const capnp::InterfaceSchema::Method& method) {
                 const kj::StringPtr method_name = method.getProto().getName();
@@ -669,7 +666,7 @@ static void Generate(kj::StringPtr src_prefix,
               int_client << "ProxyTypeRegister t" << node_nested.getId() << "{TypeList<" << proxied_class_type << ">{}};\n";
             }
             def_types << "ProxyClient<" << message_namespace << "::" << node_name
-                      << ">::~ProxyClient() { clientDestroy(*this); " << client_destroy.str() << " }\n";
+                      << ">::~ProxyClient() { clientDestroy(*this); }\n";
             def_types << "ProxyServer<" << message_namespace << "::" << node_name
                       << ">::~ProxyServer() { serverDestroy(*this); }\n";
         }


### PR DESCRIPTION
A refactor to remove unused client streams from a squash in #31741. These two are constant streams have no inputs directed to them. `client_destroy` appears to be used as a no-op in `client_destroy.str()`, warranting its removal. The client construction is delegated via the `ProxyClientCustom::ProxyClientCustom;`. This PR just removed them entirely. If they were placed there for future use, please notify.