### PR TITLE
fuzz: reset chainman after external block imports

### DIFF
--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -16,18 +16,37 @@
 #include <cstdint>
 #include <vector>
 
+extern void MakeRandDeterministicDANGEROUS(const uint256& seed) noexcept;
+
 namespace {
-const TestingSetup* g_setup;
+TestingSetup* g_setup;
+
+/** Recreate the chainman from a deterministic genesis baseline. */
+void ResetChainman(TestingSetup& setup, FakeNodeClock& node_clock)
+{
+    node_clock.set(setup.m_node.chainman->GetParams().GenesisBlock().Time());
+    MakeRandDeterministicDANGEROUS(uint256::ZERO);
+    setup.m_node.chainman.reset();
+    setup.m_make_chainman();
+    setup.LoadVerifyActivateChainstate();
+}
 } // namespace
 
 void initialize_load_external_block_file()
 {
-    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    FakeNodeClock init_clock{}; // Uses the existing mock time
+    static const auto testing_setup = MakeNoLogFileContext<TestingSetup>(
+        ChainType::REGTEST,
+        {
+            .setup_net = false,
+        });
     g_setup = testing_setup.get();
+    ResetChainman(*g_setup, init_clock);
 }
 
 FUZZ_TARGET(load_external_block_file, .init = initialize_load_external_block_file)
 {
+    SeedRandomStateForTest(SeedRand::ZEROS);
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     FakeNodeClock clock{ConsumeTime(fuzzed_data_provider)};
     FuzzedFileProvider fuzzed_file_provider{fuzzed_data_provider};
@@ -44,4 +63,6 @@ FUZZ_TARGET(load_external_block_file, .init = initialize_load_external_block_fil
         // Corresponds to the -loadblock= case (orphan blocks aren't tracked across files).
         g_setup->m_node.chainman->LoadExternalBlockFile(fuzzed_block_file);
     }
+
+    ResetChainman(*g_setup, clock);
 }


### PR DESCRIPTION
`LoadExternalBlockFile()` may add headers to the block index even when full block validation fails. Reusing the static chainman therefore lets one fuzz input affect later inputs and makes all-corpus coverage order-dependent.

Recreate the chainman after each processed input, disable unused network setup so `PeerManager` cannot retain a reference to it, and reseed the deterministic test RNG consumed by chainman initialization.

Tested with `run_deterministic_fuzz_coverage.sh load_external_block_file 20`: all 930 corpus inputs passed both the individual-repeat and randomized all-corpus checks.