### PR TITLE
wallet: harden external signer psbt processing, revamp mock

### DIFF
--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -8,10 +8,13 @@
 #include <common/run_command.h>
 #include <core_io.h>
 #include <psbt.h>
+#include <script/interpreter.h>
 #include <util/strencodings.h>
 #include <util/subprocess.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -77,6 +80,33 @@ UniValue ExternalSigner::GetDescriptors(const int account)
     return RunCommandParseJSON(Cat(m_command, Cat(Cat({"--fingerprint", m_fingerprint}, NetworkArg()), {"getdescriptors", "--account", strprintf("%d", account)})), "");
 }
 
+//! Find a sighash type used by the signer that doesn't commit to all outputs;
+//! a signature with SIGHASH_NONE or SIGHASH_SINGLE would let anyone alter
+//! them. SIGHASH_ANYONECANPAY is acceptable, since it only permits adding
+//! inputs, which does not affect us.
+static std::optional<int32_t> FindUnsafeSighashType(const PartiallySignedTransaction& psbtx)
+{
+    std::vector<int32_t> sighash_types;
+    for (const PSBTInput& input : psbtx.inputs) {
+        if (input.sighash_type) sighash_types.push_back(*input.sighash_type);
+        for (const auto& [_, sig] : input.partial_sigs) {
+            if (!sig.second.empty()) sighash_types.push_back(sig.second.back());
+        }
+        // A 64 byte taproot signature implies SIGHASH_DEFAULT, 65 bytes
+        // carries an explicit sighash type in the last byte
+        if (input.m_tap_key_sig.size() == 65) sighash_types.push_back(input.m_tap_key_sig.back());
+        for (const auto& [_, sig] : input.m_tap_script_sigs) {
+            if (sig.size() == 65) sighash_types.push_back(sig.back());
+        }
+    }
+
+    for (const int32_t sighash_type : sighash_types) {
+        const int32_t base_sighash_type{sighash_type & ~SIGHASH_ANYONECANPAY};
+        if (base_sighash_type != SIGHASH_DEFAULT && base_sighash_type != SIGHASH_ALL) return sighash_type;
+    }
+    return std::nullopt;
+}
+
 bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::string& error)
 {
     // Serialize the PSBT
@@ -118,6 +148,12 @@ bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::str
     util::Result<PartiallySignedTransaction> signer_psbtx = DecodeBase64PSBT(signer_result.find_value("psbt").get_str());
     if (!signer_psbtx) {
         error = strprintf("TX decode failed %s", util::ErrorString(signer_psbtx).original);
+        return false;
+    }
+
+    if (const std::optional<int32_t> sighash{FindUnsafeSighashType(*signer_psbtx)}) {
+        const std::string sighash_str{SighashToStr(*sighash)};
+        error = strprintf("Signer used an unsafe sighash type: %s", sighash_str.empty() ? "unknown" : sighash_str);
         return false;
     }
 

--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -121,7 +121,10 @@ bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::str
         return false;
     }
 
-    psbtx = *signer_psbtx;
+    if (!psbtx.Merge(*signer_psbtx)) {
+        error = "Signer returned a PSBT for a different transaction";
+        return false;
+    }
 
     return true;
 }

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -464,6 +464,7 @@ bool PSBTInput::Merge(const PSBTInput& input)
     for (const auto& [agg_key_lh, psigs] : input.m_musig2_partial_sigs) {
         m_musig2_partial_sigs[agg_key_lh].insert(psigs.begin(), psigs.end());
     }
+    if (sighash_type == std::nullopt && input.sighash_type != std::nullopt) sighash_type = input.sighash_type;
     if (sequence == std::nullopt && input.sequence != std::nullopt) sequence = input.sequence;
     if (time_locktime == std::nullopt && input.time_locktime != std::nullopt) time_locktime = input.time_locktime;
     if (height_locktime == std::nullopt && input.height_locktime != std::nullopt) height_locktime = input.height_locktime;

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -8,6 +8,17 @@ import sys
 import argparse
 import json
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+from test_framework.authproxy import AuthServiceProxy, JSONRPCException
+
+# Master private key for the tpub in getdescriptors below. Used by signtx,
+# which imports the keys into a wallet on the offline node provided by the
+# test and lets it do the actual signing.
+tprv = "tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK"
+
+MOCK_WALLET = "mock"
+
 def perform_pre_checks():
     mock_result_path = os.path.join(os.getcwd(), "mock_result")
     if os.path.isfile(mock_result_path):
@@ -56,20 +67,37 @@ def displayaddress(args):
 
     return sys.stdout.write(json.dumps({"address": expected_desc[args.desc]}))
 
+def get_mock_wallet():
+    """RPC connection to the wallet holding our private keys, created on
+    first use. The test provides a dedicated offline node for it and passes
+    the node's RPC URL via a file in our working directory."""
+    with open(os.path.join(os.getcwd(), "mock_rpc_url"), "r", encoding="utf8") as f:
+        node_url = f.read().strip()
+    node = AuthServiceProxy(node_url)
+    wallet = AuthServiceProxy(f"{node_url}/wallet/{MOCK_WALLET}")
+    try:
+        node.loadwallet(filename=MOCK_WALLET)
+        return wallet
+    except JSONRPCException as e:
+        if e.error["code"] == -35:  # RPC_WALLET_ALREADY_LOADED
+            return wallet
+        if e.error["code"] != -18:  # RPC_WALLET_NOT_FOUND
+            raise
+    node.createwallet(wallet_name=MOCK_WALLET, blank=True)
+    requests = []
+    for desc in [f"pkh({tprv}/<0;1>/*)", f"sh(wpkh({tprv}/<0;1>/*))", f"wpkh({tprv}/<0;1>/*)", f"tr({tprv}/<0;1>/*)"]:
+        checksum = node.getdescriptorinfo(descriptor=desc)["checksum"]
+        requests.append({"desc": f"{desc}#{checksum}", "timestamp": "now", "range": [0, 99]})
+    result = wallet.importdescriptors(requests=requests)
+    assert all(r["success"] for r in result)
+    return wallet
+
 def signtx(args):
     if args.fingerprint != "00000001":
         return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
 
-    with open(os.path.join(os.getcwd(), "mock_psbt"), "r") as f:
-        mock_psbt = f.read()
-
-    if args.fingerprint == "00000001" :
-        sys.stdout.write(json.dumps({
-            "psbt": mock_psbt,
-            "complete": True
-        }))
-    else:
-        sys.stdout.write(json.dumps({"psbt": args.psbt}))
+    result = get_mock_wallet().walletprocesspsbt(psbt=args.psbt, sign=True, bip32derivs=False, finalize=False)
+    sys.stdout.write(json.dumps({"psbt": result["psbt"]}))
 
 parser = argparse.ArgumentParser(prog='./signer.py', description='External signer mock')
 parser.add_argument('--fingerprint')

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -11,6 +11,13 @@ import json
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 from test_framework.authproxy import AuthServiceProxy, JSONRPCException
+from test_framework.psbt import (
+    PSBT,
+    PSBT_IN_PARTIAL_SIG,
+    PSBT_IN_TAP_KEY_SIG,
+    PSBT_OUT_AMOUNT,
+    PSBT_OUT_SCRIPT,
+)
 
 # Master private key for the tpub in getdescriptors below. Used by signtx,
 # which imports the keys into a wallet on the offline node provided by the
@@ -92,12 +99,51 @@ def get_mock_wallet():
     assert all(r["success"] for r in result)
     return wallet
 
+def tamper(psbt_b64, mode):
+    """Alter the transaction described by the (version 2) PSBT before signing
+    it, like a rogue or broken signer might."""
+    psbt = PSBT.from_base64(psbt_b64)
+    if mode == "change_amount":
+        # Steal from the output by redirecting the value to fees
+        amount = int.from_bytes(psbt.o[0].map[PSBT_OUT_AMOUNT], "little", signed=True)
+        psbt.o[0].map[PSBT_OUT_AMOUNT] = (amount - 1).to_bytes(8, "little", signed=True)
+    elif mode == "change_script":
+        psbt.o[0].map[PSBT_OUT_SCRIPT] = bytes([0x51])  # OP_TRUE
+    elif mode == "remove_output":
+        psbt.o.pop()
+    return psbt.to_base64()
+
 def signtx(args):
     if args.fingerprint != "00000001":
         return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
 
-    result = get_mock_wallet().walletprocesspsbt(psbt=args.psbt, sign=True, bip32derivs=False, finalize=False)
-    sys.stdout.write(json.dumps({"psbt": result["psbt"]}))
+    # The test can instruct us to sign in a specific, possibly misbehaving, way
+    mode = None
+    sign_mode_path = os.path.join(os.getcwd(), "mock_sign_mode")
+    if os.path.isfile(sign_mode_path):
+        with open(sign_mode_path, "r", encoding="utf8") as f:
+            mode = f.read().strip()
+
+    psbt = args.psbt
+    if mode in ("change_amount", "change_script", "remove_output"):
+        psbt = tamper(psbt, mode)
+
+    result = get_mock_wallet().walletprocesspsbt(psbt=psbt, sign=True, bip32derivs=False, finalize=False)
+    reply = result["psbt"]
+
+    if mode == "strip":
+        # Return only the signatures, plus the fields required to describe
+        # the same transaction
+        signed = PSBT.from_base64(reply)
+        stripped = PSBT.from_base64(reply)
+        stripped.make_blank()
+        for signed_in, stripped_in in zip(signed.i, stripped.i):
+            for key, value in signed_in.map.items():
+                if key == PSBT_IN_TAP_KEY_SIG or (isinstance(key, bytes) and key[0] == PSBT_IN_PARTIAL_SIG):
+                    stripped_in.map[key] = value
+        reply = stripped.to_base64()
+
+    sys.stdout.write(json.dumps({"psbt": reply}))
 
 parser = argparse.ArgumentParser(prog='./signer.py', description='External signer mock')
 parser.add_argument('--fingerprint')

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -14,6 +14,7 @@ from test_framework.authproxy import AuthServiceProxy, JSONRPCException
 from test_framework.psbt import (
     PSBT,
     PSBT_IN_PARTIAL_SIG,
+    PSBT_IN_SIGHASH_TYPE,
     PSBT_IN_TAP_KEY_SIG,
     PSBT_OUT_AMOUNT,
     PSBT_OUT_SCRIPT,
@@ -128,10 +129,23 @@ def signtx(args):
     if mode in ("change_amount", "change_script", "remove_output"):
         psbt = tamper(psbt, mode)
 
-    result = get_mock_wallet().walletprocesspsbt(psbt=psbt, sign=True, bip32derivs=False, finalize=False)
+    sign_options = {}
+    if mode in ("sighash_none", "sighash_none_hidden"):
+        sign_options["sighashtype"] = "NONE"
+    elif mode == "sighash_all_anyonecanpay":
+        sign_options["sighashtype"] = "ALL|ANYONECANPAY"
+
+    result = get_mock_wallet().walletprocesspsbt(psbt=psbt, sign=True, bip32derivs=False, finalize=False, **sign_options)
     reply = result["psbt"]
 
-    if mode == "strip":
+    if mode == "sighash_none_hidden":
+        # Drop the declared sighash type, leaving only the signatures
+        # themselves to reveal it
+        signed = PSBT.from_base64(reply)
+        for psbt_in in signed.i:
+            psbt_in.map.pop(PSBT_IN_SIGHASH_TYPE, None)
+        reply = signed.to_base64()
+    elif mode == "strip":
         # Return only the signatures, plus the fields required to describe
         # the same transaction
         signed = PSBT.from_base64(reply)

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -565,6 +565,34 @@ class PSBTTest(BitcoinTestFramework):
         psbt.i[0].map[PSBT_IN_SIGHASH_TYPE] = (0x101).to_bytes(4, "little")
         assert_equal(node.decodepsbt(psbt.to_base64())["inputs"][0]["sighash"], "")
 
+    def test_combinepsbt_sighash_type(self):
+        self.log.info("Test that combining PSBTs preserves the sighash type field regardless of order")
+        node = self.nodes[0]
+        node.createwallet("combine_sighash")
+        wallet = node.get_wallet_rpc("combine_sighash")
+        def_wallet = node.get_wallet_rpc(self.default_wallet_name)
+
+        def_wallet.send([{wallet.getnewaddress(address_type="bech32"): 1}])
+        self.generate(node, 1)
+        psbt = wallet.walletcreatefundedpsbt(wallet.listunspent(), [{def_wallet.getnewaddress(): 0.5}])["psbt"]
+
+        signed = wallet.walletprocesspsbt(psbt=psbt, sighashtype="ALL|ANYONECANPAY", finalize=False)["psbt"]
+        assert_equal(node.decodepsbt(signed)["inputs"][0].get("sighash"), "ALL|ANYONECANPAY")
+        updated = wallet.walletprocesspsbt(psbt=psbt, sign=False)["psbt"]
+        assert "sighash" not in node.decodepsbt(updated)["inputs"][0]
+
+        finalized = []
+        for psbts in [[signed, updated], [updated, signed]]:
+            combined = node.combinepsbt(psbts)
+            assert_equal(node.decodepsbt(combined)["inputs"][0].get("sighash"), "ALL|ANYONECANPAY")
+            fin_res = node.finalizepsbt(combined)
+            assert_equal(fin_res["complete"], True)
+            assert_equal(node.testmempoolaccept([fin_res["hex"]])[0]["allowed"], True)
+            finalized.append(fin_res["hex"])
+        assert_equal(finalized[0], finalized[1])
+
+        wallet.unloadwallet()
+
     def assert_change_type(self, psbtx, expected_type):
         """Assert that the given PSBT has a change output with the given type."""
 
@@ -1628,6 +1656,7 @@ class PSBTTest(BitcoinTestFramework):
             self.test_sighash_mismatch()
         self.test_sighash_adding()
         self.test_decodepsbt_long_sighash_type()
+        self.test_combinepsbt_sighash_type()
         self.test_psbt_named_parameter_handling()
         self.test_psbt_roundtrip()
         self.test_psbt_version()

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -36,12 +36,24 @@ class WalletSignerTest(BitcoinTestFramework):
         return sys.executable + " " + path
 
     def set_test_params(self):
-        self.num_nodes = 2
+        self.num_nodes = 3
 
         self.extra_args = [
             [],
             [f"-signer={self.mock_signer_path()}", '-keypool=10'],
+            # Node for the signer mock's wallet, kept offline so the mock
+            # can't cheat by e.g. inspecting the UTXO set
+            ["-maxconnections=0"],
         ]
+
+    def setup_network(self):
+        self.setup_nodes()
+        # Leave the signer mock's node disconnected
+        self.connect_nodes(0, 1)
+
+    def sync_except_mock(self):
+        """Sync all nodes except the signer mock's, which never receives blocks."""
+        self.sync_all(self.nodes[0:2])
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_external_signer()
@@ -54,7 +66,16 @@ class WalletSignerTest(BitcoinTestFramework):
     def clear_mock_result(self, node):
         os.remove(os.path.join(node.cwd, "mock_result"))
 
+    def init_mock_node(self):
+        """Hand the signer mock its dedicated offline node, on which it
+        creates the wallet it signs with."""
+        signer_node = self.nodes[2]
+        assert_equal(signer_node.getconnectioncount(), 0)
+        with open(os.path.join(self.nodes[1].cwd, "mock_rpc_url"), "w") as f:
+            f.write(signer_node.url)
+
     def run_test(self):
+        self.init_mock_node()
         self.test_valid_signer()
         self.test_disconnected_signer()
         self.restart_node(1, [f"-signer={self.mock_invalid_signer_path()}", "-keypool=10"])
@@ -149,73 +170,34 @@ class WalletSignerTest(BitcoinTestFramework):
             hww.walletdisplayaddress, address_fail
         )
 
-        self.log.info('Prepare mock PSBT')
-        self.nodes[0].sendtoaddress(address4, 1)
-        self.generate(self.nodes[0], 1)
+        self.log.info('Fund hww wallet')
+        for address in [address1, address2, address3, address4]:
+            self.nodes[0].sendtoaddress(address, 1)
+        self.generate(self.nodes[0], 1, sync_fun=self.sync_except_mock)
+        assert_equal(hww.getwalletinfo()["txcount"], 4)
 
-        # Load private key into wallet to generate a signed PSBT for the mock
-        self.nodes[1].createwallet(wallet_name="mock", disable_private_keys=False, blank=True)
-        mock_wallet = self.nodes[1].get_wallet_rpc("mock")
-        assert mock_wallet.getwalletinfo()['private_keys_enabled']
-
-        result = mock_wallet.importdescriptors([{
-            "desc": "tr([00000001/86h/1h/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0/*)#7ew68cn8",
-            "timestamp": 0,
-            "range": [0,1],
-            "internal": False,
-            "active": True
-        },
-        {
-            "desc": "tr([00000001/86h/1h/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/*)#0dtm6drl",
-            "timestamp": 0,
-            "range": [0, 0],
-            "internal": True,
-            "active": True
-        }])
-        assert_equal(result[0], {'success': True})
-        assert_equal(result[1], {'success': True})
-        assert_equal(mock_wallet.getwalletinfo()["txcount"], 1)
         dest = self.nodes[0].getnewaddress(address_type='bech32')
-        mock_psbt = mock_wallet.walletcreatefundedpsbt([], {dest:0.5}, 0, {'replaceable': True}, True)['psbt']
-        mock_psbt_signed = mock_wallet.walletprocesspsbt(psbt=mock_psbt, sign=True, sighashtype="ALL", bip32derivs=True)
-        mock_tx = mock_psbt_signed["hex"]
-        assert mock_wallet.testmempoolaccept([mock_tx])[0]["allowed"]
-
-        assert_equal(hww.getwalletinfo()["txcount"], 1)
-
-        assert hww.testmempoolaccept([mock_tx])[0]["allowed"]
-
-        with open(os.path.join(self.nodes[1].cwd, "mock_psbt"), "w") as f:
-            f.write(mock_psbt_signed["psbt"])
 
         self.log.info('Test send using hww1')
 
-        # Don't broadcast transaction yet so the RPC returns the raw hex
-        res = hww.send(outputs={dest:0.5},add_to_wallet=False)
+        # Spend all four address types at once. Don't broadcast the transaction
+        # yet so the RPC returns the raw hex.
+        res = hww.send(outputs={dest:3.5}, add_to_wallet=False)
         assert res["complete"]
-        assert_equal(res["hex"], mock_tx)
+        assert_equal(len(hww.decoderawtransaction(res["hex"])["vin"]), 4)
+        assert hww.testmempoolaccept([res["hex"]])[0]["allowed"]
 
         self.log.info('Test sendall using hww1')
 
-        res = hww.sendall(recipients=[{dest:0.5}, hww.getrawchangeaddress()], add_to_wallet=False)
+        res = hww.sendall(recipients=[{dest:3.5}, hww.getrawchangeaddress()], add_to_wallet=False)
         assert res["complete"]
-        assert_equal(res["hex"], mock_tx)
+        assert hww.testmempoolaccept([res["hex"]])[0]["allowed"]
         # Broadcast transaction so we can bump the fee
         hww.sendrawtransaction(res["hex"])
 
-        self.log.info('Prepare fee bumped mock PSBT')
-
-        # Now that the transaction is broadcast, bump fee in mock wallet:
-        orig_tx_id = res["txid"]
-        mock_psbt_bumped = mock_wallet.psbtbumpfee(orig_tx_id)["psbt"]
-        mock_psbt_bumped_signed = mock_wallet.walletprocesspsbt(psbt=mock_psbt_bumped, sign=True, sighashtype="ALL", bip32derivs=True)
-
-        with open(os.path.join(self.nodes[1].cwd, "mock_psbt"), "w") as f:
-            f.write(mock_psbt_bumped_signed["psbt"])
-
         self.log.info('Test bumpfee using hww1')
 
-        # Bump fee
+        orig_tx_id = res["txid"]
         res = hww.bumpfee(orig_tx_id)
         assert_greater_than(res["fee"], res["origfee"])
         assert_equal(res["errors"], [])
@@ -231,7 +213,7 @@ class WalletSignerTest(BitcoinTestFramework):
 
         # Fund wallet
         self.nodes[0].sendtoaddress(hww.getnewaddress(address_type="bech32m"), 1)
-        self.generate(self.nodes[0], 1)
+        self.generate(self.nodes[0], 1, sync_fun=self.sync_except_mock)
 
         # Restart node with no signer connected
         self.log.debug(f"-signer={self.mock_no_connected_signer_path()}")

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -66,6 +66,13 @@ class WalletSignerTest(BitcoinTestFramework):
     def clear_mock_result(self, node):
         os.remove(os.path.join(node.cwd, "mock_result"))
 
+    def set_mock_sign_mode(self, node, mode):
+        with open(os.path.join(node.cwd, "mock_sign_mode"), "w") as f:
+            f.write(mode)
+
+    def clear_mock_sign_mode(self, node):
+        os.remove(os.path.join(node.cwd, "mock_sign_mode"))
+
     def init_mock_node(self):
         """Hand the signer mock its dedicated offline node, on which it
         creates the wallet it signs with."""
@@ -77,6 +84,8 @@ class WalletSignerTest(BitcoinTestFramework):
     def run_test(self):
         self.init_mock_node()
         self.test_valid_signer()
+        self.test_unusual_signer()
+        self.test_misbehaving_signer()
         self.test_disconnected_signer()
         self.restart_node(1, [f"-signer={self.mock_invalid_signer_path()}", "-keypool=10"])
         self.test_invalid_signer()
@@ -202,6 +211,54 @@ class WalletSignerTest(BitcoinTestFramework):
         assert_greater_than(res["fee"], res["origfee"])
         assert_equal(res["errors"], [])
 
+
+    def test_unusual_signer(self):
+        self.log.info('Test unusual but acceptable external signer behavior')
+        hww = self.nodes[1].get_wallet_rpc('hww')
+
+        # Spend a segwit and a taproot UTXO, to cover both ECDSA and schnorr
+        # signatures
+        addresses = [hww.getnewaddress(address_type="bech32"), hww.getnewaddress(address_type="bech32m")]
+        for address in addresses:
+            self.nodes[0].sendtoaddress(address, 1)
+        self.generate(self.nodes[0], 1, sync_fun=self.sync_except_mock)
+        inputs = [{"txid": utxo["txid"], "vout": utxo["vout"]} for utxo in hww.listunspent(addresses=addresses)]
+        assert_equal(len(inputs), 2)
+        dest = self.nodes[0].getnewaddress()
+
+        self.log.info('The signer may strip fields it does not need')
+        self.set_mock_sign_mode(self.nodes[1], "strip")
+        res = hww.send(outputs={dest: 1.5}, inputs=inputs, add_inputs=False, add_to_wallet=False)
+        assert res["complete"]
+        assert hww.testmempoolaccept([res["hex"]])[0]["allowed"]
+
+        self.clear_mock_sign_mode(self.nodes[1])
+
+    def test_misbehaving_signer(self):
+        self.log.info('Test misbehaving external signer')
+        hww = self.nodes[1].get_wallet_rpc('hww')
+
+        # Spend a segwit and a taproot UTXO, to cover both ECDSA and schnorr
+        # signatures
+        addresses = [hww.getnewaddress(address_type="bech32"), hww.getnewaddress(address_type="bech32m")]
+        for address in addresses:
+            self.nodes[0].sendtoaddress(address, 1)
+        self.generate(self.nodes[0], 1, sync_fun=self.sync_except_mock)
+        inputs = [{"txid": utxo["txid"], "vout": utxo["vout"]} for utxo in hww.listunspent(addresses=addresses)]
+        assert_equal(len(inputs), 2)
+        dest = self.nodes[0].getnewaddress()
+
+        self.log.info('The signer must not tamper with the transaction')
+        for mode in ["change_amount", "change_script", "remove_output"]:
+            self.set_mock_sign_mode(self.nodes[1], mode)
+            with self.nodes[1].assert_debug_log(["Signer returned a PSBT for a different transaction"]):
+                assert_raises_rpc_error(-25, "External signer failed to sign", hww.send, outputs={dest: 1.5}, inputs=inputs, add_inputs=False)
+
+        self.clear_mock_sign_mode(self.nodes[1])
+
+        # The same transaction is accepted from a well-behaved signer
+        res = hww.send(outputs={dest: 1.5}, inputs=inputs, add_inputs=False, add_to_wallet=False)
+        assert res["complete"]
 
     def test_disconnected_signer(self):
         self.log.info('Test disconnected external signer')

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -232,6 +232,12 @@ class WalletSignerTest(BitcoinTestFramework):
         assert res["complete"]
         assert hww.testmempoolaccept([res["hex"]])[0]["allowed"]
 
+        self.log.info('The signer may use SIGHASH_ANYONECANPAY, which still commits to all outputs')
+        self.set_mock_sign_mode(self.nodes[1], "sighash_all_anyonecanpay")
+        res = hww.send(outputs={dest: 1.5}, inputs=inputs, add_inputs=False, add_to_wallet=False)
+        assert res["complete"]
+        assert hww.testmempoolaccept([res["hex"]])[0]["allowed"]
+
         self.clear_mock_sign_mode(self.nodes[1])
 
     def test_misbehaving_signer(self):
@@ -252,6 +258,14 @@ class WalletSignerTest(BitcoinTestFramework):
         for mode in ["change_amount", "change_script", "remove_output"]:
             self.set_mock_sign_mode(self.nodes[1], mode)
             with self.nodes[1].assert_debug_log(["Signer returned a PSBT for a different transaction"]):
+                assert_raises_rpc_error(-25, "External signer failed to sign", hww.send, outputs={dest: 1.5}, inputs=inputs, add_inputs=False)
+
+        self.log.info('The signer must not use unsafe sighash types')
+        # The first mode declares the sighash type in the PSBT, the second
+        # leaves it out, so only the signatures themselves reveal it
+        for mode in ["sighash_none", "sighash_none_hidden"]:
+            self.set_mock_sign_mode(self.nodes[1], mode)
+            with self.nodes[1].assert_debug_log(["Signer used an unsafe sighash type: NONE"]):
                 assert_raises_rpc_error(-25, "External signer failed to sign", hww.send, outputs={dest: 1.5}, inputs=inputs, add_inputs=False)
 
         self.clear_mock_sign_mode(self.nodes[1])


### PR DESCRIPTION
The current external signer functional test mock can only echo a prepared PSBT. This gets in the way of testing more complicated scenarios, i.e. misbehaving signers and (MuSig2) multisig.

Commit `test: have external signer mock use a wallet` revamps the mock signer by handing it its own node and wallet. The (offline) mock wallet has the private keys, while the test uses the watch-only version.

Commit `external_signer: merge PSBT response instead of replacing` lets the mock signer manipulate the PSBT it returns. It can drop outputs, reduce their value and change the script. Not all manipulations are malicious, e.g. a signer may simply not echo all PSBT fields, which is also covered. All this can be compensated for (thwarted) by _merging_ the external signer PSBT instead of discarding the original.

Commit `external_signer: reject unsafe sighash types` adds scenarios where devices use an unsafe sighash type.

This PR absorbs the scenarios from #35358, but is better able to test them thanks to the new mock signer implementation.

This PR does not intend to fully harden against a malicious external signer, and can't protect against a malicious HWI (equivalent) process running as the same user.

Based on:
- #36076 