### PR TITLE
net: require a dedicated bind for automatic Tor

### DIFF
--- a/doc/release-notes-36170.md
+++ b/doc/release-notes-36170.md
@@ -1,0 +1,9 @@
+P2P and network changes
+-----------------------
+
+Nodes configured with `-bind` but no dedicated `-bind=<addr>=onion` now refuse
+to start when `-listenonion` is enabled, which is the default when listening.
+A shared bind cannot distinguish Tor-forwarded connections from direct connections,
+which can grant Tor peers unintended IP-based whitelist permissions.
+Users should add a dedicated onion bind to accept incoming Tor connections, or set
+`-listenonion=0` to disable automatic onion service creation.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2265,17 +2265,19 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }
 
-    CService onion_service_target;
-    if (!connOptions.onion_binds.empty()) {
-        onion_service_target = connOptions.onion_binds.front();
-    } else if (!connOptions.vBinds.empty()) {
-        onion_service_target = connOptions.vBinds.front();
-    } else {
-        onion_service_target = DefaultOnionServiceTarget(default_bind_port_onion);
-        connOptions.onion_binds.push_back(onion_service_target);
+    // Without any -bind the onion service gets its own default target
+    if (connOptions.onion_binds.empty() && connOptions.vBinds.empty()) {
+        connOptions.onion_binds.push_back(DefaultOnionServiceTarget(default_bind_port_onion));
     }
 
     if (listenonion) {
+        if (connOptions.onion_binds.empty()) {
+            return InitError(_("The Tor onion service cannot share a -bind address because incoming "
+                               "Tor connections cannot be distinguished from regular connections. "
+                               "Use -bind=<addr>=onion to configure a dedicated onion bind, or "
+                               "-listenonion=0 to disable the onion service."));
+        }
+        const CService& onion_service_target{connOptions.onion_binds[0]};
         if (connOptions.onion_binds.size() > 1) {
             InitWarning(strprintf(_("More than one onion bind address is provided. Using %s "
                                     "for the automatically created Tor onion service."),

--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -8,6 +8,7 @@ it binds to the expected ports, and verify that duplicate or conflicting
 -bind/-whitebind configurations are rejected with a descriptive error.
 """
 
+from contextlib import suppress
 from itertools import combinations_with_replacement
 from test_framework.netutil import (
     addr_to_hex,
@@ -16,7 +17,7 @@ from test_framework.netutil import (
 from test_framework.test_framework import (
     BitcoinTestFramework,
 )
-from test_framework.test_node import ErrorMatch
+from test_framework.test_node import ErrorMatch, FailedToStartError
 from test_framework.util import (
     assert_equal,
     p2p_port,
@@ -94,6 +95,16 @@ class BindExtraTest(BitcoinTestFramework):
             assert_equal(binds, set(expected_services))
 
         self.stop_node(0)
+
+        self.log.info("Test -listenonion with a normal bind and no dedicated onion bind")
+        self.stop_node(2)
+        with suppress(FailedToStartError):
+            self.start_node(2, extra_args=self.expected[2][0] + ["-listenonion=1"])
+            self.nodes[2].stop()
+        self.nodes[2].wait_until_stopped(expected_ret_code=0, expected_stderr="")  # TODO: Reject shared Tor binds
+
+        self.log.info("Test -bind with dedicated onion bind starts when -listenonion=1")
+        self.restart_node(1, extra_args=self.expected[1][0] + ["-listenonion=1"])
 
         addr = "127.0.0.1:11012"
         for opt1, opt2 in combinations_with_replacement([f"-bind={addr}", f"-bind={addr}=onion", f"-whitebind=noban@{addr}"], 2):

--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -8,8 +8,8 @@ it binds to the expected ports, and verify that duplicate or conflicting
 -bind/-whitebind configurations are rejected with a descriptive error.
 """
 
-from contextlib import suppress
 from itertools import combinations_with_replacement
+import re
 from test_framework.netutil import (
     addr_to_hex,
     get_bind_addrs,
@@ -20,6 +20,7 @@ from test_framework.test_framework import (
 from test_framework.test_node import ErrorMatch, FailedToStartError
 from test_framework.util import (
     assert_equal,
+    assert_raises,
     p2p_port,
     rpc_port,
 )
@@ -98,10 +99,8 @@ class BindExtraTest(BitcoinTestFramework):
 
         self.log.info("Test -listenonion with a normal bind and no dedicated onion bind")
         self.stop_node(2)
-        with suppress(FailedToStartError):
-            self.start_node(2, extra_args=self.expected[2][0] + ["-listenonion=1"])
-            self.nodes[2].stop()
-        self.nodes[2].wait_until_stopped(expected_ret_code=0, expected_stderr="")  # TODO: Reject shared Tor binds
+        assert_raises(FailedToStartError, self.start_node, 2, extra_args=self.expected[2][0] + ["-listenonion=1"])
+        self.nodes[2].wait_until_stopped(expected_ret_code=1, expected_stderr=re.compile("Tor onion service cannot share"))
 
         self.log.info("Test -bind with dedicated onion bind starts when -listenonion=1")
         self.restart_node(1, extra_args=self.expected[1][0] + ["-listenonion=1"])

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -46,7 +46,10 @@ import tempfile
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    tor_port,
+)
 from test_framework.netutil import test_ipv6_local, test_unix_socket
 
 # Networks returned by RPC getpeerinfo.
@@ -438,7 +441,7 @@ class ProxyTest(BitcoinTestFramework):
         self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
         self.log.info("Test passing -onlynet=onion without -proxy or -onion but with -listenonion=1 is ok")
-        self.start_node(1, extra_args=["-onlynet=onion", "-listenonion=1"])
+        self.start_node(1, extra_args=["-onlynet=onion", "-listenonion=1", f"-bind=127.0.0.1:{tor_port(1)}=onion"])
         self.stop_node(1)
 
         self.log.info("Test passing unknown network to -onlynet raises expected init error")

--- a/test/functional/feature_torcontrol.py
+++ b/test/functional/feature_torcontrol.py
@@ -11,6 +11,7 @@ from test_framework.util import (
     assert_equal,
     ensure_for,
     p2p_port,
+    tor_port,
 )
 
 
@@ -118,6 +119,7 @@ class TorControlTest(BitcoinTestFramework):
             f"-torcontrol=127.0.0.1:{mock_tor.port}",
             "-listenonion=1",
             "-debug=tor",
+            f"-bind=127.0.0.1:{tor_port(0)}=onion",
         ])
 
         # Wait for connection and PROTOCOLINFO command

--- a/test/functional/p2p_private_broadcast.py
+++ b/test/functional/p2p_private_broadcast.py
@@ -420,6 +420,7 @@ class P2PPrivateBroadcast(BitcoinTestFramework):
             # the RPC should throw.
             "-torcontrol=127.0.0.1:1",
             "-listenonion",
+            f"-bind=127.0.0.1:{tor_port(0)}=onion",
         ])
         assert_raises_rpc_error(-1, "none of the Tor or I2P networks is reachable",
                                 tx_originator.sendrawtransaction, hexstring=txs[0]["hex"], maxfeerate=0.1)


### PR DESCRIPTION
**Problem:** When the automatic onion service has no dedicated `-bind=<addr>=onion`, Tor forwards incoming connections to the first normal P2P bind. The node cannot distinguish these connections from direct connections, so network classification is incorrect and Tor peers may inherit permissions granted to the Tor daemon's IP address.

**Fix:** Refuse startup when `-listenonion` is enabled and an explicit `-bind` configuration lacks a dedicated onion bind, following [the recommendation in #34892](https://github.com/bitcoin/bitcoin/pull/34892#issuecomment-5541662236). Users should add `-bind=<addr>=onion` or set `-listenonion=0`.

Because `-listenonion` is enabled by default when listening, existing configurations with only a normal `-bind` must also be updated. Nodes without explicit `-bind` options retain the default dedicated onion listener.