### PR TITLE
PSBT: Make input/output `Merge()` methods return void

### DIFF
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -47,14 +47,10 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
     }
 
     for (unsigned int i = 0; i < inputs.size(); ++i) {
-        if (!inputs[i].Merge(psbt.inputs[i])) {
-            return false;
-        }
+        inputs[i].Merge(psbt.inputs[i]);
     }
     for (unsigned int i = 0; i < outputs.size(); ++i) {
-        if (!outputs[i].Merge(psbt.outputs[i])) {
-            return false;
-        }
+        outputs[i].Merge(psbt.outputs[i]);
     }
     MergeGlobalXPubs(psbt);
     if (fallback_locktime == std::nullopt && psbt.fallback_locktime != std::nullopt) fallback_locktime = psbt.fallback_locktime;
@@ -421,7 +417,7 @@ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
     }
 }
 
-bool PSBTInput::Merge(const PSBTInput& input)
+void PSBTInput::Merge(const PSBTInput& input)
 {
     if (!non_witness_utxo && input.non_witness_utxo) non_witness_utxo = input.non_witness_utxo;
     if (witness_utxo.IsNull() && !input.witness_utxo.IsNull()) {
@@ -467,8 +463,6 @@ bool PSBTInput::Merge(const PSBTInput& input)
     if (sequence == std::nullopt && input.sequence != std::nullopt) sequence = input.sequence;
     if (time_locktime == std::nullopt && input.time_locktime != std::nullopt) time_locktime = input.time_locktime;
     if (height_locktime == std::nullopt && input.height_locktime != std::nullopt) height_locktime = input.height_locktime;
-
-    return true;
 }
 
 bool PSBTInput::HasSignatures() const
@@ -535,7 +529,7 @@ void PSBTOutput::FromSignatureData(const SignatureData& sigdata)
     m_musig2_participants.insert(sigdata.musig2_pubkeys.begin(), sigdata.musig2_pubkeys.end());
 }
 
-bool PSBTOutput::Merge(const PSBTOutput& output)
+void PSBTOutput::Merge(const PSBTOutput& output)
 {
     hd_keypaths.insert(output.hd_keypaths.begin(), output.hd_keypaths.end());
     m_proprietary.insert(output.m_proprietary.begin(), output.m_proprietary.end());
@@ -547,8 +541,6 @@ bool PSBTOutput::Merge(const PSBTOutput& output)
     if (m_tap_internal_key.IsNull() && !output.m_tap_internal_key.IsNull()) m_tap_internal_key = output.m_tap_internal_key;
     if (m_tap_tree.empty() && !output.m_tap_tree.empty()) m_tap_tree = output.m_tap_tree;
     m_musig2_participants.insert(output.m_musig2_participants.begin(), output.m_musig2_participants.end());
-
-    return true;
 }
 
 bool PSBTInputSigned(const PSBTInput& input)

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -324,7 +324,7 @@ public:
 
     void FillSignatureData(SignatureData& sigdata) const;
     void FromSignatureData(const SignatureData& sigdata);
-    [[nodiscard]] bool Merge(const PSBTInput& input);
+    void Merge(const PSBTInput& input);
     uint32_t GetVersion() const { return m_psbt_version; }
     COutPoint GetOutPoint() const;
     /**
@@ -958,7 +958,7 @@ public:
 
     void FillSignatureData(SignatureData& sigdata) const;
     void FromSignatureData(const SignatureData& sigdata);
-    [[nodiscard]] bool Merge(const PSBTOutput& output);
+    void Merge(const PSBTOutput& output);
     uint32_t GetVersion() const { return m_psbt_version; }
 
     explicit PSBTOutput(uint32_t psbt_version, CAmount amount, const CScript& script)


### PR DESCRIPTION
PSBT input/output `Merge()` methods always return `true` unconditionally and have no failure paths. As a result, the return value checks in `PartiallySignedTransaction::Merge()` can never fail and are dead code.
This makes the `bool` return type and `[[nodiscard]]` misleading.

This PR changes both methods to return `void` and remove the return value checks. If at some point in the future the failure logic is needed, it can be introduced again. For now using `void` makes the current behavior easier to understand.