### PR TITLE
indexes: set prune lock to genesis before first block

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -504,9 +504,9 @@ void BaseIndex::SetBestBlockIndex(const CBlockIndex* block)
 {
     assert(!m_chainstate->m_blockman.IsPruneMode() || AllowPrune());
 
-    if (AllowPrune() && block) {
+    if (AllowPrune()) {
         node::PruneLockInfo prune_lock;
-        prune_lock.height_first = block->nHeight;
+        prune_lock.height_first = block ? block->nHeight : 0;
         WITH_LOCK(::cs_main, m_chainstate->m_blockman.UpdatePruneLock(GetName(), prune_lock));
     }
 

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -20,7 +20,6 @@ from test_framework.script import (
     OP_RETURN,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.test_node import ErrorMatch
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
@@ -472,15 +471,9 @@ class PruneTest(BitcoinTestFramework):
         self.sync_blocks([self.nodes[0], self.nodes[5]], wait=5, timeout=300)
 
         self.log.info("Test prune with a new index")
-        self.stop_node(0)
+        self.restart_node(0, extra_args=["-prune=550", "-blockfilterindex=1"])
         node = self.nodes[0]
-        # TODO: Starting prune with a new index must sync the index before pruning.
-        node.assert_start_raises_init_error(
-            extra_args=["-prune=550", "-blockfilterindex=1"],
-            expected_msg="basic block filter index best block of the index goes beyond pruned data",
-            match=ErrorMatch.PARTIAL_REGEX,
-        )
-        self.start_node(0, extra_args=["-prune=550"])
+        self.wait_until(lambda: node.getindexinfo()["basic block filter index"]["best_block_height"] >= 10, timeout=300)
 
         if self.is_wallet_compiled():
             self.log.info("Test wallet re-scan")

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -20,6 +20,7 @@ from test_framework.script import (
     OP_RETURN,
 )
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import ErrorMatch
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
@@ -469,6 +470,17 @@ class PruneTest(BitcoinTestFramework):
         self.log.info("Syncing node 5 to node 0")
         self.connect_nodes(0, 5)
         self.sync_blocks([self.nodes[0], self.nodes[5]], wait=5, timeout=300)
+
+        self.log.info("Test prune with a new index")
+        self.stop_node(0)
+        node = self.nodes[0]
+        # TODO: Starting prune with a new index must sync the index before pruning.
+        node.assert_start_raises_init_error(
+            extra_args=["-prune=550", "-blockfilterindex=1"],
+            expected_msg="basic block filter index best block of the index goes beyond pruned data",
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+        self.start_node(0, extra_args=["-prune=550"])
 
         if self.is_wallet_compiled():
             self.log.info("Test wallet re-scan")


### PR DESCRIPTION
When setting both a new index and prune size and restarting an unpruned node, the node will prune the block store first and then the index will fail to start syncing.

Fix this by setting the prune lock to 0 if the index does not yet have a best block.
