### PR TITLE
http: Improve HTTPRemoteClient::MaybeDisconnect()

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1278,6 +1278,11 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
 
             // Our work is done here
             if (!m_keep_alive) {
+                LogDebug(
+                    BCLog::HTTP,
+                    "Done sending to client without keep-alive %s (id=%llu)",
+                    m_origin,
+                    m_id);
                 m_disconnect = true;
                 // Do not attempt to read from this client.
                 return false;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1097,19 +1097,18 @@ std::unique_ptr<HTTPRequest> HTTPRemoteClient::TryReadRequest(const std::shared_
 void HTTPServer::DisconnectClients()
 {
     const auto now{Now<SteadySeconds>()};
-    size_t erased = std::erase_if(m_connected,
-                                  [&](auto& client) {
-                                      return client->MaybeDisconnect(now,
-                                                                     m_rpcservertimeout,
-                                                                     /*disconnect_all=*/m_disconnect_all_clients);
-                                  });
+    size_t erased = std::erase_if(m_connected, [&](auto& client) {
+        return client->ShouldDisconnect(now,
+                                        m_rpcservertimeout,
+                                        /*disconnect_all=*/m_disconnect_all_clients);
+    });
     if (erased > 0) {
         // Report back to the main thread
         m_connected_size.fetch_sub(erased, std::memory_order_relaxed);
     }
 }
 
-bool HTTPRemoteClient::MaybeDisconnect(std::chrono::time_point<SteadyClock> now, std::chrono::seconds rpcservertimeout, bool disconnect_all)
+bool HTTPRemoteClient::ShouldDisconnect(std::chrono::time_point<SteadyClock> now, std::chrono::seconds rpcservertimeout, bool disconnect_all) const
 {
     // First check for idle timeout. We reset the timer when we send and receive data,
     // but if the server is busy handling a request we should ignore the timeout until

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1110,43 +1110,35 @@ void HTTPServer::DisconnectClients()
 
 bool HTTPRemoteClient::ShouldDisconnect(MockableSteadyClock::time_point now, std::chrono::seconds rpcservertimeout, bool disconnect_all) const
 {
-    // First check for idle timeout. We reset the timer when we send and receive data,
+    // Disconnect this client due to error or end of communication
+    // May drop unsent data if we are closing due to error.
+    if (m_disconnect) {
+        // We should already have logged the reason why we flagged for disconnect.
+
+    // Check for idle timeout. We reset the timer when we send and receive data,
     // but if the server is busy handling a request we should ignore the timeout until
     // the reply is sent. If we did erase the shared_ptr<HTTPRemoteClient> reference in m_connected
     // while the server is busy with a request, it might be prematurely dropped before
     // the response has been sent, or if the HTTPRequest was holding a temporary shared_ptr
     // client on a worker thread - it would keep the socket open even after "disconnecting".
-    const bool is_idle{rpcservertimeout.count() > 0 &&
-                       now - m_idle_since.load() > rpcservertimeout &&
-                       !m_req_busy};
+    } else if (rpcservertimeout.count() > 0 &&
+               now - m_idle_since.load() > rpcservertimeout &&
+               !m_req_busy) {
+        LogDebug(BCLog::HTTP,
+                 "HTTP client idle timeout %s (id=%llu)",
+                 m_origin,
+                 m_id);
 
-    // Disconnect this client due to error, end of communication, or idle timeout.
-    // May drop unsent data if we are closing due to error.
-    if (m_disconnect || is_idle) {
-        if (is_idle) {
-            LogDebug(BCLog::HTTP,
-                     "HTTP client idle timeout %s (id=%llu)",
-                     m_origin,
-                     m_id);
-        }
+    // Disconnect this client because the server is shutting down and we
+    // need to disconnect all clients... Unless we still have data for
+    // this client, in which case we'd rather continue the I/O loop
+    // until all data is sent or an error is encountered.
+    } else if (disconnect_all && !m_connection_busy) {
+        // This is a healthy persistent connection (e.g. keep-alive)
+        // but it's time to say goodbye.
     } else {
-        // Disconnect this client because the server is shutting
-        // down and we need to disconnect all clients...
-        if (disconnect_all) {
-            // ...unless we still have data for this client.
-            if (m_connection_busy) {
-                // There is still data for this healthy-connected client.
-                // Continue the I/O loop until all data is sent or an error is encountered.
-                return false;
-            } else {
-                // This is a healthy persistent connection (e.g. keep-alive)
-                // but it's time to say goodbye.
-                ;
-            }
-        } else {
-            // No reason to disconnect.
-            return false;
-        }
+        // No reason to disconnect.
+        return false;
     }
     // No reason NOT to disconnect, log and remove.
     LogDebug(BCLog::HTTP,

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -944,7 +944,7 @@ void HTTPRemoteClient::Receive()
         m_disconnect = true;
     } else {
         // Reset idle timeout
-        m_idle_since = Now<SteadySeconds>();
+        m_idle_since = MockableSteadyClock::now();
 
         // Prevent disconnect until all requests are completely handled.
         m_connection_busy = true;
@@ -1096,7 +1096,7 @@ std::unique_ptr<HTTPRequest> HTTPRemoteClient::TryReadRequest(const std::shared_
 
 void HTTPServer::DisconnectClients()
 {
-    const auto now{Now<SteadySeconds>()};
+    const auto now{MockableSteadyClock::now()};
     size_t erased = std::erase_if(m_connected, [&](auto& client) {
         return client->ShouldDisconnect(now,
                                         m_rpcservertimeout,
@@ -1108,7 +1108,7 @@ void HTTPServer::DisconnectClients()
     }
 }
 
-bool HTTPRemoteClient::ShouldDisconnect(std::chrono::time_point<SteadyClock> now, std::chrono::seconds rpcservertimeout, bool disconnect_all) const
+bool HTTPRemoteClient::ShouldDisconnect(MockableSteadyClock::time_point now, std::chrono::seconds rpcservertimeout, bool disconnect_all) const
 {
     // First check for idle timeout. We reset the timer when we send and receive data,
     // but if the server is busy handling a request we should ignore the timeout until
@@ -1293,7 +1293,7 @@ bool HTTPRemoteClient::MaybeSendBytesFromBuffer()
         }
 
         // Finally, reset idle timeout
-        m_idle_since = Now<SteadySeconds>();
+        m_idle_since = MockableSteadyClock::now();
     }
 
     return true;

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -492,7 +492,7 @@ class HTTPRemoteClient
 {
 public:
     explicit HTTPRemoteClient(HTTPServer::Id id, const CService& addr, std::unique_ptr<Sock> socket)
-        : m_id(id), m_addr(addr), m_origin(addr.ToStringAddrPort()), m_sock{std::move(socket)}, m_idle_since{Now<SteadySeconds>()} {}
+        : m_id(id), m_addr(addr), m_origin(addr.ToStringAddrPort()), m_sock{std::move(socket)}, m_idle_since{MockableSteadyClock::now()} {}
 
     // Disable copies (should only be used as shared pointers)
     HTTPRemoteClient(const HTTPRemoteClient&) = delete;
@@ -506,7 +506,7 @@ public:
     void Send(const HTTPResponse& res, std::span<const std::byte> reply_body, bool keep_alive) EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex, !m_sock_mutex);
     void Receive() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex);
 
-    bool ShouldDisconnect(std::chrono::time_point<SteadyClock> now, std::chrono::seconds rpcservertimeout, bool disconnect_all) const;
+    bool ShouldDisconnect(std::chrono::time_point<MockableSteadyClock> now, std::chrono::seconds rpcservertimeout, bool disconnect_all) const;
 
     /**
      * Try to read an HTTPRequest from a client's receive buffer.
@@ -624,7 +624,7 @@ private:
     //! Timestamp of last send or receive activity, used for -rpcservertimeout.
     //! Due to optimistic sends it may be updated in either a worker thread or in the
     //! I/O thread. It is checked in the I/O thread to disconnect idle clients.
-    std::atomic<SteadySeconds> m_idle_since;
+    std::atomic<MockableSteadyClock::time_point> m_idle_since;
 };
 
 /** Initialize HTTP server.

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -506,7 +506,7 @@ public:
     void Send(const HTTPResponse& res, std::span<const std::byte> reply_body, bool keep_alive) EXCLUSIVE_LOCKS_REQUIRED(!m_send_mutex, !m_sock_mutex);
     void Receive() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex);
 
-    bool MaybeDisconnect(std::chrono::time_point<SteadyClock> now, std::chrono::seconds rpcservertimeout, bool disconnect_all);
+    bool ShouldDisconnect(std::chrono::time_point<SteadyClock> now, std::chrono::seconds rpcservertimeout, bool disconnect_all) const;
 
     /**
      * Try to read an HTTPRequest from a client's receive buffer.

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -6,11 +6,14 @@
 #include <rpc/protocol.h>
 #include <test/util/common.h>
 #include <test/util/logging.h>
+#include <test/util/net.h>
 #include <test/util/setup_common.h>
+#include <util/overflow.h>
 #include <util/string.h>
 #include <util/threadpool.h>
 
 #include <boost/test/unit_test.hpp>
+#include <memory>
 
 using util::LineReader;
 using namespace bitcoin_http;
@@ -774,6 +777,110 @@ BOOST_AUTO_TEST_CASE(http_request_state_tests)
         client->receive("k:vv\n");
         BOOST_CHECK(!HTTPRemoteClient::TryReadRequest(client));
         BOOST_CHECK_EQUAL(client->GetRequest()->GetState(), HTTPRequest::State::Error);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(http_should_disconnect_tests)
+{
+    struct Client : HTTPRemoteClient {
+        Client(std::unique_ptr<Sock> socket = CreateSock(0, 0, 0))
+            : HTTPRemoteClient{/*id=*/0, /*addr=*/CService(), /*socket=*/std::move(socket)} {}
+        using HTTPRemoteClient::MutateRecvBuffer;
+    };
+    // Prevent the clock from actually progressing during this scope.
+    const FakeSteadyClock clock;
+    constexpr auto timeout{30s};
+    const auto now{MockableSteadyClock::now()};
+
+    {
+        // Nothing to disconnect for yet.
+        auto idle{std::make_shared<Client>()};
+        BOOST_CHECK(!idle->ShouldDisconnect(now, timeout, /*disconnect_all=*/false));
+        // A shutdown waits for a connection that is still busy, and it starts busy.
+        BOOST_CHECK(!idle->ShouldDisconnect(now, timeout, /*disconnect_all=*/true));
+        // Past -rpcservertimeout, which a timeout of 0 disables.
+        BOOST_CHECK( idle->ShouldDisconnect(now + timeout + 1s, timeout, /*disconnect_all=*/false));
+        // Timeout was disabled by user.
+        BOOST_CHECK(!idle->ShouldDisconnect(now + timeout + 1s, /*rpcservertimeout=*/0s, /*disconnect_all=*/false));
+    }
+
+    {
+        struct SlowSocket : ZeroSock {
+            ssize_t Send(const void*, size_t len, int) const override {
+                return CeilDiv(len, 2U); // Only let through half per call
+            }
+        private:
+            SlowSocket& operator=(Sock&&) override {
+                assert(false && "Move of Sock into SlowSocket not allowed.");
+                return *this;
+            }
+        };
+
+        // A request handed to a worker holds the idle timeout off until the reply is sent.
+        auto busy_slow{std::make_shared<Client>(std::make_unique<SlowSocket>())};
+        busy_slow->MutateRecvBuffer().append("GET / HTTP/1.0\n\n");
+        {
+            std::unique_ptr request{HTTPRemoteClient::TryReadRequest(busy_slow)};
+            BOOST_REQUIRE(request);
+            // Avoid disconnecting even if we are past the timeout, a worker is busy.
+            BOOST_CHECK(!busy_slow->ShouldDisconnect(now + timeout + 1s, timeout, /*disconnect_all=*/false));
+            BOOST_CHECK(!busy_slow->ShouldDisconnect(now + timeout + 1s, timeout, /*disconnect_all=*/true));
+            // Worker becomes finished with the request.
+            request->WriteReply(HTTP_OK);
+        }
+        // Don't disconnect here as WriteReply() was unable to complete the
+        // optimistic send of the full response due to the SlowSocket.
+        BOOST_CHECK(!busy_slow->ShouldDisconnect(now + timeout - 1s, timeout, /*disconnect_all=*/false));
+        // Disconnect anyway if we are past the timeout.
+        BOOST_CHECK( busy_slow->ShouldDisconnect(now + timeout + 1s, timeout, /*disconnect_all=*/false));
+
+        // Finish sending response.
+        while (busy_slow->ReadyToSend()) {
+            busy_slow->MaybeSendBytesFromBuffer();
+        }
+        // Now we are done sending we are ready to disconnect despite being below the timeout.
+        BOOST_CHECK( busy_slow->ShouldDisconnect(now + timeout - 1s, timeout, /*disconnect_all=*/false));
+    }
+
+    {
+        // Allow disconnecting directly after WriteReply() when it is able to
+        // complete the optimistic send of the full response due to
+        // ZeroSock::Send() claiming its able to send everything.
+        auto busy_fast{std::make_shared<Client>(std::make_unique<ZeroSock>())};
+        busy_fast->MutateRecvBuffer().append("GET / HTTP/1.0\n\n");
+        {
+            std::unique_ptr request{HTTPRemoteClient::TryReadRequest(busy_fast)};
+            BOOST_REQUIRE(request);
+            // Worker becomes finished with the request.
+            request->WriteReply(HTTP_OK);
+        }
+        BOOST_CHECK( busy_fast->ShouldDisconnect(now + timeout - 1s, timeout, /*disconnect_all=*/false));
+
+        // TODO: No need to log idle timeout if client already has m_disconnect = true
+        DebugLogHelper require_idle_message{"HTTP client idle timeout"};
+        BOOST_CHECK( busy_fast->ShouldDisconnect(now + timeout + 1s, timeout, /*disconnect_all=*/false));
+    }
+
+    {
+        // A keep-alive HTTP 1.1 client whose reply is out is neither flagged
+        // nor idle, so the shutdown branch is the only thing that can release it.
+        auto keepalive{std::make_shared<Client>(std::make_unique<ZeroSock>())};
+        keepalive->MutateRecvBuffer().append("GET / HTTP/1.1\nHost: 127.0.0.1\n\n");
+        {
+            std::unique_ptr request{HTTPRemoteClient::TryReadRequest(keepalive)};
+            BOOST_REQUIRE(request);
+            request->WriteReply(HTTP_OK);
+        }
+        BOOST_CHECK(!keepalive->ShouldDisconnect(now, timeout + 1s, /*disconnect_all=*/false));
+        BOOST_CHECK( keepalive->ShouldDisconnect(now, timeout + 1s, /*disconnect_all=*/true));
+    }
+
+    {
+        // A malformed request flags the client, and that outranks the rest.
+        auto bad{std::make_shared<Client>()};
+        bad->MutateRecvBuffer().append("GET / HTTP/1.0\nInvalid header with no colon\n\n");
+        BOOST_CHECK(!HTTPRemoteClient::TryReadRequest(bad));
+        BOOST_CHECK(bad->ShouldDisconnect(now, /*rpcservertimeout=*/0s, /*disconnect_all=*/false));
     }
 }
 

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -856,8 +856,10 @@ BOOST_AUTO_TEST_CASE(http_should_disconnect_tests)
         }
         BOOST_CHECK( busy_fast->ShouldDisconnect(now + timeout - 1s, timeout, /*disconnect_all=*/false));
 
-        // TODO: No need to log idle timeout if client already has m_disconnect = true
-        DebugLogHelper require_idle_message{"HTTP client idle timeout"};
+        DebugLogHelper ban_idle_message{"HTTP client idle timeout", [](const std::string* s) {
+            if (s) BOOST_ERROR("Should not get idle message when m_disconnect is already set.");
+            return false;
+        }};
         BOOST_CHECK( busy_fast->ShouldDisconnect(now + timeout + 1s, timeout, /*disconnect_all=*/false));
     }
 

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -822,6 +822,9 @@ BOOST_AUTO_TEST_CASE(http_server_socket_tests)
     // Create a mock client with pre-loaded request data and add it to the local CreateSock queue.
     // Keep a handle for the mock client's send and receive pipes so we can examine
     // the data it "receives".
+    // No keep-alive, so the server closes once the reply is flushed, and says so.
+    DebugLogHelper find_close{"Done sending to client without keep-alive"};
+
     std::shared_ptr<DynSock::Pipes> mock_client_socket_pipes{ConnectClient(std::as_bytes(std::span(full_request)))};
 
     // Wait up to a minute to find and connect the client in the I/O loop


### PR DESCRIPTION
### Issues

#35182 had 1 case where we flag a client for disconnect where we do not log the reason.

#35829 introduced the somewhat poorly named non-`const` `HTTPRemoteClient::MaybeDisconnect()`. It also lacks testing.

The control-flow in `MaybeDisconnect()/ShouldDisconnect()` is somewhat complex. https://github.com/bitcoin/bitcoin/pull/35829#discussion_r3846342291

### Commits solving these issues in same order

* http: Add log message for remaining case where we set `HTTPRemoteClient::m_disconnect = true`
* refactor: Rename `MaybeDisconnect()` to `ShouldDisconnect()` and make it `const`
* refactor: Enable mocking the time around `ShouldDisconnect()`
* test: Add test for behavior of `ShouldDisconnect()`
* refactor: Flatten control flow in `ShouldDisconnect()`