### PR TITLE
wallet: remove unused code

### DIFF
--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -1027,11 +1027,6 @@ bool SelectionResult::operator<(SelectionResult other) const
     return *m_waste < *other.m_waste || (*m_waste == *other.m_waste && m_selected_inputs.size() > other.m_selected_inputs.size());
 }
 
-std::string COutput::ToString() const
-{
-    return strprintf("COutput(%s, %d, %d) [%s]", outpoint.hash.ToString(), outpoint.n, depth, FormatMoney(txout.nValue));
-}
-
 std::string GetAlgorithmName(const SelectionAlgorithm algo)
 {
     switch (algo)

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -98,8 +98,6 @@ public:
         effective_value = txout.nValue - fee.value();
     }
 
-    std::string ToString() const;
-
     bool operator<(const COutput& rhs) const
     {
         return outpoint < rhs.outpoint;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -175,8 +175,6 @@ struct DatabaseOptions {
     // Specialized options. Not every option is supported by every backend.
     bool verify = true;             //!< Check data integrity on load.
     bool use_unsafe_sync = false;   //!< Disable file sync for faster performance.
-    bool use_shared_memory = false; //!< Let other processes access the database.
-    int64_t max_log_mb = 100;       //!< Max log size to allow before consolidating.
 };
 
 enum class DatabaseStatus {

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -11,7 +11,6 @@
 #include <support/allocators/secure.h>
 #include <util/fs.h>
 
-#include <atomic>
 #include <memory>
 #include <optional>
 #include <string>
@@ -135,9 +134,6 @@ public:
 
     /** Open the database if it is not already opened. */
     virtual void Open() = 0;
-
-    //! Counts the number of active database users to be sure that the database is not closed while someone is using it
-    std::atomic<int> m_refcount{0};
 
     /** Rewrite the entire database on disk
      */

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -119,7 +119,7 @@ static void WalletToolReleaseWallet(CWallet* wallet)
     delete wallet;
 }
 
-bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings)
+bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error)
 {
     if (name.empty()) {
         tfm::format(std::cerr, "Wallet name cannot be empty\n");

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -8,7 +8,6 @@
 #include <util/fs.h>
 
 #include <string>
-#include <vector>
 
 struct bilingual_str;
 class ArgsManager;
@@ -17,7 +16,7 @@ namespace wallet {
 class WalletDatabase;
 
 bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& error);
-bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
+bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_DUMP_H

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1173,15 +1173,6 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
     return result;
 }
 
-void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey &pubkey)
-{
-    LOCK(cs_desc_man);
-    WalletBatch batch(m_storage.GetDatabase());
-    if (!AddDescriptorKeyWithDB(batch, key, pubkey)) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor private key failed");
-    }
-}
-
 bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey)
 {
     AssertLockHeld(cs_desc_man);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -321,7 +321,6 @@ private:
 
     void Load();
 
-    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey);
     void UpdateWithSigningProvider(WalletBatch& batch, const FlatSigningProvider& signing_provider) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     //! Setup descriptors based on the given CExtKey

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -99,8 +99,6 @@ public:
     uint32_t nExternalChainCounter;
     uint32_t nInternalChainCounter;
     CKeyID seed_id; //!< seed hash160
-    int64_t m_next_external_index{0}; // Next index in the keypool to be used. Memory only.
-    int64_t m_next_internal_index{0}; // Next index in the keypool to be used. Memory only.
 
     static constexpr int VERSION_HD_BASE{1};
     static constexpr int VERSION_HD_CHAIN_SPLIT{2};

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -162,11 +162,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         return ret;
     } else if (command == "createfromdump") {
         bilingual_str error;
-        std::vector<bilingual_str> warnings;
-        bool ret = CreateFromDump(args, name, path, error, warnings);
-        for (const auto& warning : warnings) {
-            tfm::format(std::cout, "%s\n", warning.original);
-        }
+        bool ret = CreateFromDump(args, name, path, error);
         if (!ret && !error.empty()) {
             tfm::format(std::cerr, "%s\n", error.original);
         }


### PR DESCRIPTION
Six unused items in src/wallet, one per commit.

`DescriptorScriptPubKeyMan::AddDescriptorKey`, a private wrapper that
lost its caller in #28333.

`COutput::ToString`, no callers. It was used by `COutput::print()`,
which went away with the other `print()` methods in wallet.

The two `CHDChain` keypool index members, whose last uses went away with
`LegacySPKM` in #28710.

`WalletDatabase::m_refcount`. Only BDB ever maintained it, and BDB went
away in #28710.

The `warnings` parameter of `CreateFromDump`, never written, along with
the loop that printed it in wallet-tool. The `push_back` went away with
the `-format` option in #31250.

The two BDB-only members of `DatabaseOptions`, `use_shared_memory` and
`max_log_mb`. Their last readers went away with BDB in #28710, along
with the `-privdb` and `-dblogsize` options that set them.
