### PR TITLE
blockstorage: Defer error notifications to callers

### DIFF
--- a/src/bench/readwriteblock.cpp
+++ b/src/bench/readwriteblock.cpp
@@ -34,8 +34,9 @@ static void WriteBlockBench(benchmark::Bench& bench)
     const CBlock block{CreateTestBlock()};
     bench.run([&] {
         LOCK(::cs_main);
-        const auto pos{blockman.WriteBlock(block, 413'567)};
-        assert(!pos.IsNull());
+        const auto outcome{blockman.WriteBlock(block, 413'567)};
+        assert(outcome.notifications.empty());
+        assert(!outcome.value.IsNull());
     });
 }
 
@@ -45,7 +46,9 @@ static void ReadBlockBench(benchmark::Bench& bench)
     auto& blockman{testing_setup->m_node.chainman->m_blockman};
     const auto& test_block{CreateTestBlock()};
     const auto& expected_hash{test_block.GetHash()};
-    const auto& pos{WITH_LOCK(::cs_main, return blockman.WriteBlock(test_block, 413'567))};
+    const auto outcome{WITH_LOCK(::cs_main, return blockman.WriteBlock(test_block, 413'567))};
+    assert(outcome.notifications.empty());
+    const auto& pos{outcome.value};
     bench.run([&] {
         CBlock block;
         const auto success{blockman.ReadBlock(block, pos, expected_hash)};
@@ -57,7 +60,9 @@ static void ReadRawBlockBench(benchmark::Bench& bench)
 {
     const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(ChainType::MAIN)};
     auto& blockman{testing_setup->m_node.chainman->m_blockman};
-    const auto pos{WITH_LOCK(::cs_main, return blockman.WriteBlock(CreateTestBlock(), 413'567))};
+    const auto outcome{WITH_LOCK(::cs_main, return blockman.WriteBlock(CreateTestBlock(), 413'567))};
+    assert(outcome.notifications.empty());
+    const auto& pos{outcome.value};
     bench.run([&] {
         const auto res{blockman.ReadRawBlock(pos)};
         assert(res);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1208,7 +1208,6 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         BlockManager::Options blockman_opts_dummy{
             .chainparams = chainman_opts_dummy.chainparams,
             .blocks_dir = args.GetBlocksDirPath(),
-            .notifications = chainman_opts_dummy.notifications,
             .block_tree_db_params = DBParams{
                 .path = args.GetDataDirNet() / "blocks" / "index",
                 .cache_bytes = 0,
@@ -1413,7 +1412,6 @@ static ChainstateLoadResult InitAndLoadChainstate(
     BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = args.GetBlocksDirPath(),
-        .notifications = chainman_opts.notifications,
         .block_tree_db_params = DBParams{
             .path = args.GetDataDirNet() / "blocks" / "index",
             .cache_bytes = cache_sizes.block_tree_db,

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -468,7 +468,6 @@ struct ChainstateManagerOptions {
           m_blockman_options{node::BlockManager::Options{
               .chainparams = *context->m_chainparams,
               .blocks_dir = blocks_dir,
-              .notifications = *context->m_notifications,
               .block_tree_db_params = DBParams{
                   .path = data_dir / "blocks" / "index",
                   .cache_bytes = kernel::CacheSizes{DEFAULT_KERNEL_CACHE}.block_tree_db,

--- a/src/kernel/blockmanager_opts.h
+++ b/src/kernel/blockmanager_opts.h
@@ -6,7 +6,6 @@
 #define BITCOIN_KERNEL_BLOCKMANAGER_OPTS_H
 
 #include <dbwrapper.h>
-#include <kernel/notifications_interface.h>
 #include <util/fs.h>
 
 #include <cstdint>
@@ -27,7 +26,6 @@ struct BlockManagerOpts {
     uint64_t prune_target{0};
     bool fast_prune{false};
     const fs::path blocks_dir;
-    Notifications& notifications;
     DBParams block_tree_db_params;
 };
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -7,6 +7,7 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <consensus/params.h>
+#include <consensus/validation.h>
 #include <crypto/hex_base.h>
 #include <dbwrapper.h>
 #include <flatfile.h>
@@ -170,6 +171,17 @@ std::string CBlockFileInfo::ToString() const
 } // namespace kernel
 
 namespace node {
+namespace {
+
+void AppendNotifications(BlockStorageErrors& destination, BlockStorageErrors&& source)
+{
+    destination.reserve(destination.size() + source.size());
+    for (auto& notification : source) {
+        destination.push_back(std::move(notification));
+    }
+}
+
+} // namespace
 
 bool CBlockIndexWorkComparator::operator()(const CBlockIndex* pa, const CBlockIndex* pb) const
 {
@@ -437,18 +449,19 @@ CBlockIndex* BlockManager::InsertBlockIndex(const uint256& hash)
     return pindex;
 }
 
-bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
+BlockStorageOutcome<bool> BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
 {
+    BlockStorageOutcome<bool> outcome{false, {}};
     if (!m_block_tree_db->LoadBlockIndexGuts(
             GetConsensus(), [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }, m_interrupt)) {
-        return false;
+        return outcome;
     }
 
     if (snapshot_blockhash) {
         const std::optional<AssumeutxoData> maybe_au_data = GetParams().AssumeutxoForBlockhash(*snapshot_blockhash);
         if (!maybe_au_data) {
-            m_opts.notifications.fatalError(strprintf(_("Assumeutxo data not found for the given blockhash '%s'."), snapshot_blockhash->ToString()));
-            return false;
+            outcome.notifications.push_back({BlockStorageErrorType::FATAL, strprintf(_("Assumeutxo data not found for the given blockhash '%s'."), snapshot_blockhash->ToString())});
+            return outcome;
         }
         const AssumeutxoData& au_data = *Assert(maybe_au_data);
         m_snapshot_height = au_data.height;
@@ -475,10 +488,10 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
 
     CBlockIndex* previous_index{nullptr};
     for (CBlockIndex* pindex : vSortedByHeight) {
-        if (m_interrupt) return false;
+        if (m_interrupt) return outcome;
         if (previous_index && pindex->nHeight > previous_index->nHeight + 1) {
             LogError("%s: block index is non-contiguous, index of height %d missing\n", __func__, previous_index->nHeight + 1);
-            return false;
+            return outcome;
         }
         previous_index = pindex;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
@@ -523,7 +536,8 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
         }
     }
 
-    return true;
+    outcome.value = true;
+    return outcome;
 }
 
 void BlockManager::WriteBlockIndexDB()
@@ -545,12 +559,11 @@ void BlockManager::WriteBlockIndexDB()
     m_block_tree_db->WriteBatchSync(vFiles, max_blockfile, vBlocks);
 }
 
-bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
+BlockStorageOutcome<bool> BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
 {
     AssertLockHeld(::cs_main);
-    if (!LoadBlockIndex(snapshot_blockhash)) {
-        return false;
-    }
+    auto outcome{LoadBlockIndex(snapshot_blockhash)};
+    if (!outcome.value) return outcome;
     int max_blockfile_num{0};
 
     // Load block file info
@@ -581,7 +594,8 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++) {
         FlatFilePos pos(*it, 0);
         if (OpenBlockFile(pos, /*fReadOnly=*/true).IsNull()) {
-            return false;
+            outcome.value = false;
+            return outcome;
         }
     }
 
@@ -604,7 +618,7 @@ bool BlockManager::LoadBlockIndexDB(const std::optional<uint256>& snapshot_block
     m_block_tree_db->ReadReindexing(fReindexing);
     if (fReindexing) m_blockfiles_indexed = false;
 
-    return true;
+    return outcome;
 }
 
 void BlockManager::ScanAndUnlinkAlreadyPrunedFiles()
@@ -747,43 +761,44 @@ bool BlockManager::ReadBlockUndo(CBlockUndo& blockundo, const CBlockIndex& index
     return true;
 }
 
-bool BlockManager::FlushUndoFile(int block_file, bool finalize)
+BlockStorageOutcome<bool> BlockManager::FlushUndoFile(int block_file, bool finalize)
 {
+    BlockStorageOutcome<bool> outcome{true, {}};
     FlatFilePos undo_pos_old(block_file, m_blockfile_info[block_file].nUndoSize);
     if (!m_undo_file_seq.Flush(undo_pos_old, finalize)) {
-        m_opts.notifications.flushError(_("Flushing undo file to disk failed. This is likely the result of an I/O error."));
-        return false;
+        outcome.value = false;
+        outcome.notifications.push_back({BlockStorageErrorType::FLUSH, _("Flushing undo file to disk failed. This is likely the result of an I/O error.")});
     }
-    return true;
+    return outcome;
 }
 
-bool BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo)
+BlockStorageOutcome<bool> BlockManager::FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo)
 {
     AssertLockHeld(::cs_main);
-    bool success = true;
+    BlockStorageOutcome<bool> outcome{true, {}};
 
     if (m_blockfile_info.size() < 1) {
         // Return if we haven't loaded any blockfiles yet. This happens during
         // chainstate init, when we call ChainstateManager::MaybeRebalanceCaches() (which
         // then calls FlushStateToDisk()), resulting in a call to this function before we
         // have populated `m_blockfile_info` via LoadBlockIndexDB().
-        return true;
+        return outcome;
     }
     assert(static_cast<int>(m_blockfile_info.size()) > blockfile_num);
 
     FlatFilePos block_pos_old(blockfile_num, m_blockfile_info[blockfile_num].nSize);
     if (!m_block_file_seq.Flush(block_pos_old, fFinalize)) {
-        m_opts.notifications.flushError(_("Flushing block file to disk failed. This is likely the result of an I/O error."));
-        success = false;
+        outcome.value = false;
+        outcome.notifications.push_back({BlockStorageErrorType::FLUSH, _("Flushing block file to disk failed. This is likely the result of an I/O error.")});
     }
     // we do not always flush the undo file, as the chain tip may be lagging behind the incoming blocks,
     // e.g. during IBD or a sync after a node going offline
     if (!fFinalize || finalize_undo) {
-        if (!FlushUndoFile(blockfile_num, finalize_undo)) {
-            success = false;
-        }
+        auto undo_outcome{FlushUndoFile(blockfile_num, finalize_undo)};
+        if (!undo_outcome.value) outcome.value = false;
+        AppendNotifications(outcome.notifications, std::move(undo_outcome.notifications));
     }
-    return success;
+    return outcome;
 }
 
 BlockfileType BlockManager::BlockfileTypeForHeight(int height)
@@ -794,7 +809,7 @@ BlockfileType BlockManager::BlockfileTypeForHeight(int height)
     return (height >= *m_snapshot_height) ? BlockfileType::ASSUMED : BlockfileType::NORMAL;
 }
 
-bool BlockManager::FlushChainstateBlockFile(int tip_height)
+BlockStorageOutcome<bool> BlockManager::FlushChainstateBlockFile(int tip_height)
 {
     AssertLockHeld(::cs_main);
     auto& cursor = m_blockfile_cursors[BlockfileTypeForHeight(tip_height)];
@@ -805,7 +820,7 @@ bool BlockManager::FlushChainstateBlockFile(int tip_height)
         return FlushBlockFile(cursor->file_num, /*fFinalize=*/false, /*finalize_undo=*/false);
     }
     // No need to log warnings in this case.
-    return true;
+    return {true, {}};
 }
 
 uint64_t BlockManager::CalculateCurrentUsage()
@@ -847,7 +862,7 @@ fs::path BlockManager::GetBlockPosFilename(const FlatFilePos& pos) const
     return m_block_file_seq.FileName(pos);
 }
 
-FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime)
+BlockStorageOutcome<FlatFilePos> BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime)
 {
     AssertLockHeld(::cs_main);
     const BlockfileType chain_type = BlockfileTypeForHeight(nHeight);
@@ -895,9 +910,8 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
             m_blockfile_info.resize(nFile + 1);
         }
     }
-    FlatFilePos pos;
-    pos.nFile = nFile;
-    pos.nPos = m_blockfile_info[nFile].nSize;
+    BlockStorageOutcome<FlatFilePos> outcome{{nFile, m_blockfile_info[nFile].nSize}, {}};
+    FlatFilePos& pos{outcome.value};
 
     if (nFile != last_blockfile) {
         LogDebug(BCLog::BLOCKSTORAGE, "Leaving block file %i: %s (onto %i) (height %i)\n",
@@ -910,11 +924,13 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
         // data may be inconsistent after a crash if the flush is called during
         // a reindex. A flush error might also leave some of the data files
         // untrimmed.
-        if (!FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo)) {
+        auto flush_outcome{FlushBlockFile(last_blockfile, /*fFinalize=*/true, finalize_undo)};
+        if (!flush_outcome.value) {
             LogWarning(
                           "Failed to flush previous block file %05i (finalize=1, finalize_undo=%i) before opening new block file %05i\n",
                           last_blockfile, finalize_undo, nFile);
         }
+        outcome.notifications = std::move(flush_outcome.notifications);
         // No undo data yet in the new file, so reset our undo-height tracking.
         m_blockfile_cursors[chain_type] = BlockfileCursor{nFile};
     }
@@ -925,15 +941,16 @@ FlatFilePos BlockManager::FindNextBlockPos(unsigned int nAddSize, unsigned int n
     bool out_of_space;
     size_t bytes_allocated = m_block_file_seq.Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        m_opts.notifications.fatalError(_("Disk space is too low!"));
-        return {};
+        outcome.value = {};
+        outcome.notifications.push_back({BlockStorageErrorType::FATAL, _("Disk space is too low!")});
+        return outcome;
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
     }
 
     m_dirty_fileinfo.insert(nFile);
-    return pos;
+    return outcome;
 }
 
 void BlockManager::UpdateBlockInfo(const CBlock& block, unsigned int nHeight, const FlatFilePos& pos)
@@ -957,9 +974,10 @@ void BlockManager::UpdateBlockInfo(const CBlock& block, unsigned int nHeight, co
     m_dirty_fileinfo.insert(nFile);
 }
 
-bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize)
+BlockStorageOutcome<bool> BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize)
 {
     AssertLockHeld(::cs_main);
+    BlockStorageOutcome<bool> outcome{true, {}};
     pos.nFile = nFile;
 
     pos.nPos = m_blockfile_info[nFile].nUndoSize;
@@ -969,18 +987,22 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
     bool out_of_space;
     size_t bytes_allocated = m_undo_file_seq.Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        return FatalError(m_opts.notifications, state, _("Disk space is too low!"));
+        const bilingual_str message = _("Disk space is too low!");
+        outcome.value = state.Error(message.original);
+        outcome.notifications.push_back({BlockStorageErrorType::FATAL, message});
+        return outcome;
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
     }
 
-    return true;
+    return outcome;
 }
 
-bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+BlockStorageOutcome<bool> BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
 {
     AssertLockHeld(::cs_main);
+    BlockStorageOutcome<bool> outcome{true, {}};
     const BlockfileType type = BlockfileTypeForHeight(block.nHeight);
     auto& cursor = *Assert(m_blockfile_cursors[type]);
 
@@ -988,16 +1010,20 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
     if (block.GetUndoPos().IsNull()) {
         FlatFilePos pos;
         const auto blockundo_size{static_cast<uint32_t>(GetSerializeSize(blockundo))};
-        if (!FindUndoPos(state, block.nFile, pos, blockundo_size + UNDO_DATA_DISK_OVERHEAD)) {
+        outcome = FindUndoPos(state, block.nFile, pos, blockundo_size + UNDO_DATA_DISK_OVERHEAD);
+        if (!outcome.value) {
             LogError("FindUndoPos failed for %s while writing block undo", pos.ToString());
-            return false;
+            return outcome;
         }
 
         // Open history file to append
         AutoFile file{OpenUndoFile(pos)};
         if (file.IsNull()) {
             LogError("OpenUndoFile failed for %s while writing block undo", pos.ToString());
-            return FatalError(m_opts.notifications, state, _("Failed to write undo data."));
+            const bilingual_str message = _("Failed to write undo data.");
+            outcome.value = state.Error(message.original);
+            outcome.notifications.push_back({BlockStorageErrorType::FATAL, message});
+            return outcome;
         }
         {
             BufferedWriter fileout{file};
@@ -1018,7 +1044,10 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         // Make sure that the file is closed before we call `FlushUndoFile`.
         if (file.fclose() != 0) {
             LogError("Failed to close block undo file %s: %s", pos.ToString(), SysErrorString(errno));
-            return FatalError(m_opts.notifications, state, _("Failed to close block undo file."));
+            const bilingual_str message = _("Failed to close block undo file.");
+            outcome.value = state.Error(message.original);
+            outcome.notifications.push_back({BlockStorageErrorType::FATAL, message});
+            return outcome;
         }
 
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)
@@ -1032,9 +1061,11 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
             // the caller would assume the undo data not to be written, when in
             // fact it is. Note though, that a failed flush might leave the data
             // file untrimmed.
-            if (!FlushUndoFile(pos.nFile, true)) {
+            auto flush_outcome{FlushUndoFile(pos.nFile, /*finalize=*/true)};
+            if (!flush_outcome.value) {
                 LogWarning("Failed to flush undo file %05i\n", pos.nFile);
             }
+            AppendNotifications(outcome.notifications, std::move(flush_outcome.notifications));
         } else if (pos.nFile == cursor.file_num && block.nHeight > cursor.undo_height) {
             cursor.undo_height = block.nHeight;
         }
@@ -1044,7 +1075,7 @@ bool BlockManager::WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationSt
         m_dirty_blockindex.insert(&block);
     }
 
-    return true;
+    return outcome;
 }
 
 bool BlockManager::ReadBlock(CBlock& block, const FlatFilePos& pos, const std::optional<uint256>& expected_hash) const
@@ -1145,20 +1176,22 @@ BlockManager::ReadRawBlockResult BlockManager::ReadRawBlock(const FlatFilePos& p
     }
 }
 
-FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
+BlockStorageOutcome<FlatFilePos> BlockManager::WriteBlock(const CBlock& block, int nHeight)
 {
     AssertLockHeld(::cs_main);
     const unsigned int block_size{static_cast<unsigned int>(GetSerializeSize(TX_WITH_WITNESS(block)))};
-    FlatFilePos pos{FindNextBlockPos(block_size + STORAGE_HEADER_BYTES, nHeight, block.GetBlockTime())};
+    auto outcome{FindNextBlockPos(block_size + STORAGE_HEADER_BYTES, nHeight, block.GetBlockTime())};
+    FlatFilePos& pos{outcome.value};
     if (pos.IsNull()) {
         LogError("FindNextBlockPos failed for %s while writing block", pos.ToString());
-        return FlatFilePos();
+        return outcome;
     }
     AutoFile file{OpenBlockFile(pos, /*fReadOnly=*/false)};
     if (file.IsNull()) {
         LogError("OpenBlockFile failed for %s while writing block", pos.ToString());
-        m_opts.notifications.fatalError(_("Failed to write block."));
-        return FlatFilePos();
+        outcome.value = {};
+        outcome.notifications.push_back({BlockStorageErrorType::FATAL, _("Failed to write block.")});
+        return outcome;
     }
     {
         BufferedWriter fileout{file};
@@ -1172,11 +1205,12 @@ FlatFilePos BlockManager::WriteBlock(const CBlock& block, int nHeight)
 
     if (file.fclose() != 0) {
         LogError("Failed to close block file %s: %s", pos.ToString(), SysErrorString(errno));
-        m_opts.notifications.fatalError(_("Failed to close file when writing block."));
-        return FlatFilePos();
+        outcome.value = {};
+        outcome.notifications.push_back({BlockStorageErrorType::FATAL, _("Failed to close file when writing block.")});
+        return outcome;
     }
 
-    return pos;
+    return outcome;
 }
 
 static auto InitBlocksdirXorKey(const BlockManager::Options& opts)

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -25,6 +25,7 @@
 #include <util/fs.h>
 #include <util/hasher.h>
 #include <util/obfuscation.h>
+#include <util/translation.h>
 
 #include <algorithm>
 #include <array>
@@ -185,6 +186,29 @@ enum class ReadRawError {
     BadPartRange,
 };
 
+/** Errors produced by block storage instead of invoking application callbacks. */
+enum class BlockStorageErrorType {
+    FLUSH,
+    FATAL,
+};
+
+struct BlockStorageError {
+    BlockStorageErrorType type;
+    bilingual_str message;
+};
+
+using BlockStorageErrors = std::vector<BlockStorageError>;
+
+/**
+ * Result of a block storage operation. Notifications are returned in occurrence
+ * order and may accompany a successful value.
+ */
+template <typename T>
+struct BlockStorageOutcome {
+    T value;
+    BlockStorageErrors notifications;
+};
+
 /**
  * Maintains a tree of blocks (stored in `m_block_index`) which is consulted
  * to determine where the most-work tip is.
@@ -205,14 +229,14 @@ private:
      * per index entry (nStatus, nChainWork, nTimeMax, etc.) as well as peripheral
      * collections like m_dirty_blockindex.
      */
-    bool LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
+    BlockStorageOutcome<bool> LoadBlockIndex(const std::optional<uint256>& snapshot_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Return false if block file or undo file flushing fails. */
-    [[nodiscard]] bool FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] BlockStorageOutcome<bool> FlushBlockFile(int blockfile_num, bool fFinalize, bool finalize_undo) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Return false if undo file flushing fails. */
-    [[nodiscard]] bool FlushUndoFile(int block_file, bool finalize = false);
+    [[nodiscard]] BlockStorageOutcome<bool> FlushUndoFile(int block_file, bool finalize);
 
     /**
      * Helper function performing various preparations before a block can be saved to disk:
@@ -223,9 +247,9 @@ private:
      * The nAddSize argument passed to this function should include not just the size of the serialized CBlock, but also the size of
      * separator fields (STORAGE_HEADER_BYTES).
      */
-    [[nodiscard]] FlatFilePos FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    [[nodiscard]] bool FlushChainstateBlockFile(int tip_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    [[nodiscard]] bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] BlockStorageOutcome<FlatFilePos> FindNextBlockPos(unsigned int nAddSize, unsigned int nHeight, uint64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] BlockStorageOutcome<bool> FlushChainstateBlockFile(int tip_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    [[nodiscard]] BlockStorageOutcome<bool> FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     AutoFile OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false) const;
 
@@ -359,7 +383,7 @@ public:
     std::unique_ptr<BlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 
     void WriteBlockIndexDB() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
+    BlockStorageOutcome<bool> LoadBlockIndexDB(const std::optional<uint256>& snapshot_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
@@ -382,7 +406,7 @@ public:
     /** Get block file info entry for one block file */
     CBlockFileInfo* GetBlockFileInfo(size_t n) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    bool WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+    BlockStorageOutcome<bool> WriteBlockUndo(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Store block on disk and update block file statistics.
@@ -393,7 +417,7 @@ public:
      * @returns in case of success, the position to which the block was written to
      *          in case of an error, an empty FlatFilePos
      */
-    FlatFilePos WriteBlock(const CBlock& block, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    BlockStorageOutcome<FlatFilePos> WriteBlock(const CBlock& block, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Update blockfile info while processing a block during reindex. The block must be available on disk.
      *

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -7,7 +7,6 @@
 #include <clientversion.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
-#include <node/kernel_notifications.h>
 #include <script/solver.h>
 #include <primitives/block.h>
 #include <util/chaintype.h>
@@ -21,7 +20,6 @@
 using kernel::CBlockFileInfo;
 using node::STORAGE_HEADER_BYTES;
 using node::BlockManager;
-using node::KernelNotifications;
 using node::MAX_BLOCKFILE_SIZE;
 
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
@@ -30,11 +28,9 @@ BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
     const auto params {CreateChainParams(ArgsManager{}, ChainType::MAIN)};
-    KernelNotifications notifications{Assert(m_node.shutdown_request), m_node.exit_status, *Assert(m_node.warnings)};
     const BlockManager::Options blockman_opts{
         .chainparams = *params,
         .blocks_dir = m_args.GetBlocksDirPath(),
-        .notifications = notifications,
         .block_tree_db_params = DBParams{
             .path = m_args.GetDataDirNet() / "blocks" / "index",
             .cache_bytes = 0,
@@ -237,11 +233,9 @@ BOOST_FIXTURE_TEST_CASE(blockmanager_readblock_hash_mismatch, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
 {
-    KernelNotifications notifications{Assert(m_node.shutdown_request), m_node.exit_status, *Assert(m_node.warnings)};
     node::BlockManager::Options blockman_opts{
         .chainparams = Params(),
         .blocks_dir = m_args.GetBlocksDirPath(),
-        .notifications = notifications,
         .block_tree_db_params = DBParams{
             .path = m_args.GetDataDirNet() / "blocks" / "index",
             .cache_bytes = 0,

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -7,9 +7,11 @@
 #include <clientversion.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
-#include <script/solver.h>
 #include <primitives/block.h>
+#include <script/solver.h>
+#include <uint256.h>
 #include <util/chaintype.h>
+#include <util/fs.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -57,6 +59,68 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     const auto second_outcome{blockman.WriteBlock(params->GenesisBlock(), 1)};
     BOOST_CHECK(second_outcome.notifications.empty());
     BOOST_CHECK_EQUAL(second_outcome.value.nPos, STORAGE_HEADER_BYTES + ::GetSerializeSize(TX_WITH_WITNESS(params->GenesisBlock())) + STORAGE_HEADER_BYTES);
+}
+
+BOOST_AUTO_TEST_CASE(blockmanager_returns_flush_errors)
+{
+    const auto params{CreateChainParams(ArgsManager{}, ChainType::MAIN)};
+    const BlockManager::Options blockman_opts{
+        .chainparams = *params,
+        .blocks_dir = m_args.GetBlocksDirPath(),
+        .block_tree_db_params = DBParams{
+            .path = m_args.GetDataDirNet() / "blocks" / "index",
+            .cache_bytes = 0,
+        },
+    };
+    BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
+
+    CBlock block;
+    LOCK(::cs_main);
+    const auto first_outcome{blockman.WriteBlock(block, /*nHeight=*/0)};
+    const FlatFilePos first_pos{first_outcome.value};
+    BOOST_REQUIRE(!first_pos.IsNull());
+    BOOST_REQUIRE_EQUAL(first_pos.nFile, 0);
+    BOOST_REQUIRE(first_outcome.notifications.empty());
+
+    // Force a rollover, and make both files from the previous sequence entry
+    // impossible to open. The new block write itself can still succeed.
+    blockman.GetBlockFileInfo(first_pos.nFile)->nSize = MAX_BLOCKFILE_SIZE;
+    const fs::path block_path{blockman.GetBlockPosFilename(FlatFilePos{first_pos.nFile, 0})};
+    BOOST_REQUIRE(fs::remove(block_path));
+    BOOST_REQUIRE(fs::create_directory(block_path));
+    BOOST_REQUIRE(fs::create_directory(m_args.GetBlocksDirPath() / "rev00000.dat"));
+
+    const auto second_outcome{blockman.WriteBlock(block, /*nHeight=*/1)};
+    const FlatFilePos second_pos{second_outcome.value};
+    BOOST_REQUIRE(!second_pos.IsNull());
+    BOOST_CHECK_NE(second_pos.nFile, first_pos.nFile);
+    BOOST_REQUIRE_EQUAL(second_outcome.notifications.size(), 2);
+    BOOST_CHECK(second_outcome.notifications[0].type == node::BlockStorageErrorType::FLUSH);
+    BOOST_CHECK_EQUAL(second_outcome.notifications[0].message.original, "Flushing block file to disk failed. This is likely the result of an I/O error.");
+    BOOST_CHECK(second_outcome.notifications[1].type == node::BlockStorageErrorType::FLUSH);
+    BOOST_CHECK_EQUAL(second_outcome.notifications[1].message.original, "Flushing undo file to disk failed. This is likely the result of an I/O error.");
+}
+
+BOOST_AUTO_TEST_CASE(blockmanager_returns_fatal_error)
+{
+    const auto params{CreateChainParams(ArgsManager{}, ChainType::MAIN)};
+    const BlockManager::Options blockman_opts{
+        .chainparams = *params,
+        .blocks_dir = m_args.GetBlocksDirPath(),
+        .block_tree_db_params = DBParams{
+            .path = m_args.GetDataDirNet() / "blocks" / "index",
+            .cache_bytes = 0,
+            .memory_only = true,
+        },
+    };
+    BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
+
+    LOCK(::cs_main);
+    const auto outcome{blockman.LoadBlockIndexDB(uint256::ONE)};
+    BOOST_CHECK(!outcome.value);
+    BOOST_REQUIRE_EQUAL(outcome.notifications.size(), 1);
+    BOOST_CHECK(outcome.notifications[0].type == node::BlockStorageErrorType::FATAL);
+    BOOST_CHECK_NE(outcome.notifications[0].message.original.find("Assumeutxo data not found for the given blockhash"), std::string::npos);
 }
 
 BOOST_FIXTURE_TEST_CASE(blockmanager_scan_unlink_already_pruned_files, TestChain100Setup)

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -43,7 +43,9 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
     // simulate adding a genesis block normally
     LOCK(::cs_main);
-    BOOST_CHECK_EQUAL(blockman.WriteBlock(params->GenesisBlock(), 0).nPos, STORAGE_HEADER_BYTES);
+    const auto first_outcome{blockman.WriteBlock(params->GenesisBlock(), 0)};
+    BOOST_CHECK(first_outcome.notifications.empty());
+    BOOST_CHECK_EQUAL(first_outcome.value.nPos, STORAGE_HEADER_BYTES);
     // simulate what happens during reindex
     // simulate a well-formed genesis block being found at offset 8 in the blk00000.dat file
     // the block is found at offset 8 because there is an 8 byte serialization header
@@ -56,8 +58,9 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     // this is a check to make sure that https://github.com/bitcoin/bitcoin/issues/21379 does not recur
     // 8 bytes (for serialization header) + 285 (for serialized genesis block) = 293
     // add another 8 bytes for the second block's serialization header and we get 293 + 8 = 301
-    FlatFilePos actual{blockman.WriteBlock(params->GenesisBlock(), 1)};
-    BOOST_CHECK_EQUAL(actual.nPos, STORAGE_HEADER_BYTES + ::GetSerializeSize(TX_WITH_WITNESS(params->GenesisBlock())) + STORAGE_HEADER_BYTES);
+    const auto second_outcome{blockman.WriteBlock(params->GenesisBlock(), 1)};
+    BOOST_CHECK(second_outcome.notifications.empty());
+    BOOST_CHECK_EQUAL(second_outcome.value.nPos, STORAGE_HEADER_BYTES + ::GetSerializeSize(TX_WITH_WITNESS(params->GenesisBlock())) + STORAGE_HEADER_BYTES);
 }
 
 BOOST_FIXTURE_TEST_CASE(blockmanager_scan_unlink_already_pruned_files, TestChain100Setup)
@@ -262,10 +265,14 @@ BOOST_AUTO_TEST_CASE(blockmanager_flush_block_file)
     BOOST_CHECK_EQUAL(blockman.CalculateCurrentUsage(), 0);
 
     // Write the first block to a new location.
-    FlatFilePos pos1{blockman.WriteBlock(block1, /*nHeight=*/1)};
+    const auto first_outcome{blockman.WriteBlock(block1, /*nHeight=*/1)};
+    BOOST_CHECK(first_outcome.notifications.empty());
+    FlatFilePos pos1{first_outcome.value};
 
     // Write second block
-    FlatFilePos pos2{blockman.WriteBlock(block2, /*nHeight=*/2)};
+    const auto second_outcome{blockman.WriteBlock(block2, /*nHeight=*/2)};
+    BOOST_CHECK(second_outcome.notifications.empty());
+    FlatFilePos pos2{second_outcome.value};
 
     // Two blocks in the file
     BOOST_CHECK_EQUAL(blockman.CalculateCurrentUsage(), (TEST_BLOCK_SIZE + STORAGE_HEADER_BYTES) * 2);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -319,7 +319,6 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, TestOpts opts)
         const BlockManager::Options blockman_opts{
             .chainparams = chainman_opts.chainparams,
             .blocks_dir = m_args.GetBlocksDirPath(),
-            .notifications = chainman_opts.notifications,
             .block_tree_db_params = DBParams{
                 .path = m_args.GetDataDirNet() / "blocks" / "index",
                 .cache_bytes = m_kernel_cache_sizes.block_tree_db,

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -444,7 +444,6 @@ struct SnapshotTestSetup : TestChain100Setup {
             const BlockManager::Options blockman_opts{
                 .chainparams = chainman_opts.chainparams,
                 .blocks_dir = m_args.GetBlocksDirPath(),
-                .notifications = chainman_opts.notifications,
                 .block_tree_db_params = DBParams{
                     .path = chainman.m_options.datadir / "blocks" / "index",
                     .cache_bytes = m_kernel_cache_sizes.block_tree_db,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2138,6 +2138,20 @@ bool FatalError(Notifications& notifications, BlockValidationState& state, const
     return state.Error(message.original);
 }
 
+static void NotifyBlockStorageErrors(Notifications& notifications, node::BlockStorageErrors errors)
+{
+    for (const auto& error : errors) {
+        switch (error.type) {
+        case node::BlockStorageErrorType::FLUSH:
+            notifications.flushError(error.message);
+            break;
+        case node::BlockStorageErrorType::FATAL:
+            notifications.fatalError(error.message);
+            break;
+        }
+    }
+}
+
 /**
  * Restore the UTXO in a Coin at a given COutPoint
  * @param undo The Coin to be restored.
@@ -2632,7 +2646,9 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return true;
     }
 
-    if (!m_blockman.WriteBlockUndo(blockundo, state, *pindex)) {
+    auto write_undo_outcome{m_blockman.WriteBlockUndo(blockundo, state, *pindex)};
+    NotifyBlockStorageErrors(m_chainman.GetNotifications(), std::move(write_undo_outcome.notifications));
+    if (!write_undo_outcome.value) {
         return false;
     }
 
@@ -2706,7 +2722,6 @@ bool Chainstate::FlushStateToDisk(
     assert(this->CanFlushToDisk());
     std::set<int> setFilesToPrune;
     bool full_flush_completed = false;
-
     [[maybe_unused]] const size_t coins_count{CoinsTip().GetCacheSize()};
     [[maybe_unused]] const size_t coins_mem_usage{CoinsTip().DynamicMemoryUsage()};
 
@@ -2781,7 +2796,9 @@ bool Chainstate::FlushStateToDisk(
                 // First make sure all block and undo data is flushed to disk.
                 // TODO: Handle return error, or add detailed comment why it is
                 // safe to not return an error upon failure.
-                if (!m_blockman.FlushChainstateBlockFile(m_chain.Height())) {
+                auto flush_outcome{m_blockman.FlushChainstateBlockFile(m_chain.Height())};
+                NotifyBlockStorageErrors(m_chainman.GetNotifications(), std::move(flush_outcome.notifications));
+                if (!flush_outcome.value) {
                     LogWarning("%s: Failed to flush block file.\n", __func__);
                 }
             }
@@ -4378,7 +4395,9 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             blockPos = *dbp;
             m_blockman.UpdateBlockInfo(block, pindex->nHeight, blockPos);
         } else {
-            blockPos = m_blockman.WriteBlock(block, pindex->nHeight);
+            auto write_outcome{m_blockman.WriteBlock(block, pindex->nHeight)};
+            NotifyBlockStorageErrors(GetNotifications(), std::move(write_outcome.notifications));
+            blockPos = write_outcome.value;
             if (blockPos.IsNull()) {
                 state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
                 return false;
@@ -4921,8 +4940,9 @@ bool ChainstateManager::LoadBlockIndex()
     AssertLockHeld(cs_main);
     // Load block index from databases
     if (m_blockman.m_blockfiles_indexed) {
-        bool ret{m_blockman.LoadBlockIndexDB(CurrentChainstate().m_from_snapshot_blockhash)};
-        if (!ret) return false;
+        auto load_outcome{m_blockman.LoadBlockIndexDB(CurrentChainstate().m_from_snapshot_blockhash)};
+        NotifyBlockStorageErrors(GetNotifications(), std::move(load_outcome.notifications));
+        if (!load_outcome.value) return false;
 
         m_blockman.ScanAndUnlinkAlreadyPrunedFiles();
 
@@ -4957,7 +4977,9 @@ bool ChainstateManager::LoadGenesisBlock()
     }
 
     try {
-        FlatFilePos blockPos{m_blockman.WriteBlock(genesis_block, 0)};
+        auto write_outcome{m_blockman.WriteBlock(genesis_block, 0)};
+        NotifyBlockStorageErrors(GetNotifications(), std::move(write_outcome.notifications));
+        FlatFilePos blockPos{write_outcome.value};
         if (blockPos.IsNull()) {
             LogError("Writing genesis block to disk failed");
             return false;


### PR DESCRIPTION
`BlockManager` currently invokes `fatalError` and `flushError` callbacks synchronously during storage operations, making it unsafe to protect those operations with a non-recursive mutex.

This PR introduces `BlockStorageOutcome<T>` to return the operation result together with ordered notifications. Callers dispatch them after the storage operation returns, including when a successful rollover produces multiple flush errors.

It also removes the notification dependency from `BlockManager` and adds coverage for ordered flush errors and fatal errors.