### PR TITLE
test: Avoid unsafe memory race in index_reorg_crash shutdown

### DIFF
--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -223,6 +223,9 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, TestChain100Setup)
         BOOST_REQUIRE(m_node.chainman->ProcessNewBlock(block, /*force_processing=*/true, /*min_pow_checked=*/true, nullptr));
     }
 
+    // The index thread is blocked and not done
+    BOOST_CHECK(!index.GetSummary().synced);
+
     // Unblock the index thread so it can process the reorg
     promise.set_value();
     // Wait for the index to reach the new tip

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -84,6 +84,10 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
             // Reload index to see which block data was actually committed.
             BOOST_REQUIRE(index->Init());
             BOOST_CHECK_EQUAL(index->GetSummary().best_block_height, expected_commit_height);
+
+            // Drain in-flight validation callbacks before destroying the index.
+            m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
+            // shutdown sequence (c.f. Shutdown() in init.cpp)
             index->Stop();
         };
 

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -230,6 +230,10 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, TestChain100Setup)
     promise.set_value();
     // Wait for the index to reach the new tip
     func_wait_until(blocking_height + 2, 5s);
+
+    // Drain unused BlockConnected events, to avoid unsafe memory races during destruction
+    m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
+    // shutdown sequence (c.f. Shutdown() in init.cpp)
     index.Stop();
 }
 


### PR DESCRIPTION
Currently, the `index_reorg_crash` test may rarely crash due to UB in sanitizers like TSan or ASan. This is perfectly fine, because it is just a rare test-only issue.

However, fix it nonetheless by adding a missing drain of the unused in-flight events. Also, add a small check about the synced state while touching this test.