### PR TITLE
doc: document ZMQ notification asynchrony and RPC synchronization

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -206,3 +206,13 @@ The `sequence` topic refers specifically to the mempool sequence
 number, which is also published along with all mempool events. This
 is a different sequence value than in ZMQ itself in order to allow a total
 ordering of mempool events to be constructed.
+
+ZMQ notifications are dispatched asynchronously from a background thread,
+after the block or mempool change has already been applied to the node's
+state. A subscriber may therefore observe the node ahead of a notification
+it just received. For example, `getbestblockhash` may already return a block
+later than the one announced by `hashblock`. Notifications should be treated
+as a trigger to re-query the node rather than as a synchronous snapshot of its
+current state. Message ordering is preserved within a topic, but there is no
+ordering guarantee across the ZMQ, `-*notify`, and RPC interfaces, which
+operate independently.


### PR DESCRIPTION
`doc/zmq.md` describes each topic and the per-topic sequence numbers, but says
nothing about *when* notifications are delivered relative to the node's own
state. This trips up clients that treat a notification as a snapshot: ZMQ
messages are queued on the `SerialTaskRunner` (`src/scheduler.h`) that backs
`ValidationSignals` and dispatched from the scheduler thread *after* the block
or mempool change is already applied, so a subscriber that reacts to
`hashblock` by calling `getbestblockhash` can legitimately get a later block
than the one it was just told about.

This adds a paragraph to the Remarks section stating that:

- notifications are dispatched asynchronously, after the state change,
- a notification should be used as a trigger to re-query rather than as a
  snapshot of current state,
- ordering is preserved within a topic, but not across the ZMQ, `-*notify` and
  RPC interfaces, which run independently (`-blocknotify`, for instance, runs
  its command on a detached thread in `src/init.cpp`).

Documentation only; no behaviour change.

This addresses part of #14278.
