### PR TITLE
descriptor: add CreateMultisigDescriptor()

### DIFF
--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -2994,16 +2994,21 @@ uint256 DescriptorID(const Descriptor& desc)
     return id;
 }
 
-util::Result<std::string> CreateMultisigDescriptor(
-    int threshold,
-    const std::vector<std::string>& keys,
-    OutputType output_type)
+util::Result<std::string> CreateMultisigDescriptor(int threshold, const std::vector<std::string>& keys, OutputType output_type)
 {
+    std::string multisig_fn;
+    std::string internal_key;
     switch (output_type) {
     case OutputType::BECH32:
+        multisig_fn = "sortedmulti";
         break;
     case OutputType::BECH32M:
-        return util::Error{_("Taproot multisig is not yet supported")};
+        // NUMS_H is accepted by most hardware signers that support taproot multisig.
+        // One limitation to using a fixed point would be the possibility of fingerprinting
+        // as script-path spends reveal a recognizable internal key.
+        multisig_fn = "sortedmulti_a";
+        internal_key = "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6QgnecKFpJFPpdzxKrwoaZoV44qAJewsc4kX9vGaCaBExuvJH57"; //HexStr(XOnlyPubKey::NUMS_H);
+        break;
     case OutputType::LEGACY:
     case OutputType::P2SH_SEGWIT:
     case OutputType::UNKNOWN:
@@ -3029,12 +3034,15 @@ util::Result<std::string> CreateMultisigDescriptor(
     std::set<std::string> seen;
     uint32_t key_exp_index{0};
 
+    const ParseScriptContext ctx{output_type == OutputType::BECH32M
+        ? ParseScriptContext::P2TR
+        : ParseScriptContext::P2WSH};
+
     for (const auto& key : keys) {
         FlatSigningProvider provider;
         std::string error;
         std::span<const char> sp{key};
-        auto parsed{ParsePubkey(key_exp_index, sp,
-            ParseScriptContext::P2WSH, provider, error)};
+        auto parsed{ParsePubkey(key_exp_index, sp, ctx, provider, error)};
 
         if (parsed.empty()) {
             return util::Error{strprintf(
@@ -3069,11 +3077,18 @@ util::Result<std::string> CreateMultisigDescriptor(
         canonical_keys.emplace_back(canonical);
     }
 
-    std::string descriptor{"wsh(sortedmulti(" + util::ToString(threshold)};
+    std::string inner{multisig_fn + "(" + util::ToString(threshold)};
     for (const auto& key : canonical_keys) {
-        descriptor += "," + key + "/<0;1>/*";
+        inner += "," + key + "/<0;1>/*";
     }
-    descriptor += "))";
+    inner += ")";
+
+    std::string descriptor;
+    if (output_type == OutputType::BECH32M) {
+        descriptor = "tr(" + internal_key + "," + inner + ")";
+    } else {
+        descriptor = "wsh(" + inner + ")";
+    }
 
     FlatSigningProvider provider;
     std::string error;

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -30,6 +30,7 @@
 #include <util/expected.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/translation.h>
 #include <util/vector.h>
 
 #include <algorithm>
@@ -2991,6 +2992,101 @@ uint256 DescriptorID(const Descriptor& desc)
     uint256 id;
     CSHA256().Write((unsigned char*)desc_str.data(), desc_str.size()).Finalize(id.begin());
     return id;
+}
+
+util::Result<std::string> CreateMultisigDescriptor(
+    int threshold,
+    const std::vector<std::string>& keys,
+    OutputType output_type)
+{
+    switch (output_type) {
+    case OutputType::BECH32:
+        break;
+    case OutputType::BECH32M:
+        return util::Error{_("Taproot multisig is not yet supported")};
+    case OutputType::LEGACY:
+    case OutputType::P2SH_SEGWIT:
+    case OutputType::UNKNOWN:
+        return util::Error{_("Unsupported address type")};
+    }
+    const int n{int(keys.size())};
+    if (n < 2) {
+        return util::Error{_("A multisig requires at least 2 keys")};
+    }
+    if (n > MAX_PUBKEYS_PER_MULTISIG) {
+        return util::Error{strprintf(
+            _("A multisig cannot have more than %d keys, %d were provided"),
+            MAX_PUBKEYS_PER_MULTISIG, n)};
+    }
+    if (threshold < 1 || threshold > n) {
+        return util::Error{strprintf(
+            _("The threshold must be between 1 and %d, %d was provided"),
+            n, threshold)};
+    }
+
+    std::vector<std::string> canonical_keys;
+    canonical_keys.reserve(keys.size());
+    std::set<std::string> seen;
+    uint32_t key_exp_index{0};
+
+    for (const auto& key : keys) {
+        FlatSigningProvider provider;
+        std::string error;
+        std::span<const char> sp{key};
+        auto parsed{ParsePubkey(key_exp_index, sp,
+            ParseScriptContext::P2WSH, provider, error)};
+
+        if (parsed.empty()) {
+            return util::Error{strprintf(
+                _("Invalid key '%s': %s"), key, error)};
+        }
+        if (!provider.keys.empty()) {
+            return util::Error{strprintf(
+                _("Key '%s' contains private key; only public keys may be shared with cosigners"), key)};
+        }
+        // This function produces a single-spending-path multisig.
+        if (parsed.size() != 1) {
+            return util::Error{strprintf(_("Key '%s' must not specify a multipath derivation"), key)};
+        }
+
+        const auto xpub{parsed[0]->GetRootExtPubKey()};
+        if (!xpub) {
+            return util::Error{strprintf(_("Key '%s' must be an extended public key"), key)};
+        }
+
+        const std::string canonical{parsed[0]->ToString()};
+        if (!canonical.starts_with('[')) {
+            return util::Error{strprintf(_("Key '%s' must include key origin information, formatted [fingerprint/path]xpub"), key)};
+        }
+        if (!canonical.ends_with(EncodeExtPubKey(*xpub))) {
+            return util::Error{strprintf(_("Key '%s' must not specify a derivation path"), key)};
+        }
+
+        if (!seen.insert(EncodeExtPubKey(*xpub)).second) {
+            return util::Error{strprintf(_("Duplicate key: %s"), key)};
+        }
+
+        canonical_keys.emplace_back(canonical);
+    }
+
+    std::string descriptor{"wsh(sortedmulti(" + util::ToString(threshold)};
+    for (const auto& key : canonical_keys) {
+        descriptor += "," + key + "/<0;1>/*";
+    }
+    descriptor += "))";
+
+    FlatSigningProvider provider;
+    std::string error;
+    const auto descs{Parse(descriptor, provider, error)};
+    if (descs.empty()) {
+        return util::Error{strprintf(_("Invalid descriptor: %s"), error)};
+    }
+    if (!Assume(descs.size() == 2)) {
+        return util::Error{_(
+            "Internal error: descriptor did not expand to a receive and a change path")};
+    }
+
+    return AddChecksum(descriptor);
 }
 
 void DescriptorCache::CacheParentExtPubKey(uint32_t key_exp_pos, const CExtPubKey& xpub)

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -6,9 +6,9 @@
 #define BITCOIN_SCRIPT_DESCRIPTOR_H
 
 #include <outputtype.h>
-#include <util/result.h>
 #include <pubkey.h>
 #include <uint256.h>
+#include <util/result.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -6,6 +6,7 @@
 #define BITCOIN_SCRIPT_DESCRIPTOR_H
 
 #include <outputtype.h>
+#include <util/result.h>
 #include <pubkey.h>
 #include <uint256.h>
 
@@ -243,5 +244,17 @@ std::unique_ptr<Descriptor> InferDescriptor(const CScript& script, const Signing
 *   This is not part of BIP 380, not guaranteed to be interoperable and should not be exposed to the user.
 */
 uint256 DescriptorID(const Descriptor& desc);
+
+/** Assemble and validate a Multisig descriptor during the multisig wallet setup process.
+ * The descriptor uses sortedmulti(k, ...), so key order doesn't matter for the resulting addresses.
+ * Key origin is mandatory and formatted [fingerprint/path]xpub.
+ *
+ * @param[in] threshold    Signatures required, 1 <= threshold <= keys.size().
+ * @param[in] keys         Key placeholders, formatted [fingerprint/path]xpub.
+ * @param[in] output_type  The address type. BECH32 (P2WSH) is currently supported;
+ *                         other types return an error.
+ * @return The ranged, multipath descriptor with checksum, or an error describing what was rejected.
+ */
+util::Result<std::string> CreateMultisigDescriptor(int threshold, const std::vector<std::string>& keys, OutputType output_type);
 
 #endif // BITCOIN_SCRIPT_DESCRIPTOR_H

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -7,8 +7,10 @@
 #include <script/sign.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
+#include <util/result.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/translation.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -592,6 +594,17 @@ void CheckInferDescriptor(const std::string& script_hex, const std::string& expe
 
     std::unique_ptr<Descriptor> desc = InferDescriptor(script, provider);
     BOOST_CHECK_EQUAL(desc->ToString(), expected_desc + "#" + checksum);
+}
+
+const std::string MULTISIG_KEY_A{"[6738736c/48h/0h/0h/2h]xpub6FC1fXFP1GXLX5TKtcjHGT4q89SDRehkQLtbKJ2PzWcvbBHtyDsJPLtpLtkGqYNYZdVVAjRQ5kug9CsapegmmeRutpP7PW4u4wVF9JfkDhw"};
+const std::string MULTISIG_KEY_B{"[b2b1f0cf/48h/0h/0h/2h]xpub6EWhjpPa6FqrcaPBuGBZRJVjzGJ1ZsMygRF26RwN932Vfkn1gyCiTbECVitBjRCkexEvetLdiqzTcYimmzYxyR1BZ79KNevgt61PDcukmC7"};
+const std::string MULTISIG_KEY_C{"[a666a867/44h/0h/0h/100h]xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2"};
+
+void CheckMultisigError(const util::Result<std::string>& res, std::string_view expected_reason)
+{
+    BOOST_REQUIRE(!res);
+    const std::string err{util::ErrorString(res).original};
+    BOOST_CHECK_MESSAGE(err.find(expected_reason) != std::string::npos, "expected '" << expected_reason << "' in error: " << err);
 }
 
 }
@@ -1417,5 +1430,55 @@ BOOST_AUTO_TEST_CASE(unused_descriptor_test)
     CheckUnused("unused(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)", "unused(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)");
     CheckUnused("unused(xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/0h/0h/1)", "unused(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/0h/0h/1)");
 }
+
+BOOST_AUTO_TEST_CASE(descriptor_create_multisig_valid)
+{
+    const std::string inner{
+        "wsh(sortedmulti(2,"
+        + MULTISIG_KEY_A + "/<0;1>/*,"
+        + MULTISIG_KEY_B + "/<0;1>/*,"
+        + MULTISIG_KEY_C + "/<0;1>/*))"};
+    const std::string expected{inner + "#" + GetDescriptorChecksum(inner)};
+
+    {
+        const auto res{CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32)};
+        BOOST_REQUIRE(res);
+        BOOST_CHECK_EQUAL(*res, expected);
+
+        FlatSigningProvider provider;
+        std::string error;
+        const auto descs{Parse(*res, provider, error)};
+        BOOST_REQUIRE_EQUAL(descs.size(), 2U);
+        BOOST_CHECK(descs[0]->ToString().find("/0/*") != std::string::npos);
+        BOOST_CHECK(descs[1]->ToString().find("/1/*") != std::string::npos);
+    }
+
+    // Threshold = 1 and threshold = n are valid edge cases
+    BOOST_CHECK(CreateMultisigDescriptor(1, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32));
+    BOOST_CHECK(CreateMultisigDescriptor(3, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32));
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_create_multisig_invalid_policy)
+{
+    CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32M), "Taproot");
+    CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::LEGACY), "Unsupported address type");
+    CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::P2SH_SEGWIT), "Unsupported address type");
+    CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::UNKNOWN), "Unsupported address type");
+
+    CheckMultisigError(CreateMultisigDescriptor(0, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32), "threshold");
+    CheckMultisigError(CreateMultisigDescriptor(4, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32), "threshold");
+    CheckMultisigError(CreateMultisigDescriptor(1, {MULTISIG_KEY_A}, OutputType::BECH32), "at least 2");
+    CheckMultisigError(CreateMultisigDescriptor(1, {}, OutputType::BECH32), "at least 2");
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_create_multisig_invalid_keys)
+{
+    CheckMultisigError(CreateMultisigDescriptor(1, {MULTISIG_KEY_A, MULTISIG_KEY_A}, OutputType::BECH32), "Duplicate");
+    CheckMultisigError(CreateMultisigDescriptor(1, {MULTISIG_KEY_A + "/0", MULTISIG_KEY_B}, OutputType::BECH32), "derivation path");
+    CheckMultisigError(CreateMultisigDescriptor(1, {MULTISIG_KEY_A + "/<0;1>/*", MULTISIG_KEY_B}, OutputType::BECH32), "multipath");
+    CheckMultisigError(CreateMultisigDescriptor(1, {"L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1", MULTISIG_KEY_B}, OutputType::BECH32), "private key");
+    CheckMultisigError(CreateMultisigDescriptor(1, {"[6738736c/48h/0h/0h/2h]xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi", MULTISIG_KEY_B}, OutputType::BECH32), "private key");
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -1458,9 +1458,25 @@ BOOST_AUTO_TEST_CASE(descriptor_create_multisig_valid)
     BOOST_CHECK(CreateMultisigDescriptor(3, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32));
 }
 
+BOOST_AUTO_TEST_CASE(descriptor_create_multisig_valid_p2tr)
+{
+    const auto res{CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32M)};
+    BOOST_REQUIRE(res);
+    // NUMS_H as internal key
+    BOOST_CHECK(res->starts_with("tr(xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6QgnecKFpJFPpdzxKrwoaZoV44qAJewsc4kX9vGaCaBExuvJH57,"));
+    BOOST_CHECK(res->find("sortedmulti_a(2,") != std::string::npos);
+    BOOST_CHECK(res->find("/<0;1>/*") != std::string::npos);
+
+    FlatSigningProvider provider;
+    std::string error;
+    const auto descs{Parse(*res, provider, error)};
+    BOOST_REQUIRE_EQUAL(descs.size(), 2U);
+    BOOST_CHECK(descs[0]->ToString().find("/0/*") != std::string::npos);
+    BOOST_CHECK(descs[1]->ToString().find("/1/*") != std::string::npos);
+}
+
 BOOST_AUTO_TEST_CASE(descriptor_create_multisig_invalid_policy)
 {
-    CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::BECH32M), "Taproot");
     CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::LEGACY), "Unsupported address type");
     CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::P2SH_SEGWIT), "Unsupported address type");
     CheckMultisigError(CreateMultisigDescriptor(2, {MULTISIG_KEY_A, MULTISIG_KEY_B, MULTISIG_KEY_C}, OutputType::UNKNOWN), "Unsupported address type");


### PR DESCRIPTION
The multisig setup flows need to assemble a descriptor from collected cosigner keys without hand-crafting the descriptor string, which today means bash interpolation with no validation of key forms, duplicates, or threshold.

CreateMultisigDescriptor() takes a threshold, a list of key expressions with origin info, and an output type, and returns a ranged, multipath wsh(sortedmulti(...)) descriptor with checksum.

Part of the multisig wizard tracking issue #35645.