### PR TITLE
http: throttle send buffer when client stops draining

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -997,23 +997,32 @@ HTTPServer::IOReadiness HTTPServer::GenerateWaitSockets() const
         // Safely copy the shared pointer to the socket
         std::shared_ptr<Sock> sock{http_client->GetSock()};
 
-        // Check if client is ready to send data. Don't try to receive again
-        // until the send buffer is cleared (all data sent to client).
-        // Keep this as a separate critical section from the m_sock_mutex one above:
-        // never hold m_sock_mutex and m_send_mutex at the same time here.
-        // MaybeSendBytesFromBuffer() locks m_send_mutex then m_sock_mutex, so nesting
-        // them in the opposite order here would risk a lock-order inversion deadlock.
+        // Event choice:
+        //   1. ReadyToSend() (m_send_ready set) -> Send
+        //      m_send_ready stays set while the send buffer still has data to
+        //      drain, so we keep sending and do not Recv. This is also how the
+        //      send-throttle applies backpressure: while the send buffer is
+        //      full, TryReadRequest() holds a completed request back from a
+        //      worker, so nothing new is read until send has drained.
+        //   2. Else, m_req is incomplete and needs more data, or there is no
+        //      m_req at all and the recv buffer is empty -> Recv
+        //   3. Else (no parse in progress, leftover bytes in m_recv_buffer) -> 0
+        //      Stay in the I/O map so TryReadRequest() drains the buffer first.
+        //      Extra pipelined data waits in the kernel socket buffer
+        //      (TCP backpressure), not in m_recv_buffer.
+        //
+        // Lock-order safety: the convention established by
+        // MaybeSendBytesFromBuffer() is to take m_send_mutex before m_sock_mutex.
+        // In this loop GetSock() (above) takes m_sock_mutex and ReadyToSend()
+        // (below) takes m_send_mutex; both are scoped, so each lock is released
+        // before the next is taken and they stay separate critical sections.
+        // Holding m_sock_mutex while acquiring m_send_mutex would invert that
+        // order and risk a lock-order-inversion deadlock.
         Sock::Event event{0};
         if (http_client->ReadyToSend()) {
             event = Sock::SendEvent;
         } else if (http_client->GetRequest() != nullptr || http_client->ReceiveBufferEmpty()) {
-            // Read from the socket when the parser has an incomplete request in
-            // progress (needs more bytes) or when the buffer is empty. If the
-            // buffer is non-empty but no parse is in progress, leave event=0:
-            // the client stays in the I/O map so TryReadRequest() runs first to
-            // consume buffered bytes before admitting more socket data. Excess
-            // pipelined data then backs up in the kernel socket buffer, applying
-            // TCP backpressure instead of accumulating without bound in m_recv_buffer.
+            // Mid-parse (need more bytes) or buffer empty.
             event = Sock::RecvEvent;
         }
 
@@ -1092,6 +1101,15 @@ std::unique_ptr<HTTPRequest> HTTPRemoteClient::TryReadRequest(const std::shared_
 
     // If the request is ready, hand it to a worker.
     if (client->m_req->GetState() == HTTPRequest::State::Complete) {
+        // Unless this client's send buffer is full: in that case hold the
+        // parsed request here instead of moving it to a worker. This prevents
+        // the server from reading any more data from this client until they
+        // drain their end of the socket, and prevents the server from packing
+        // more responses into the send buffer.
+        const size_t buffer_used{WITH_LOCK(
+            client->m_send_mutex,
+            return client->m_send_buffer.size();)};
+        if (buffer_used > MAX_BODY_SIZE) return nullptr;
         LogDebug(
             BCLog::HTTP,
             "Received a %s request for %s from %s (id=%llu)",

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -77,7 +77,8 @@ inline constexpr size_t MIN_REQUEST_LINE_LENGTH = std::string_view("GET / HTTP/1
 //! And libevent http.c evhttp_parse_headers_()
 inline constexpr size_t MAX_HEADERS_SIZE{8192};
 
-//! Maximum size of an HTTP request body
+//! Maximum size of an HTTP request body received from a client.
+//! Also used to limit data queued for sending back to client.
 inline constexpr uint64_t MAX_BODY_SIZE{32_MiB};
 
 //! Thrown when a request body exceeds MAX_BODY_SIZE (or *will* exceed, in chunked transfer)
@@ -515,7 +516,7 @@ public:
      * left in the buffer to wait for more data. Some read errors
      * will mark this client for disconnection.
      */
-    static std::unique_ptr<HTTPRequest> TryReadRequest(const std::shared_ptr<HTTPRemoteClient>& client);
+    static std::unique_ptr<HTTPRequest> TryReadRequest(const std::shared_ptr<HTTPRemoteClient>& client) EXCLUSIVE_LOCKS_REQUIRED(!client->m_send_mutex);
 
     /**
      * Push data (if there is any) from client's m_send_buffer to the connected socket.

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -6,7 +6,13 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.netutil import NETWORK_ERRORS
-from test_framework.util import assert_equal, assert_raises, str_to_b64str
+from test_framework.util import (
+    assert_equal,
+    assert_raises,
+    mine_large_block,
+    str_to_b64str
+)
+from test_framework.wallet import MiniWallet
 
 import concurrent.futures
 import http.client
@@ -154,6 +160,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         self.check_whitespace_in_headers()
         self.check_connection_limit()
         self.check_pipelined_data_is_throttled()
+        self.check_slow_read_throttle()
 
 
     def check_default_connection(self):
@@ -778,6 +785,63 @@ class HTTPBasicsTest (BitcoinTestFramework):
         response = conn.recv_raw().decode()
         assert generated_block in response
 
+
+    def check_slow_read_throttle(self):
+        self.log.info("Check that request processing is throttled if the client is not draining the socket")
+        self.restart_node(0, extra_args=["-rest=1"])
+        # Generate a big block
+        self.wallet = MiniWallet(self.node)
+        mine_large_block(self, self.wallet, self.node)
+        big_block_hash = self.node.getbestblockhash()
+
+        conn = BitcoinHTTPConnection(self.node)
+
+        # Request the big block JSON once to check its size and establish the connection
+        URI = f"/rest/block/{big_block_hash}.json"
+        response_body_size = len(conn.get(URI).read())
+        assert response_body_size > 7 * 1024 * 1024, f"Big block JSON response size is {response_body_size} bytes"
+
+        # Prepare a batch of requests. We want to fill up at
+        # least one server-side read operation (about 65kB, see HTTPRemoteClient::Receive()).
+        single_req = f"GET {URI} HTTP/1.1\r\nHost: somehost\r\n\r\n"
+        num_req = 0x10000 // len(single_req)
+        batch = single_req * num_req
+        self.log.info(f"Sending {num_req} big block JSON requests")
+
+        # Save a debug log checkpoint
+        dl_start_size = self.node.debug_log_size(encoding="utf-8")
+
+        # Send the batch but do not read any of the responses, leaving
+        # that data on the server-side of the socket.
+        conn.send_raw(batch.encode("ascii"))
+
+        # Open the debug log and count how many of the batch requests were processed.
+        # Expect progress to stall after a few seconds.
+        tries = 6
+        prev_count = -1
+        min_count = MAX_BODY_SIZE // response_body_size
+        with open(self.node.debug_log_path, encoding="utf-8", errors="replace") as dl:
+            while True:
+                dl.seek(dl_start_size)
+                log = dl.read()
+                count = log.count(URI)
+                if count == prev_count and count > min_count:
+                    self.log.info(f"Response progress stalled after {count} requests were handled.")
+                    assert count < num_req, f"Server handled the whole batch of {num_req}: nothing was throttled"
+                    break
+                prev_count = count
+                tries -= 1
+                assert tries > 0, f"Progress failed to stall after {count} requests were handled."
+                time.sleep(5)
+
+        # Drain the responses that were handled up to the stall point,
+        # plus a few more to confirm that pulling out the cork restores the flow.
+        conn.conn.sock.settimeout(10)
+        num_res = 0
+        while num_res < count + 2:
+            response = conn.conn.sock.recv(10 * 1024 * 1024)
+            num_res += response.count(b"HTTP/1.1 200")
+        self.log.info(f"Drained {num_res} responses")
 
 if __name__ == '__main__':
     HTTPBasicsTest(__file__).main()


### PR DESCRIPTION
This is a follow-up to #36123 and applies a second throttle mechanism to the send-side. If a misbehaving client refuses to read data from the socket, the server will now stop processing requests instead of packing more and more responses to `m_send_buffer` without bound.

After we parse a complete request from a client, **before** we dispatch it to a worker, we quickly lock and check the size of `m_send_buffer`. If there's already 32MiB of data there (reusing `MAX_BODY_SIZE` here, open for bikeshedding...) we do not dispatch the request to a worker, leaving it in place as `m_req`. 


This was found and disclosed responsibly by the Red Team 🟥.