### PR TITLE
test: harden arbitrary-parent block creation

### DIFF
--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -75,10 +75,11 @@ std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const
     return ret;
 }
 
-void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t time)
+void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t time, const Consensus::Params& params)
 {
     block.hashPrevBlock = parent.GetBlockHash();
     block.nTime = time;
+    block.nBits = GetNextWorkRequired(&parent, &block, params);
     {
         CMutableTransaction tx_coinbase{*block.vtx.at(0)};
         tx_coinbase.nLockTime = static_cast<uint32_t>(parent.nHeight);
@@ -106,7 +107,7 @@ bool BuildChain(const NodeContext& node, const CBlockIndex* pindex,
 
         // The template is built on the active tip, so repoint it at pindex and
         // redo the fields that depend on the predecessor.
-        RebuildBlockForParent(block, *pindex, /*time=*/pindex->nTime + 1);
+        RebuildBlockForParent(block, *pindex, /*time=*/pindex->nTime + 1, consensus);
 
         while (!CheckProofOfWork(block.GetHash(), block.nBits, consensus)) ++block.nNonce;
 

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -84,7 +84,8 @@ void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t ti
         const int height{parent.nHeight + 1};
         CMutableTransaction tx_coinbase{*block.vtx.at(0)};
         tx_coinbase.nLockTime = static_cast<uint32_t>(parent.nHeight);
-        tx_coinbase.vin.at(0).scriptSig = CScript{} << height;
+        // Include a dummy OP_0 so low-height coinbase input scripts meet the minimum length
+        tx_coinbase.vin.at(0).scriptSig = CScript{} << height << OP_0;
         tx_coinbase.vout.at(0).nValue = GetBlockSubsidy(height, params);
         block.vtx.at(0) = MakeTransactionRef(std::move(tx_coinbase));
         block.hashMerkleRoot = BlockMerkleRoot(block);

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -75,6 +75,19 @@ std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const
     return ret;
 }
 
+void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t time)
+{
+    block.hashPrevBlock = parent.GetBlockHash();
+    block.nTime = time;
+    {
+        CMutableTransaction tx_coinbase{*block.vtx.at(0)};
+        tx_coinbase.nLockTime = static_cast<uint32_t>(parent.nHeight);
+        tx_coinbase.vin.at(0).scriptSig = CScript{} << parent.nHeight + 1;
+        block.vtx.at(0) = MakeTransactionRef(std::move(tx_coinbase));
+        block.hashMerkleRoot = BlockMerkleRoot(block);
+    }
+}
+
 bool BuildChain(const NodeContext& node, const CBlockIndex* pindex,
     const CScript& coinbase_script_pub_key,
     size_t length,
@@ -93,15 +106,7 @@ bool BuildChain(const NodeContext& node, const CBlockIndex* pindex,
 
         // The template is built on the active tip, so repoint it at pindex and
         // redo the fields that depend on the predecessor.
-        block.hashPrevBlock = pindex->GetBlockHash();
-        block.nTime = pindex->nTime + 1;
-        {
-            CMutableTransaction tx_coinbase{*block.vtx.at(0)};
-            tx_coinbase.nLockTime = static_cast<uint32_t>(pindex->nHeight);
-            tx_coinbase.vin.at(0).scriptSig = CScript{} << pindex->nHeight + 1;
-            block.vtx.at(0) = MakeTransactionRef(std::move(tx_coinbase));
-            block.hashMerkleRoot = BlockMerkleRoot(block);
-        }
+        RebuildBlockForParent(block, *pindex, /*time=*/pindex->nTime + 1);
 
         while (!CheckProofOfWork(block.GetHash(), block.nBits, consensus)) ++block.nNonce;
 

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -81,9 +81,11 @@ void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t ti
     block.nTime = time;
     block.nBits = GetNextWorkRequired(&parent, &block, params);
     {
+        const int height{parent.nHeight + 1};
         CMutableTransaction tx_coinbase{*block.vtx.at(0)};
         tx_coinbase.nLockTime = static_cast<uint32_t>(parent.nHeight);
-        tx_coinbase.vin.at(0).scriptSig = CScript{} << parent.nHeight + 1;
+        tx_coinbase.vin.at(0).scriptSig = CScript{} << height;
+        tx_coinbase.vout.at(0).nValue = GetBlockSubsidy(height, params);
         block.vtx.at(0) = MakeTransactionRef(std::move(tx_coinbase));
         block.hashMerkleRoot = BlockMerkleRoot(block);
     }

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -6,6 +6,7 @@
 #define BITCOIN_TEST_UTIL_MINING_H
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,6 +23,9 @@ struct NodeContext;
 
 /** Create a blockchain, starting from genesis */
 std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);
+
+/** Rebuild a block template for a different parent and timestamp */
+void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t time);
 
 /**
  * Build a chain of `length` coinbase-only blocks on top of `pindex` (which need

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -16,6 +16,9 @@ class CBlockIndex;
 class CChainParams;
 class COutPoint;
 class CScript;
+namespace Consensus {
+struct Params;
+} // namespace Consensus
 namespace node {
 struct BlockCreateOptions;
 struct NodeContext;
@@ -25,7 +28,7 @@ struct NodeContext;
 std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);
 
 /** Rebuild a block template for a different parent and timestamp */
-void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t time);
+void RebuildBlockForParent(CBlock& block, const CBlockIndex& parent, uint32_t time, const Consensus::Params& params);
 
 /**
  * Build a chain of `length` coinbase-only blocks on top of `pindex` (which need

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -100,11 +100,9 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     txCoinbase.vout[1].nValue = txCoinbase.vout[0].nValue;
     txCoinbase.vout[0].nValue = 0;
     txCoinbase.vin[0].scriptWitness.SetNull();
-    // Always pad with OP_0 as dummy extraNonce (also avoids bad-cb-length error for block <=16)
-    const int prev_height{WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(prev_hash)->nHeight)};
-    txCoinbase.vin[0].scriptSig = CScript{} << prev_height + 1 << OP_0;
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
     BOOST_REQUIRE_EQUAL(pblock->vtx[0]->nLockTime, static_cast<uint32_t>(parent.nHeight));
+    BOOST_REQUIRE(pblock->vtx[0]->vin[0].scriptSig == (CScript{} << parent.nHeight + 1 << OP_0));
     BOOST_REQUIRE_EQUAL(pblock->vtx[0]->vout[1].nValue, GetBlockSubsidy(parent.nHeight + 1, params));
 
     return pblock;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -16,6 +16,7 @@
 #include <script/script.h>
 #include <sync.h>
 #include <test/util/common.h>
+#include <test/util/mining.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
@@ -86,8 +87,9 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     }, /*cooldown=*/false)};
     BOOST_REQUIRE(block_template);
     auto pblock = std::make_shared<CBlock>(block_template->getBlock());
-    pblock->hashPrevBlock = prev_hash;
-    pblock->nTime = ++time;
+    const auto& params{Params().GetConsensus()};
+    const auto& parent{*Assert(WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(prev_hash)))};
+    RebuildBlockForParent(*pblock, parent, /*time=*/++time, params);
 
     // Make the coinbase transaction with two outputs:
     // One zero-value one that has a unique pubkey to make sure that blocks at the same height can have a different hash
@@ -101,8 +103,9 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     // Always pad with OP_0 as dummy extraNonce (also avoids bad-cb-length error for block <=16)
     const int prev_height{WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(prev_hash)->nHeight)};
     txCoinbase.vin[0].scriptSig = CScript{} << prev_height + 1 << OP_0;
-    txCoinbase.nLockTime = static_cast<uint32_t>(prev_height);
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
+    BOOST_REQUIRE_EQUAL(pblock->vtx[0]->nLockTime, static_cast<uint32_t>(parent.nHeight));
+    BOOST_REQUIRE_EQUAL(pblock->vtx[0]->vout[1].nValue, GetBlockSubsidy(parent.nHeight + 1, params));
 
     return pblock;
 }


### PR DESCRIPTION
**Problem:** While reviewing #35847, a few hardening opportunities came up in the test helpers that attach active-tip block templates to arbitrary parents.
The copied work target and subsidy may describe a different child, and rebuilding a coinbase input script from heights 1 through 16 without padding violates its minimum length.
Existing callers already avoid these cases or handle them locally, so no current test fails.

**Fix:** Share the parent-dependent reconstruction between `BuildChain()` and `MinerTestingSetup::Block()`.
Use the caller-selected timestamp, recalculate the work target and subsidy for the actual parent and height, and append a dummy `OP_0` to low-height coinbase input scripts.
Require the validation setup's completed block to retain the reconstructed locktime, script, and subsidy.
