### PR TITLE
doc: Correct comment about which subsystem detects lagging clocks

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3034,10 +3034,10 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
                 peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
                     m_chainparams.HeadersSync(), chain_start_header, minimum_chain_work));
             } catch (const HeadersSyncState::SystemClockError& e) {
-                // Typically we would expect the chain state loading logic to
-                // already have verified that the tip of the locally stored
-                // chain is <= system clock + MAX_FUTURE_BLOCK_TIME. Getting
-                // here is really unexpected.
+                // The chain state loading logic performs an earlier check to
+                // verify that the tip of the locally stored chain is <=
+                // system clock + MAX_FUTURE_BLOCK_TIME.
+                // But if we have no pre-existing chain state we might get here.
                 const auto msg{strprintf("Failure when attempting to initiate headers sync: %s", e.what())};
                 std::cerr << msg << std::endl;
                 LogError("%s", msg);


### PR DESCRIPTION
Turns out a completely fresh datadir means there is no chain state to load and hence no detection of a lagging clock occurs in that subsystem. Instead we do proceed into attempting to start a headers sync.

<details><summary>Diff to repro with fresh -datadir</summary>

```diff
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1499,6 +1499,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const ArgsManager& args = *Assert(node.args);
     const CChainParams& chainparams = Params();
 
+    SetMockTime(chainparams.GenesisBlock().Time() - 3h);
+
     auto opt_max_upload = ParseByteUnits(args.GetArg("-maxuploadtarget", DEFAULT_MAX_UPLOAD_TARGET), ByteUnit::M);
     if (!opt_max_upload) {
         return InitError(strprintf(_("Unable to parse -maxuploadtarget: '%s'"), args.GetArg("-maxuploadtarget", "")));
```

</details>

Follow-up to #35351