### PR TITLE
mining: preserve lookup result count without a mempool

### DIFF
--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -1031,7 +1031,7 @@ public:
 
     std::vector<CTransactionRef> getTransactionsByTxID(const std::vector<Txid>& txids) override
     {
-        if (!m_node.mempool) return {};
+        if (!m_node.mempool) return std::vector<CTransactionRef>(txids.size());
 
         std::vector<CTransactionRef> results;
         results.reserve(txids.size());
@@ -1044,7 +1044,7 @@ public:
 
     std::vector<CTransactionRef> getTransactionsByWitnessID(const std::vector<Wtxid>& wtxids) override
     {
-        if (!m_node.mempool) return {};
+        if (!m_node.mempool) return std::vector<CTransactionRef>(wtxids.size());
 
         std::vector<CTransactionRef> results;
         results.reserve(wtxids.size());

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -103,12 +103,12 @@ BOOST_FIXTURE_TEST_CASE(transaction_lookups_without_mempool, BasicTestingSetup)
 
     const std::vector txids{Txid::FromUint256(uint256::ZERO), Txid::FromUint256(uint256::ONE)};
     const auto tx_results{mining->getTransactionsByTxID(txids)};
-    BOOST_REQUIRE_EQUAL(tx_results.size(), 0U); // TODO: Return one result per requested txid
+    BOOST_REQUIRE_EQUAL(tx_results.size(), txids.size());
     for (auto& tx : tx_results) BOOST_CHECK(!tx);
 
     const std::vector wtxids{Wtxid::FromUint256(uint256::ZERO), Wtxid::FromUint256(uint256::ONE)};
     const auto wtx_results{mining->getTransactionsByWitnessID(wtxids)};
-    BOOST_REQUIRE_EQUAL(wtx_results.size(), 0U); // TODO: Return one result per requested wtxid
+    BOOST_REQUIRE_EQUAL(wtx_results.size(), wtxids.size());
     for (auto& tx : wtx_results) BOOST_CHECK(!tx);
 }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -96,6 +96,22 @@ BOOST_FIXTURE_TEST_SUITE(miner_tests, MinerTestingSetup)
 
 static CFeeRate blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
 
+BOOST_FIXTURE_TEST_CASE(transaction_lookups_without_mempool, BasicTestingSetup)
+{
+    const node::NodeContext node;
+    const auto mining{Assert(interfaces::MakeMining(node, /*wait_loaded=*/false))};
+
+    const std::vector txids{Txid::FromUint256(uint256::ZERO), Txid::FromUint256(uint256::ONE)};
+    const auto tx_results{mining->getTransactionsByTxID(txids)};
+    BOOST_REQUIRE_EQUAL(tx_results.size(), 0U); // TODO: Return one result per requested txid
+    for (auto& tx : tx_results) BOOST_CHECK(!tx);
+
+    const std::vector wtxids{Wtxid::FromUint256(uint256::ZERO), Wtxid::FromUint256(uint256::ONE)};
+    const auto wtx_results{mining->getTransactionsByWitnessID(wtxids)};
+    BOOST_REQUIRE_EQUAL(wtx_results.size(), 0U); // TODO: Return one result per requested wtxid
+    for (auto& tx : wtx_results) BOOST_CHECK(!tx);
+}
+
 constexpr static struct {
     unsigned int extranonce;
     unsigned int nonce;


### PR DESCRIPTION
**Problem:** The mining interface returns one nullable transaction for every requested txid or wtxid so callers can match results by position.
When its `NodeContext` has no mempool ([not sure that's possible](https://github.com/bitcoin/bitcoin/pull/34020#discussion_r2962016282), but there's a condition for it which violates the contract), both lookup methods return an empty vector for every nonempty request and discard that positional mapping, see: https://github.com/bitcoin/bitcoin/blob/7b6f9ba7bad13b0c4169259000f7802854cdda0d/src/interfaces/mining.h#L202-L203

**Fix:** Return a vector sized to the request when no mempool is available.
Default-initialized null entries match the existing representation for identifiers absent from an available mempool, so callers receive one response position per request in either state.
