### PR TITLE
makeseeds: fix off-by-one in field count check

### DIFF
--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import random
 import re
 import sys
+import unittest
 from typing import Union
 
 asmap_dir = Path(__file__).parent.parent / "asmap"
@@ -265,6 +266,28 @@ def main():
         if 'asn' in ip:
             print(f" # AS{ip['asn']}", end="")
         print()
+
+class TestParseLine(unittest.TestCase):
+    """Unit tests for `parseline`."""
+
+    # A seeder line has 12 whitespace-separated fields: address, good, lastSuccess, %(2h), %(8h), %(1d), %(7d), %(30d), blocks, services, version, user agent
+    VALID_LINE = '1.2.3.4:8333 1 1700000000 100.00% 100.00% 100.00% 100.00% 100.00% 910001 000000000000040d 70016 "/Satoshi:29.0.0/"'
+
+    def test_valid_line(self):
+        parsed = parseline(self.VALID_LINE)
+        self.assertEqual(parsed['net'], 'ipv4')
+        self.assertEqual(parsed['ip'], '1.2.3.4')
+        self.assertEqual(parsed['port'], 8333)
+        self.assertEqual(parsed['agent'], '/Satoshi:29.0.0/')
+
+    def test_truncated_line_is_skipped(self):
+        fields = self.VALID_LINE.split()
+        for count in range(11):
+            with self.subTest(fields=count):
+                self.assertIsNone(parseline(' '.join(fields[:count])))
+        # TODO: the user agent is the 12th field, so a line with 11 fields should be skipped rather than aborting the run
+        with self.assertRaises(IndexError):
+            parseline(' '.join(fields[:11]))
 
 if __name__ == '__main__':
     main()

--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -62,7 +62,7 @@ def parseline(line: str) -> Union[dict, None]:
         # Ignore line that starts with comment
         return None
     sline = line.split()
-    if len(sline) < 11:
+    if len(sline) < 12:
         # line too short to be valid, skip it.
         return None
     # Skip bad results.
@@ -285,9 +285,7 @@ class TestParseLine(unittest.TestCase):
         for count in range(11):
             with self.subTest(fields=count):
                 self.assertIsNone(parseline(' '.join(fields[:count])))
-        # TODO: the user agent is the 12th field, so a line with 11 fields should be skipped rather than aborting the run
-        with self.assertRaises(IndexError):
-            parseline(' '.join(fields[:11]))
+        self.assertIsNone(parseline(' '.join(fields[:11])))  # The user agent is the 12th field, so 11 fields is still too short
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #36146.

`parseline()` checks that a line has at least 11 whitespace-separated fields:

```python
if len(sline) < 11:
    # line too short to be valid, skip it.
    return None
```

but it later reads `sline[11]` (the user agent), which needs 12. A line with exactly 11 fields got past the check and then raised `IndexError`, aborting the whole run instead of skipping that line. 11 is the highest index the function uses, so the check now requires 12 fields.

This isn't only theoretical: README.md builds seeds_main.txt by appending one crawler's output onto another's, so the file mixes two independently maintained formats, and a truncated download leaves a short last line too. Skipping the line is what the check was already trying to do.

The first commit adds tests, since nothing covered makeseeds before. They pass on both commits with different expectations: it first records that an 11-field line raises `IndexError`, and the fix commit replaces that single assertion with the line being skipped. Run with:

```
python3 -m unittest contrib.seeds.makeseeds
```




