### PR TITLE
validation: Leave pruned blocks in `m_blocks_unlinked`, fix another `nSequenceId` issue

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -259,7 +259,7 @@ void BlockManager::AddUnlinkedBlock(CBlockIndex* block)
 {
     AssertLockHeld(cs_main);
     Assume(block != nullptr);
-    Assume(block->nStatus & BLOCK_HAVE_DATA);
+    Assume(block->nTx > 0); // Not BLOCK_HAVE_DATA: the data of the block may have been pruned
     auto range = m_blocks_unlinked.equal_range(block->pprev);
     for (auto it = range.first; it != range.second; ++it) {
         if (it->second == block) return;  // don't insert duplicates
@@ -281,18 +281,10 @@ void BlockManager::PruneOneBlockFile(const int fileNumber)
             pindex->nUndoPos = 0;
             m_dirty_blockindex.insert(pindex);
 
-            // Prune from m_blocks_unlinked -- any block we prune would have
-            // to be downloaded again in order to consider its chain, at which
-            // point it would be considered as a candidate for
-            // m_blocks_unlinked or setBlockIndexCandidates.
-            auto range = m_blocks_unlinked.equal_range(pindex->pprev);
-            while (range.first != range.second) {
-                std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
-                range.first++;
-                if (_it->second == pindex) {
-                    m_blocks_unlinked.erase(_it);
-                }
-            }
+            // Note that the block is deliberately left in m_blocks_unlinked:
+            // Removing it here would mean if a potential missing ancestor arrives,
+            // ReceivedBlockTransactions() no longer finds this block and never
+            // computes its m_chain_tx_count.
         }
     }
 
@@ -498,9 +490,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
                     pindex->m_chain_tx_count = pindex->pprev->m_chain_tx_count + pindex->nTx;
                 } else {
                     pindex->m_chain_tx_count = 0;
-                    if (pindex->nStatus & BLOCK_HAVE_DATA) {
-                        AddUnlinkedBlock(pindex);
-                    }
+                    AddUnlinkedBlock(pindex);
                 }
             } else {
                 pindex->m_chain_tx_count = pindex->nTx;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -351,7 +351,16 @@ public:
     std::vector<CBlockIndex*> GetAllBlockIndices() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
-     * All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
+     * Pairs A->B, where the transactions of B have been received at some point,
+     * but B is not a candidate for connection, because for A or one of its predecessors
+     * the transactions were never received, or the block data is no longer
+     * available (the latter is only tracked for blocks that were candidates for
+     * the most-work chain). B is reconsidered as a chain candidate when the
+     * block of A is received.
+     *
+     * Membership depends on transactions ever having been received (nTx > 0),
+     * not on block data currently being available (BLOCK_HAVE_DATA), so pruning
+     * B does not remove it from here.
      */
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
     void AddUnlinkedBlock(CBlockIndex* block) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -165,14 +165,6 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
                     prune_block->nFile = 0;
                     prune_block->nDataPos = 0;
                     prune_block->nUndoPos = 0;
-                    auto range = blockman.m_blocks_unlinked.equal_range(prune_block->pprev);
-                    while (range.first != range.second) {
-                        std::multimap<CBlockIndex*, CBlockIndex*>::iterator _it = range.first;
-                        range.first++;
-                        if (_it->second == prune_block) {
-                            blockman.m_blocks_unlinked.erase(_it);
-                        }
-                    }
                     pruned_blocks.push_back(prune_block);
                 }
             },

--- a/src/test/fuzz/block_index_tree.cpp
+++ b/src/test/fuzz/block_index_tree.cpp
@@ -152,13 +152,9 @@ FUZZ_TARGET(block_index_tree, .init = initialize_block_index_tree)
             [&] {
                 // Prune chain - dealing with block files is beyond the scope of this test, so just prune random blocks, making no assumptions
                 // about what blocks are pruned together because they are in the same block file.
-                // Also don't prune blocks outside of the chain for now - this would make the fuzzer crash because of the problem described in
-                // https://github.com/bitcoin/bitcoin/issues/31512
                 LOCK(cs_main);
-                auto& chain = chainman.ActiveChain();
-                int prune_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, chain.Height());
-                CBlockIndex* prune_block{chain[prune_height]};
-                if (prune_block != chain.Tip() && (prune_block->nStatus & BLOCK_HAVE_DATA)) {
+                CBlockIndex* prune_block{PickValue(fuzzed_data_provider, blocks)};
+                if (prune_block != chainman.ActiveChain().Tip() && (prune_block->nStatus & BLOCK_HAVE_DATA)) {
                     blockman.m_have_pruned = true;
                     prune_block->nStatus &= ~BLOCK_HAVE_DATA;
                     prune_block->nStatus &= ~BLOCK_HAVE_UNDO;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3825,6 +3825,13 @@ void ChainstateManager::ReceivedBlockTransactions(const CBlock& block, CBlockInd
                    pindex->nHeight, pindex->m_chain_tx_count, prev_tx_sum(*pindex), CLIENT_NAME, FormatFullVersion(), CLIENT_BUGREPORT);
             }
             pindex->m_chain_tx_count = prev_tx_sum(*pindex);
+            // nSequenceId is one of the sort keys of setBlockIndexCandidates, so pindex must
+            // not be in any of them while it is changed - doing so would corrupt their
+            // ordering. pindex can be a candidate here if we receive the block data of a block
+            // that already is one, which happens when it is downloaded again after being pruned.
+            for (const auto& c : m_chainstates) {
+                c->setBlockIndexCandidates.erase(pindex);
+            }
             pindex->nSequenceId = nBlockSequenceId++;
             for (const auto& c : m_chainstates) {
                 c->TryAddBlockIndexCandidate(pindex);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5384,11 +5384,15 @@ void ChainstateManager::CheckBlockIndex() const
                 foundInUnlinked = true;
             }
         }
-        if (pindex->pprev && (pindex->nStatus & BLOCK_HAVE_DATA) && pindexFirstNeverProcessed != nullptr && pindexFirstInvalid == nullptr) {
-            // If this block has block data available, some parent was never received, and has no invalid parents, it must be in m_blocks_unlinked.
+        if (foundInUnlinked) assert(pindex->nTx > 0); // Only blocks whose transactions were received belong in m_blocks_unlinked
+        if (pindex->pprev && pindex->nTx > 0 && pindexFirstNeverProcessed != nullptr && pindexFirstInvalid == nullptr) {
+            // If the transactions of this block were received, some parent was never received, and it has no
+            // invalid parents, it must be in m_blocks_unlinked. Note that this holds whether or not the block
+            // data is still available, because pruning does not remove entries.
             assert(foundInUnlinked);
         }
-        if (!(pindex->nStatus & BLOCK_HAVE_DATA)) assert(!foundInUnlinked); // Can't be in m_blocks_unlinked if we don't HAVE_DATA
+        // Can't be in m_blocks_unlinked if we don't HAVE_DATA, unless our own data was pruned after being added there.
+        if (!(pindex->nStatus & BLOCK_HAVE_DATA)) assert(m_blockman.IsBlockPruned(*pindex) || !foundInUnlinked);
         if (pindexFirstMissing == nullptr) assert(!foundInUnlinked); // We aren't missing data for any parent -- cannot be in m_blocks_unlinked.
         if (pindex->pprev && (pindex->nStatus & BLOCK_HAVE_DATA) && pindexFirstNeverProcessed == nullptr && pindexFirstMissing != nullptr) {
             // We HAVE_DATA for this block, have received data for all parents at some point, but we're currently missing data for some parent.

--- a/test/functional/feature_prune_stale_fork.py
+++ b/test/functional/feature_prune_stale_fork.py
@@ -2,7 +2,15 @@
 # Copyright (c) 2026-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test node restart with a pruned stale-fork block whose parent has no transactions."""
+"""Test pruned stale-fork blocks whose parent has no transactions.
+
+A stale-fork block whose parent's transactions were never received cannot be
+connected, so it is tracked in m_blocks_unlinked until they are. Pruning removes
+its block data, but not the fact that its own transactions were received, so it
+has to stay listed there. Otherwise the arrival of the parent no longer reaches
+it, and neither it nor its descendants - which may well still have their own
+block data - ever get their m_chain_tx_count, which trips CheckBlockIndex().
+"""
 
 from test_framework.blocktools import create_empty_fork
 from test_framework.test_framework import BitcoinTestFramework
@@ -14,11 +22,17 @@ class FeaturePruneStaleForkTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [["-prune=1", "-fastprune"]]
 
+    def tip_status(self, node, block_hash):
+        """Return the getchaintips status of block_hash, which must be a tip."""
+        tips = [tip for tip in node.getchaintips() if tip["hash"] == block_hash]
+        assert_equal(len(tips), 1)
+        return tips[0]["status"]
+
     def run_test(self):
         node = self.nodes[0]
 
-        self.log.info("Create a 2-block stale fork: parent has no transactions, child has transactions")
-        [side_parent, side_child] = create_empty_fork(node, 2)
+        self.log.info("Create a 3-block stale fork: parent has no transactions, child has transactions")
+        [side_parent, side_child, side_grandchild] = create_empty_fork(node, 3)
 
         node.submitheader(side_parent.serialize().hex())
         node.submitblock(side_child.serialize().hex())
@@ -32,6 +46,26 @@ class FeaturePruneStaleForkTest(BitcoinTestFramework):
 
         self.log.info("Restart and mine; node must reload cleanly after the stale-fork child was pruned")
         self.restart_node(0)
+        self.generate(node, 1)
+
+        # The child is now only listed in m_blocks_unlinked if the restart put it back there
+        # without its block data, so what follows also covers reloading the block index.
+        self.log.info("Submit the grandchild of the pruned child; it keeps its own block data")
+        node.submitblock(side_grandchild.serialize().hex())
+        node.getblock(side_grandchild.hash_hex)
+        assert_equal(self.tip_status(node, side_grandchild.hash_hex), "headers-only")
+
+        self.log.info("Submit the parent's block; the whole fork must be linked up")
+        node.submitblock(side_parent.serialize().hex())
+        assert_equal(node.getblockheader(side_parent.hash_hex)["nTx"], 1)
+        # The child's block data is still gone, but its transactions were received at some
+        # point, so the grandchild is no longer waiting for transactions the node has.
+        assert_raises_rpc_error(-1, "Block not available (pruned data)", node.getblock, side_child.hash_hex)
+        assert_equal(self.tip_status(node, side_grandchild.hash_hex), "valid-headers")
+
+        self.log.info("Restart again; the reloaded node must agree with the running one")
+        self.restart_node(0)
+        assert_equal(self.tip_status(node, side_grandchild.hash_hex), "valid-headers")
         self.generate(node, 1)
 
 


### PR DESCRIPTION
`m_blocks_unlinked` serves two purposes:
 1. finding blocks to `setBlockIndexCandidates` once their parents are
       received
 2. setting `m_chain_tx_count` once the parents are received

In case the parent block of a previously pruned block is received,  2. is currently not being done, because pruning removed the entries from `m_blocks_unlinked`.
This can result in `CheckBlockIndex` failures (#31512, #36021) and incorrect rpc results, plus we are in a temporarily inconsistent state (`m_chain_tx_count` is currently not set, but would get set if we restarted).

This scenario is unlikely to happen during normal node operation unless there are huge reorgs, but it can happen, for example, in `getblockfrompeer` scenarios.
Fix this by leaving pruned blocks in `m_chain_tx_count`, and also adding them on restart. 

This was one of two reasons, the fuzz target `block_index_tree` couldn't cover pruning of blocks not in the main chain.

The other one is similar to #34521 and #35070 - if we receive a block a second time (after pruning), we could change `nSequenceId` while the block is in `setBlockIndexCandidates` - fix this by attempting to remove it from the set before re-adding it.

After the two issues are fixed, the restriction from `block_index_tree` fuzz target is removed.

Fixes #36021
Fixes #31512