### PR TITLE
test: cover the feature-negotiation version boundary in p2p_leak

### DIFF
--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -125,14 +125,21 @@ class P2PLeakTest(BitcoinTestFramework):
         pre_wtxidrelay_peer = self.nodes[0].add_p2p_connection(NoVerackIdlePeer(), send_version=False, wait_for_verack=False)
         pre_wtxidrelay_peer.send_without_ping(self.create_old_version(70015))
 
+        # Peer at exactly nVersion == 70016, the lowest version that supports the
+        # feature negotiation messages, so it must receive WTXIDRELAY and SENDADDRV2.
+        wtxidrelay_peer = self.nodes[0].add_p2p_connection(NoVerackIdlePeer(), send_version=False, wait_for_verack=False)
+        wtxidrelay_peer.send_without_ping(self.create_old_version(70016))
+
         # Wait until the peer gets the verack in response to the version. Though, don't wait for the node to receive the
         # verack, since the peer never sent one
         no_verack_idle_peer.wait_for_verack()
         pre_wtxidrelay_peer.wait_for_verack()
+        wtxidrelay_peer.wait_for_verack()
 
         no_version_idle_peer.wait_until(lambda: no_version_idle_peer.ever_connected)
         no_verack_idle_peer.wait_until(lambda: no_verack_idle_peer.version_received)
         pre_wtxidrelay_peer.wait_until(lambda: pre_wtxidrelay_peer.version_received)
+        wtxidrelay_peer.wait_until(lambda: wtxidrelay_peer.version_received)
 
         # Mine a block and make sure that it's not sent to the connected peers
         self.generate(self.nodes[0], nblocks=1)
@@ -159,10 +166,16 @@ class P2PLeakTest(BitcoinTestFramework):
         assert not pre_wtxidrelay_peer.got_sendaddrv2
         assert not pre_wtxidrelay_peer.got_feature
 
+        assert not wtxidrelay_peer.unexpected_msg
+        assert wtxidrelay_peer.got_wtxidrelay
+        assert wtxidrelay_peer.got_sendaddrv2
+        assert not wtxidrelay_peer.got_feature  # feature messages start at nVersion >= 70017
+
         # Expect peers to be disconnected due to timeout
         assert not no_version_idle_peer.is_connected
         assert not no_verack_idle_peer.is_connected
         assert not pre_wtxidrelay_peer.is_connected
+        assert not wtxidrelay_peer.is_connected
 
         self.log.info('Check that the version message does not leak the local address of the node')
         p2p_version_store = self.nodes[0].add_p2p_connection(P2PVersionStore())
@@ -177,7 +190,7 @@ class P2PLeakTest(BitcoinTestFramework):
 
         self.log.info('Check that old peers are disconnected')
         p2p_old_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
-        with self.nodes[0].assert_debug_log(["using obsolete version 31799, disconnecting peer=5"]):
+        with self.nodes[0].assert_debug_log(["using obsolete version 31799, disconnecting peer=6"]):
             p2p_old_peer.send_without_ping(self.create_old_version(31799))
             p2p_old_peer.wait_for_disconnect()
 

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -100,6 +100,18 @@ class SendTxRcnclTest(BitcoinTestFramework):
         assert not peer.sendtxrcncl_msg_received
         self.nodes[0].disconnect_p2ps()
 
+        self.log.info('SENDTXRCNCL on lowest WTXID version should be sent')
+        peer = self.nodes[0].add_p2p_connection(SendTxrcnclReceiver(), send_version=False, wait_for_verack=False)
+        wtxid_version_msg = msg_version()
+        wtxid_version_msg.nVersion = 70016
+        wtxid_version_msg.strSubVer = P2P_SUBVERSION
+        wtxid_version_msg.nServices = P2P_SERVICES
+        wtxid_version_msg.relay = 1
+        peer.send_without_ping(wtxid_version_msg)
+        peer.wait_for_verack()
+        assert peer.sendtxrcncl_msg_received
+        self.nodes[0].disconnect_p2ps()
+
         self.log.info('SENDTXRCNCL for fRelay=false should not be sent')
         peer = self.nodes[0].add_p2p_connection(SendTxrcnclReceiver(), send_version=False, wait_for_verack=False)
         no_txrelay_version_msg = msg_version()


### PR DESCRIPTION
p2p_leak already checks that a pre-wtxidrelay peer (nVersion 70015) is sent neither WTXIDRELAY nor SENDADDRV2, but nothing pins down the exact boundary: the feature negotiation messages are offered when the common version is >= WTXID_RELAY_VERSION (70016). 

Add a peer advertising exactly 70016 and assert it receives both messages, so an off-by-one change of either `greatest_common_version >= WTXID_RELAY_VERSION` / `>= 70016` comparison to `>` is detected.

It kills https://bitcoincore.space/src/net_processing.cpp#3462 and https://bitcoincore.space/src/net_processing.cpp#3464

-----

edit: added a commit that adds a test case that checks `SENDTXRCNCL` is sent at version 70016. The existing 70015 case only shows SENDTXRCNCL is withheld below the wtxidrelay version. Add a peer at exactly 70016 so the lower bound of the `>= WTXID_RELAY_VERSION` check is covered too. It kills: https://bitcoincore.space/src/net_processing.cpp#3466.

