### PR TITLE
net: fix startup failures from stale Tor examples

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -11,6 +11,10 @@ The following directions assume you have a Tor proxy running on port 9050. Many 
 
 - Tor removed v2 support beginning with version 0.4.6.
 
+- Since [v31](https://github.com/bitcoin/bitcoin/pull/34031), `onion` should be used
+  instead of `tor` (as in `-onlynet=onion` or `-proxy=addr:port=onion`).
+  The `-debug=tor` logging category is unaffected.
+
 ## How to see information about your Tor configuration via Bitcoin Core
 
 There are several ways to see your local onion address in Bitcoin Core:
@@ -39,7 +43,7 @@ outgoing connections, but more is possible.
         as well. You need to use -noonion or -onion=0 to explicitly disable
         outbound access to onion services.
 
-    -proxy=ip[:port]=tor
+    -proxy=ip[:port]=onion
     or
     -onion=ip[:port]
         Set the proxy server for reaching .onion addresses. You do not need to
@@ -51,7 +55,7 @@ outgoing connections, but more is possible.
         -proxy=addr:port=ipv4 or
         -proxy=addr:port=ipv6
         (last one if multiple options are given). It is not taken from
-        -proxy=addr:port=tor or
+        -proxy=addr:port=onion or
         -onion=addr:port.
         If no proxy for DNS requests is configured, then they will be done using
         the functions provided by the operating system, most likely resulting in

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1771,7 +1771,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             if (eq_pos + 1 == param_value.length()) {
                 return InitError(strprintf(_("Invalid -proxy address or hostname, ends with '=': '%s'"), param_value));
             }
-            net_str = ToLower(param_value.substr(eq_pos + 1)); // e.g. 127.0.0.1:9050=ipv4 -> ipv4
+            net_str = param_value.substr(eq_pos + 1); // e.g. 127.0.0.1:9050=ipv4 -> ipv4
         }
 
         Proxy proxy;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1792,16 +1792,18 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
         if (net_str.empty()) { // For all networks.
             ipv4_proxy = ipv6_proxy = name_proxy = cjdns_proxy = onion_proxy = proxy;
-        } else if (net_str == "ipv4") {
-            ipv4_proxy = name_proxy = proxy;
-        } else if (net_str == "ipv6") {
-            ipv6_proxy = name_proxy = proxy;
-        } else if (net_str == "onion") {
-            onion_proxy = proxy;
-        } else if (net_str == "cjdns") {
-            cjdns_proxy = proxy;
         } else {
-            return InitError(strprintf(_("Unrecognized network in -proxy='%s': '%s'"), param_value, net_str));
+            switch (ParseNetwork(net_str)) {
+            case NET_IPV4: ipv4_proxy = name_proxy = proxy; break;
+            case NET_IPV6: ipv6_proxy = name_proxy = proxy; break;
+            case NET_ONION: onion_proxy = proxy; break;
+            case NET_CJDNS: cjdns_proxy = proxy; break;
+            case NET_UNROUTABLE:
+            case NET_I2P:
+            case NET_INTERNAL:
+            case NET_MAX:
+                return InitError(strprintf(_("Unrecognized network in -proxy='%s': '%s'"), param_value, net_str));
+            } // no default case, so the compiler can warn about missing cases
         }
     }
     if (ipv4_proxy.IsValid()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -621,7 +621,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    "Connect through SOCKS5 proxy, set -noproxy to disable. " +
                    proxy_doc_for_unix_socket +
                    "Could end in =network to set the proxy only for that network. " +
-                   "The network can be any of ipv4, ipv6, tor or cjdns. " +
+                   "The network can be any of " + Join(std::vector{NET_IPV4, NET_IPV6, NET_ONION, NET_CJDNS}, ", ", GetNetworkName) + ". " +
                    "(default: disabled)",
                    ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_ELISION,
                    OptionsCategory::CONNECTION);

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -455,7 +455,7 @@ class ProxyTest(BitcoinTestFramework):
         self.log.info("Test unknown, removed and non-SOCKS5 network names are rejected by -proxy")
         for network in ["Foo", "tor", "i2p"]:
             self.nodes[1].extra_args = [f"-proxy=127.0.0.1:9050={network}"]
-            msg = f"Error: Unrecognized network in -proxy='127.0.0.1:9050={network}': '{network.lower()}'"  # TODO: The error must identify the invalid input exactly
+            msg = f"Error: Unrecognized network in -proxy='127.0.0.1:9050={network}': '{network}'"
             self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
         self.log.info("Test passing proxy only for IPv6")

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -441,20 +441,22 @@ class ProxyTest(BitcoinTestFramework):
         self.start_node(1, extra_args=["-onlynet=onion", "-listenonion=1"])
         self.stop_node(1)
 
-        self.log.info("Test passing unknown network to -onlynet raises expected init error")
-        self.nodes[1].extra_args = ["-onlynet=abc"]
-        msg = "Error: Unknown network specified in -onlynet: 'abc'"
-        self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
+        self.log.info("Test unknown and removed network names are rejected by -onlynet")
+        for network in ["abc", "tor"]:
+            self.nodes[1].extra_args = [f"-onlynet={network}"]
+            msg = f"Error: Unknown network specified in -onlynet: '{network}'"
+            self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
         self.log.info("Test passing trailing '=' raises expected init error")
         self.nodes[1].extra_args = ["-proxy=127.0.0.1:9050="]
         msg = "Error: Invalid -proxy address or hostname, ends with '=': '127.0.0.1:9050='"
         self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
-        self.log.info("Test passing unrecognized network raises expected init error")
-        self.nodes[1].extra_args = ["-proxy=127.0.0.1:9050=foo"]
-        msg = "Error: Unrecognized network in -proxy='127.0.0.1:9050=foo': 'foo'"
-        self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
+        self.log.info("Test unknown, removed and non-SOCKS5 network names are rejected by -proxy")
+        for network in ["Foo", "tor", "i2p"]:
+            self.nodes[1].extra_args = [f"-proxy=127.0.0.1:9050={network}"]
+            msg = f"Error: Unrecognized network in -proxy='127.0.0.1:9050={network}': '{network.lower()}'"  # TODO: The error must identify the invalid input exactly
+            self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
         self.log.info("Test passing proxy only for IPv6")
         self.start_node(1, extra_args=["-proxy=127.6.6.6:6666=ipv6"])
@@ -470,8 +472,8 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(nets["ipv6"]["proxy"], "127.6.6.6:6666")
         self.stop_node(1)
 
-        self.log.info("Test overriding the Onion proxy")
-        self.start_node(1, extra_args=["-proxy=127.1.1.1:1111", "-proxy=127.2.2.2:2222=onion"])
+        self.log.info("Test overriding the Onion proxy with a mixed-case network suffix")
+        self.start_node(1, extra_args=["-proxy=127.1.1.1:1111", "-proxy=127.2.2.2:2222=OnIoN"])
         nets = networks_dict(self.nodes[1].getnetworkinfo())
         assert_equal(nets["ipv4"]["proxy"], "127.1.1.1:1111")
         assert_equal(nets["ipv6"]["proxy"], "127.1.1.1:1111")
@@ -485,6 +487,15 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(nets["ipv6"]["proxy"], "127.1.1.1:1111")
         assert_equal(nets["onion"]["proxy"], "127.1.1.1:1111")
         assert_equal(nets["cjdns"]["proxy"], "")
+        self.stop_node(1)
+
+        self.log.info("Test that clearing the IPv4 proxy also clears the name proxy")
+        self.start_node(1, extra_args=[f"-proxy={self.conf1.addr[0]}:{self.conf1.addr[1]}", "-proxy=0=ipv4", "-dns=0"])
+        with self.nodes[1].assert_debug_log(
+            expected_msgs=["trying v1 connection (manual) to example.com:8333"],
+            unexpected_msgs=["SOCKS5 connecting example.com"],
+        ):
+            self.nodes[1].addnode("example.com:8333", "onetry", v2transport=False)
         self.stop_node(1)
 
         self.log.info("Test passing too-long unix path to -proxy raises init error")

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -334,13 +334,13 @@ class NetTest(BitcoinTestFramework):
         assert_equal(res[0]["port"], 8333)
         assert_equal(res[0]["services"], P2P_SERVICES)
 
-        # Test for the absence of onion, I2P and CJDNS addresses.
-        for network in ["onion", "i2p", "cjdns"]:
+        for network in ["onion", "OnIoN", "i2p", "cjdns"]:
             assert_equal(self.nodes[0].getnodeaddresses(0, network), [])
 
         # Test invalid arguments.
         assert_raises_rpc_error(-8, "Address count out of range", self.nodes[0].getnodeaddresses, -1)
-        assert_raises_rpc_error(-8, "Network not recognized: Foo", self.nodes[0].getnodeaddresses, 1, "Foo")
+        for network in ["Foo", "tor"]:
+            assert_raises_rpc_error(-8, f"Network not recognized: {network}", self.nodes[0].getnodeaddresses, 1, network)
 
     def test_addpeeraddress(self):
         self.log.info("Test addpeeraddress")


### PR DESCRIPTION
**Problem:** #34031 removed `tor` as a network name, but the `-proxy` help and Tor documentation still advertise it, and following those examples fails at startup.
The proxy option also maintains its own network-name mapping while `-onlynet` and `getnodeaddresses` use the shared parser.

**Fix:** Reuse the shared parser and canonical network names for `-proxy`, and document `onion` consistently. Unsupported network names are now echoed as supplied, matching the other interfaces, while accepted names remain case-insensitive.