### PR TITLE
fuzz: Corpus sharding in parallel runs

### DIFF
--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -33,7 +33,19 @@ def main():
     settings.update([
         "BASE_BUILD_DIR",
         "CI_FAILFAST_TEST_LEAVE_DANGLING",
+        "TMPDIR",
     ])
+
+    os.environ["TMPDIR"] = "/ci-test-tmp/"
+    if os.getenv("CI_OS_NAME") == "macos":
+        ramdisk_sectors = 4 * 1024 * 1024 * 2048  # 4 GiB
+        ramdisk = run(
+            ["hdiutil", "attach", "-nomount", f"ram://{ramdisk_sectors}"],
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+        run(["diskutil", "erasevolume", "APFS", "CI_TEST_TMP", ramdisk])
+        os.environ["TMPDIR"] = "/Volumes/CI_TEST_TMP/"
 
     # Append $USER to /tmp/env to support multi-user systems and $CONTAINER_NAME
     # to allow support starting multiple runs simultaneously by the same user.
@@ -53,6 +65,7 @@ def main():
         for create_dir in [
                 os.environ["CCACHE_DIR"],
                 os.environ["PREVIOUS_RELEASES_DIR"],
+                os.environ["TMPDIR"],
         ]:
             Path(create_dir).mkdir(parents=True, exist_ok=True)
 
@@ -136,6 +149,7 @@ def main():
         cmd_run += [
             "--cap-add=LINUX_IMMUTABLE",
             *shlex.split(os.getenv("CI_CONTAINER_CAP", "")),
+            "--mount=type=tmpfs,destination=/ci-test-tmp,tmpfs-size=4G",
             f"--mount=type=bind,src={os.environ['BASE_READ_ONLY_DIR']},dst={os.environ['BASE_READ_ONLY_DIR']},readonly",
             f"--mount={CI_CCACHE_MOUNT}",
             f"--mount={CI_DEPENDS_MOUNT}",

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -12,6 +12,7 @@ import configparser
 import logging
 import os
 import random
+import tempfile
 import subprocess
 import sys
 
@@ -65,6 +66,11 @@ def main():
         help='How many targets to merge or execute in parallel.',
     )
     parser.add_argument(
+        '--corpus-shards',
+        type=int,
+        help='How many shards to split each target corpus into (default: --par).',
+    )
+    parser.add_argument(
         'corpus_dir',
         help='The corpus to run on (must contain subfolders for each fuzz target).',
     )
@@ -88,6 +94,8 @@ def main():
     )
 
     args = parser.parse_args()
+    if args.corpus_shards is None:
+        args.corpus_shards = args.par
     args.corpus_dir = Path(args.corpus_dir)
 
     # Set up logging
@@ -198,6 +206,7 @@ def main():
             using_libfuzzer=using_libfuzzer,
             use_valgrind=args.valgrind,
             empty_min_time=args.empty_min_time,
+            corpus_shards=args.corpus_shards,
         )
 
 
@@ -327,40 +336,58 @@ def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, merge_dirs)
         future.result()
 
 
-def run_once(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, using_libfuzzer, use_valgrind, empty_min_time):
+def run_once(*, fuzz_pool, corpus, test_list, src_dir, fuzz_bin, using_libfuzzer, use_valgrind, empty_min_time, corpus_shards):
     jobs = []
     for t in test_list:
         corpus_path = corpus / t
         os.makedirs(corpus_path, exist_ok=True)
-        args = [
-            fuzz_bin,
-        ]
-        empty_dir = not any(corpus_path.iterdir())
-        if using_libfuzzer:
-            if empty_min_time and empty_dir:
-                args += [f"-max_total_time={empty_min_time}"]
-            else:
-                args += [
-                    "-runs=1",
-                    corpus_path,
-                ]
+        corpus_files = sorted(path for path in corpus_path.iterdir() if path.is_file())
+        empty_dir = not corpus_files
+
+        if corpus_shards > 1 and len(corpus_files) > 1:
+            shard_count = min(corpus_shards, len(corpus_files))
+            shard_files = [[] for _ in range(shard_count)]
+            for index, corpus_file in enumerate(corpus_files):
+                shard_files[index % shard_count].append(corpus_file)
         else:
-            args += [corpus_path]
-        if use_valgrind:
-            args = ['valgrind', '--quiet', '--error-exitcode=1'] + args
+            shard_count = 1
+            shard_files = [corpus_files]
 
-        def job(t, args):
-            output = 'Run {} with args {}'.format(t, args)
-            result = subprocess.run(
-                args,
-                env=get_fuzz_env(target=t, source_dir=src_dir),
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-            output += result.stderr
-            return output, result, t
+        for shard_index, files in enumerate(shard_files):
+            def job(t, corpus_path, empty_dir, files, shard_index, materialize):
+                def run(shard_path):
+                    args = [fuzz_bin]
+                    if using_libfuzzer:
+                        if empty_min_time and empty_dir:
+                            args += [f"-max_total_time={empty_min_time}"]
+                        else:
+                            args += ["-runs=1", shard_path]
+                    else:
+                        args += [shard_path]
+                    if use_valgrind:
+                        args = ['valgrind', '--quiet', '--error-exitcode=1'] + args
 
-        jobs.append(fuzz_pool.submit(job, t, args))
+                    output = 'Run {} with args {}'.format(t, args)
+                    result = subprocess.run(
+                        args,
+                        env=get_fuzz_env(target=t, source_dir=src_dir),
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    )
+                    output += result.stderr
+                    return output, result, t
+
+                if materialize:
+                    shard_parent = corpus.parent / "tmp_shards" / t
+                    shard_parent.mkdir(parents=True, exist_ok=True)
+                    with tempfile.TemporaryDirectory(dir=shard_parent, prefix=f"{shard_index}-") as shard_dir:
+                        shard_path = Path(shard_dir)
+                        for corpus_file in files:
+                            os.link(corpus_file, shard_path / corpus_file.name)
+                        return run(shard_path)
+                return run(corpus_path)
+
+            jobs.append(fuzz_pool.submit(job, t, corpus_path, empty_dir, files, shard_index, shard_count > 1))
 
     stats = []
     for future in as_completed(jobs):


### PR DESCRIPTION
Currently, the fuzz runner accepts a `--par` option to schedule fuzz runs in parallel. This is fine. However, when only a single target is selected, `--par` will not speed up the run. Moreover, when multiple targets are selected, the run-time of the longest target dominates.

Fix both issues by splitting the corpus to into `--par` equal-sized shards by default. The sharding can be disabled, if needed.

Can be tested e.g. by running a single target:

```
time ./bld-cmake/test/fuzz/test_runner.py --par 1  -l DEBUG ./qa-assets/fuzz_corpora/ utxo_snapshot  # slow
time ./bld-cmake/test/fuzz/test_runner.py --par 99 -l DEBUG ./qa-assets/fuzz_corpora/ utxo_snapshot  # fast