### PR TITLE
net: validate Tor onion service replies and cached keys

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -70,6 +70,7 @@ constexpr int MAX_LINE_LENGTH = 100000;
 constexpr int MAX_LINE_COUNT = 1000;
 /** Timeout for socket operations */
 constexpr auto SOCKET_SEND_TIMEOUT = 10s;
+constexpr std::string_view PRIVATE_KEY_NEW{"NEW:ED25519-V3"};
 
 /****** Low-level TorControlConnection ********/
 
@@ -566,7 +567,7 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
 
         // Finally - now create the service
         if (m_private_key.empty()) { // No private key, generate one
-            m_private_key = "NEW:ED25519-V3"; // Explicitly request key type - see issue #9214
+            m_private_key = PRIVATE_KEY_NEW; // Explicitly request key type - see issue #9214
         }
         // Request onion service, redirect port.
         _conn.Command(MakeAddOnionCmd(m_private_key, m_target.ToStringAddrPort(), /*enable_pow=*/true),

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -71,6 +71,16 @@ constexpr int MAX_LINE_COUNT = 1000;
 /** Timeout for socket operations */
 constexpr auto SOCKET_SEND_TIMEOUT = 10s;
 constexpr std::string_view PRIVATE_KEY_NEW{"NEW:ED25519-V3"};
+constexpr std::string_view PRIVATE_KEY_PREFIX{"ED25519-V3:"};
+
+/** Whether the value requests a new Ed25519 v3 key or has the expected key format */
+static bool IsWellFormedPrivateKey(std::string_view key)
+{
+    if (key == PRIVATE_KEY_NEW) return true;
+    if (!key.starts_with(PRIVATE_KEY_PREFIX)) return false;
+    const auto decoded{DecodeBase64(key.substr(PRIVATE_KEY_PREFIX.size()))};
+    return decoded && decoded->size() == 64; // A 32-byte secret scalar followed by a 32-byte PRF secret
+}
 
 /****** Low-level TorControlConnection ********/
 
@@ -522,8 +532,13 @@ void TorController::add_onion_cb(TorControlConnection& _conn, const TorControlRe
             std::map<std::string,std::string>::iterator i;
             if ((i = m.find("ServiceID")) != m.end())
                 m_service_id = i->second;
-            if ((i = m.find("PrivateKey")) != m.end())
+            if ((i = m.find("PrivateKey")) != m.end()) {
+                if (!IsWellFormedPrivateKey(i->second)) { // Never adopt or cache such a key
+                    LogWarning("tor: ADD_ONION returned a malformed private key");
+                    return;
+                }
                 m_private_key = i->second;
+            }
         }
         if (m_service_id.empty()) {
             LogWarning("tor: Error parsing ADD_ONION parameters:");
@@ -533,6 +548,10 @@ void TorController::add_onion_cb(TorControlConnection& _conn, const TorControlRe
             return;
         }
         m_service = LookupNumeric(std::string(m_service_id+".onion"), Params().GetDefaultPort());
+        if (!m_service.IsValid()) {
+            LogWarning("tor: ADD_ONION returned a malformed service ID");
+            return;
+        }
         LogInfo("Got tor service ID %s, advertising service %s", m_service_id, m_service.ToStringAddrPort());
         if (WriteBinaryFile(GetPrivateKeyFile(), m_private_key)) {
             LogDebug(BCLog::TOR, "Cached service private key to %s", fs::PathToString(GetPrivateKeyFile()));
@@ -568,6 +587,10 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
         // Finally - now create the service
         if (m_private_key.empty()) { // No private key, generate one
             m_private_key = PRIVATE_KEY_NEW; // Explicitly request key type - see issue #9214
+        } else if (!IsWellFormedPrivateKey(m_private_key)) {
+            // add_onion_cb() never adopts such a key, so it can only come from the cache file
+            LogWarning("tor: Refusing to use cached private key %s because it is malformed; remove the file to generate a new key", fs::PathToString(GetPrivateKeyFile()));
+            return;
         }
         // Request onion service, redirect port.
         _conn.Command(MakeAddOnionCmd(m_private_key, m_target.ToStringAddrPort(), /*enable_pow=*/true),

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -260,12 +260,73 @@ class TorControlTest(BitcoinTestFramework):
 
         mock_tor.stop()
 
+    def test_malformed_service_id(self):
+        invalid_service_id = "invalid"
+        key_path = self.nodes[0].chain_path / "onion_v3_private_key"
+        mock_tor = MockTorControlServer(self.next_port(), service_id=invalid_service_id)
+
+        self.log.info("Test a malformed service ID returned by ADD_ONION")
+        with self.nodes[0].assert_debug_log([f"Got tor service ID {invalid_service_id}"], timeout=10):  # TODO: Reject the malformed service ID
+            self.restart_with_mock(mock_tor)
+        assert key_path.exists()  # TODO: Do not cache a key for a malformed service ID
+        mock_tor.stop()
+
+    def test_private_key_tor_command_injection(self):
+        valid_private_key = "ED25519-V3:wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=="  # 64 arbitrary bytes encoded as Base64
+        key_path = self.nodes[0].chain_path / "onion_v3_private_key"
+
+        self.log.info("Test that a valid returned private key is cached and reused")
+        tor_control_port = self.next_port()
+        mock_tor = MockTorControlServer(tor_control_port, private_key=valid_private_key)
+        with self.nodes[0].assert_debug_log(["Cached service private key"], timeout=10):
+            self.restart_with_mock(mock_tor)
+        assert_equal(key_path.read_bytes(), valid_private_key.encode())
+        mock_tor.stop()
+
+        mock_tor = MockTorControlServer(tor_control_port)
+        self.restart_with_mock(mock_tor, cached_private_key=valid_private_key)
+        self.wait_until(lambda: any(command.startswith(f"ADD_ONION {valid_private_key} ") for command in mock_tor.received_commands), timeout=10)
+        mock_tor.stop()
+
+        for private_key, injected, cached_log in [
+            # A line break ends the ADD_ONION command, so Tor runs the rest of the key as a second command
+            (
+                f"{valid_private_key}\r\nSIGNAL SHUTDOWN\r\n",
+                "SIGNAL SHUTDOWN",
+                "Received unexpected sync reply 510",  # TODO: Refuse to use the cached key
+            ),
+            # A space ends the key argument, so Tor parses the rest of the key as further ADD_ONION arguments
+            (
+                f"{valid_private_key} Flags=Detach",
+                "Flags=Detach",
+                "Cached service private key",  # TODO: Refuse to use the cached key
+            ),
+        ]:
+            self.log.info(f"Test {injected!r} injected through a returned private key")
+            # A reply line ends at CRLF and an unquoted value at a space, so only a quoted value can carry either
+            escaped_private_key = private_key.replace("\r", "\\r").replace("\n", "\\n")
+            quoted_private_key = f'"{escaped_private_key}"'
+            mock_tor = MockTorControlServer(tor_control_port, private_key=quoted_private_key)
+            with self.nodes[0].assert_debug_log(["Cached service private key"], timeout=10):  # TODO: Reject the returned key
+                self.restart_with_mock(mock_tor)
+            assert_equal(key_path.read_bytes(), private_key.encode())  # TODO: Reject the returned key
+            mock_tor.stop()
+
+            self.log.info(f"Test {injected!r} injected through a cached private key")
+            mock_tor = MockTorControlServer(tor_control_port)
+            with self.nodes[0].assert_debug_log([cached_log], timeout=10):
+                self.restart_with_mock(mock_tor, cached_private_key=private_key)
+            self.wait_until(lambda: any(injected in command for command in mock_tor.received_commands), timeout=10)  # TODO: Refuse to send the cached key
+            mock_tor.stop()
+
     def run_test(self):
         self.test_basic()
         self.test_partial_data()
         self.test_pow_fallback()
         self.test_oversized_line()
         self.test_overmany_lines()
+        self.test_malformed_service_id()
+        self.test_private_key_tor_command_injection()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -266,9 +266,9 @@ class TorControlTest(BitcoinTestFramework):
         mock_tor = MockTorControlServer(self.next_port(), service_id=invalid_service_id)
 
         self.log.info("Test a malformed service ID returned by ADD_ONION")
-        with self.nodes[0].assert_debug_log([f"Got tor service ID {invalid_service_id}"], timeout=10):  # TODO: Reject the malformed service ID
+        with self.nodes[0].assert_debug_log(["ADD_ONION returned a malformed service ID"], timeout=10):
             self.restart_with_mock(mock_tor)
-        assert key_path.exists()  # TODO: Do not cache a key for a malformed service ID
+        assert not key_path.exists()
         mock_tor.stop()
 
     def test_private_key_tor_command_injection(self):
@@ -293,13 +293,13 @@ class TorControlTest(BitcoinTestFramework):
             (
                 f"{valid_private_key}\r\nSIGNAL SHUTDOWN\r\n",
                 "SIGNAL SHUTDOWN",
-                "Received unexpected sync reply 510",  # TODO: Refuse to use the cached key
+                f"Refusing to use cached private key {key_path}",
             ),
             # A space ends the key argument, so Tor parses the rest of the key as further ADD_ONION arguments
             (
                 f"{valid_private_key} Flags=Detach",
                 "Flags=Detach",
-                "Cached service private key",  # TODO: Refuse to use the cached key
+                f"Refusing to use cached private key {key_path}",
             ),
         ]:
             self.log.info(f"Test {injected!r} injected through a returned private key")
@@ -307,16 +307,16 @@ class TorControlTest(BitcoinTestFramework):
             escaped_private_key = private_key.replace("\r", "\\r").replace("\n", "\\n")
             quoted_private_key = f'"{escaped_private_key}"'
             mock_tor = MockTorControlServer(tor_control_port, private_key=quoted_private_key)
-            with self.nodes[0].assert_debug_log(["Cached service private key"], timeout=10):  # TODO: Reject the returned key
+            with self.nodes[0].assert_debug_log(["ADD_ONION returned a malformed private key"], timeout=10):
                 self.restart_with_mock(mock_tor)
-            assert_equal(key_path.read_bytes(), private_key.encode())  # TODO: Reject the returned key
+            assert not key_path.exists()
             mock_tor.stop()
 
             self.log.info(f"Test {injected!r} injected through a cached private key")
             mock_tor = MockTorControlServer(tor_control_port)
             with self.nodes[0].assert_debug_log([cached_log], timeout=10):
                 self.restart_with_mock(mock_tor, cached_private_key=private_key)
-            self.wait_until(lambda: any(injected in command for command in mock_tor.received_commands), timeout=10)  # TODO: Refuse to send the cached key
+            assert not any(injected in command for command in mock_tor.received_commands)
             mock_tor.stop()
 
     def run_test(self):

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -13,9 +13,11 @@ from test_framework.util import (
     p2p_port,
 )
 
+SERVICE_ID = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd"
+
 
 class MockTorControlServer:
-    def __init__(self, port, manual_mode=False):
+    def __init__(self, port, manual_mode=False, private_key=None, service_id=SERVICE_ID):
         self.port = port
         self.sock = None
         self.conn = None
@@ -23,6 +25,8 @@ class MockTorControlServer:
         self.thread = None
         self.received_commands = []
         self.manual_mode = manual_mode
+        self.private_key = private_key  # returned by ADD_ONION, as Tor does for a generated key
+        self.service_id = service_id
         self.conn_ready = threading.Event()
 
     def start(self):
@@ -94,10 +98,10 @@ class MockTorControlServer:
         elif command == "AUTHENTICATE":
             return "250 OK\r\n"
         elif command.startswith("ADD_ONION"):
-            return (
-                "250-ServiceID=testserviceid1234567890123456789012345678901234567890123456\r\n"
-                "250 OK\r\n"
-            )
+            reply = f"250-ServiceID={self.service_id}\r\n"
+            if self.private_key:
+                reply += f"250-PrivateKey={self.private_key}\r\n"
+            return reply + "250 OK\r\n"
         elif command.startswith("GETINFO"):
             return "250-net/listeners/socks=\"127.0.0.1:9050\"\r\n250 OK\r\n"
         else:
@@ -112,9 +116,15 @@ class TorControlTest(BitcoinTestFramework):
         self._port_counter = getattr(self, '_port_counter', 0) + 1
         return p2p_port(self.num_nodes + self._port_counter)
 
-    def restart_with_mock(self, mock_tor):
+    def restart_with_mock(self, mock_tor, cached_private_key=None):
+        self.stop_node(0)
+        key_path = self.nodes[0].chain_path / "onion_v3_private_key"
+        if cached_private_key is None:
+            key_path.unlink(missing_ok=True)
+        else:
+            key_path.write_bytes(cached_private_key.encode())
         mock_tor.start()
-        self.restart_node(0, extra_args=[
+        self.start_node(0, extra_args=[
             f"-torcontrol=127.0.0.1:{mock_tor.port}",
             "-listenonion=1",
             "-debug=tor",
@@ -189,14 +199,8 @@ class TorControlTest(BitcoinTestFramework):
 
         class NoPowServer(MockTorControlServer):
             def _get_response(self, command):
-                if command.startswith("ADD_ONION"):
-                    if "PoWDefensesEnabled=1" in command:
-                        return "512 Unrecognized option\r\n"
-                    else:
-                        return (
-                            "250-ServiceID=testserviceid1234567890123456789012345678901234567890123456\r\n"
-                            "250 OK\r\n"
-                        )
+                if command.startswith("ADD_ONION") and "PoWDefensesEnabled=1" in command:
+                    return "512 Unrecognized option\r\n"
                 return super()._get_response(command)
 
         mock_tor = NoPowServer(self.next_port())


### PR DESCRIPTION
**Problem:** A node creates its onion service through Tor's control protocol and caches the returned private key for reconnects.
Tor reply parsing unescapes quoted values, so a control endpoint can return a private key containing a line break or space.
When the node reconnects, it inserts that key unquoted into an `ADD_ONION` command, where CRLF frames the remainder as a separate command and a space adds further arguments.
An unprivileged local process can exploit this by impersonating the default loopback endpoint while Tor is unavailable, seeding the cache, and releasing the port before Tor returns.
A compromised operator-configured endpoint can return the same malicious key.
The reply handler also continues after receiving an invalid service ID, logging it and caching the key before attempting to advertise the invalid address.

**Fix:** This PR validates the returned service ID as a Tor v3 onion address before logging it, caching the key, or advertising the service.
It accepts `NEW:ED25519-V3` or an `ED25519-V3` key whose Base64 payload decodes to 64 bytes.
Returned keys are validated before adoption or caching, and cached keys are validated before reuse.
A malformed cached key leaves the onion service unavailable until the operator removes the file and restarts the node, but cannot inject another command or argument.
