### PR TITLE
qt: don't abort or drop settings when dynamic settings are disabled

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -105,9 +105,9 @@ public:
     virtual common::SettingsValue getPersistentSetting(const std::string& name) = 0;
 
     //! Update a setting in <datadir>/settings.json.
-    //! The in-memory value is always updated. The write to disk is skipped
-    //! when settings are disabled with -nosettings.
-    virtual void updateRwSetting(const std::string& name, const common::SettingsValue& value) = 0;
+    //! The in-memory value is always updated. Returns whether it reached
+    //! disk, which it does not when settings are disabled with -nosettings.
+    virtual bool updateRwSetting(const std::string& name, const common::SettingsValue& value) = 0;
 
     //! Force a setting value to be applied, overriding any other configuration
     //! source, but not being persisted.

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -105,6 +105,8 @@ public:
     virtual common::SettingsValue getPersistentSetting(const std::string& name) = 0;
 
     //! Update a setting in <datadir>/settings.json.
+    //! The in-memory value is always updated. The write to disk is skipped
+    //! when settings are disabled with -nosettings.
     virtual void updateRwSetting(const std::string& name, const common::SettingsValue& value) = 0;
 
     //! Force a setting value to be applied, overriding any other configuration
@@ -112,7 +114,9 @@ public:
     virtual void forceSetting(const std::string& name, const common::SettingsValue& value) = 0;
 
     //! Clear all settings in <datadir>/settings.json and store a backup of
-    //! previous settings in <datadir>/settings.json.bak.
+    //! previous settings in <datadir>/settings.json.bak. The in-memory
+    //! settings are always cleared, and both writes are skipped when settings
+    //! are disabled with -nosettings.
     virtual void resetSettings() = 0;
 
     //! Map port.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -172,7 +172,7 @@ public:
         return ignored;
     }
     common::SettingsValue getPersistentSetting(const std::string& name) override { return args().GetPersistentSetting(name); }
-    void updateRwSetting(const std::string& name, const common::SettingsValue& value) override
+    bool updateRwSetting(const std::string& name, const common::SettingsValue& value) override
     {
         args().LockSettings([&](common::Settings& settings) {
             if (value.isNull()) {
@@ -181,7 +181,7 @@ public:
                 settings.rw_settings[name] = value;
             }
         });
-        if (args().GetSettingsPath()) args().WriteSettingsFile();
+        return args().GetSettingsPath() && args().WriteSettingsFile();
     }
     void forceSetting(const std::string& name, const common::SettingsValue& value) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -181,7 +181,7 @@ public:
                 settings.rw_settings[name] = value;
             }
         });
-        args().WriteSettingsFile();
+        if (args().GetSettingsPath()) args().WriteSettingsFile();
     }
     void forceSetting(const std::string& name, const common::SettingsValue& value) override
     {
@@ -195,11 +195,11 @@ public:
     }
     void resetSettings() override
     {
-        args().WriteSettingsFile(/*errors=*/nullptr, /*backup=*/true);
+        if (args().GetSettingsPath()) args().WriteSettingsFile(/*errors=*/nullptr, /*backup=*/true);
         args().LockSettings([&](common::Settings& settings) {
             settings.rw_settings.clear();
         });
-        args().WriteSettingsFile();
+        if (args().GetSettingsPath()) args().WriteSettingsFile();
     }
     void mapPort(bool enable) override { StartMapPort(enable); }
     std::optional<Proxy> getProxy(Network net) override { return GetProxy(net); }

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -380,7 +380,11 @@ void OptionsDialog::on_okButton_clicked()
 {
     model->setData(model->index(OptionsModel::FontForMoney, 0), ui->moneyFont->itemData(ui->moneyFont->currentIndex()));
 
+    model->clearWriteFailed();
     mapper->submit();
+    if (model->writeFailed()) {
+        QMessageBox::warning(this, tr("Options warning"), tr("Some settings could not be saved and will be lost on restart."));
+    }
     accept();
     updateDefaultProxyNets();
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -57,7 +57,7 @@ static const char* SettingName(OptionsModel::OptionID option)
 }
 
 /** Call node.updateRwSetting() with Bitcoin 22.x workaround. */
-static void UpdateRwSetting(interfaces::Node& node, OptionsModel::OptionID option, const std::string& suffix, const common::SettingsValue& value)
+static bool UpdateRwSetting(interfaces::Node& node, OptionsModel::OptionID option, const std::string& suffix, const common::SettingsValue& value)
 {
     if (value.isNum() &&
         (option == OptionsModel::DatabaseCache ||
@@ -71,9 +71,9 @@ static void UpdateRwSetting(interfaces::Node& node, OptionsModel::OptionID optio
         // in later releases by https://github.com/bitcoin/bitcoin/pull/24498.
         // If new numeric settings are added, they can be written as numbers
         // instead of strings, because bitcoin 22.x will not try to read these.
-        node.updateRwSetting(SettingName(option) + suffix, value.getValStr());
+        return node.updateRwSetting(SettingName(option) + suffix, value.getValStr());
     } else {
-        node.updateRwSetting(SettingName(option) + suffix, value);
+        return node.updateRwSetting(SettingName(option) + suffix, value);
     }
 }
 
@@ -386,7 +386,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
 // write QSettings values
 bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, int role)
 {
-    bool successful = true; /* set to false on parse error */
+    bool successful = true; /* set to false on parse error or failed write */
     if(role == Qt::EditRole)
     {
         successful = setOption(OptionID(index.row()), value);
@@ -503,10 +503,16 @@ QFont OptionsModel::getFontForMoney() const
 // NOLINTNEXTLINE(misc-no-recursion)
 bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::string& suffix)
 {
+    bool successful = true; /* set to false on parse error or failed write */
+    bool restart_required = false;
     auto changed = [&] { return value.isValid() && value != getOption(option, suffix); };
-    auto update = [&](const common::SettingsValue& value) { return UpdateRwSetting(node(), option, suffix, value); };
+    auto update = [&](const common::SettingsValue& value) {
+        const bool ok{UpdateRwSetting(node(), option, suffix, value)};
+        if (!ok) m_write_failed = true;
+        successful &= ok;
+        return ok;
+    };
 
-    bool successful = true; /* set to false on parse error */
     QSettings settings;
 
     switch (option) {
@@ -539,7 +545,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             if (suffix.empty() && !value.toBool()) setOption(option, true, "-prev");
             update(ProxyString(value.toBool(), getOption(ProxyIP).toString(), getOption(ProxyPort).toString()));
             if (suffix.empty() && value.toBool()) UpdateRwSetting(node(), option, "-prev", {});
-            if (suffix.empty()) setRestartRequired(true);
+            if (suffix.empty()) restart_required = true;
         }
         break;
     case ProxyIP:
@@ -549,7 +555,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             } else {
                 update(ProxyString(true, value.toString(), getOption(ProxyPort).toString()));
             }
-            if (suffix.empty() && getOption(ProxyUse).toBool()) setRestartRequired(true);
+            if (suffix.empty() && getOption(ProxyUse).toBool()) restart_required = true;
         }
         break;
     case ProxyPort:
@@ -559,7 +565,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             } else {
                 update(ProxyString(true, getOption(ProxyIP).toString(), value.toString()));
             }
-            if (suffix.empty() && getOption(ProxyUse).toBool()) setRestartRequired(true);
+            if (suffix.empty() && getOption(ProxyUse).toBool()) restart_required = true;
         }
         break;
 
@@ -569,7 +575,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             if (suffix.empty() && !value.toBool()) setOption(option, true, "-prev");
             update(ProxyString(value.toBool(), getOption(ProxyIPTor).toString(), getOption(ProxyPortTor).toString()));
             if (suffix.empty() && value.toBool()) UpdateRwSetting(node(), option, "-prev", {});
-            if (suffix.empty()) setRestartRequired(true);
+            if (suffix.empty()) restart_required = true;
         }
         break;
     case ProxyIPTor:
@@ -579,7 +585,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             } else {
                 update(ProxyString(true, value.toString(), getOption(ProxyPortTor).toString()));
             }
-            if (suffix.empty() && getOption(ProxyUseTor).toBool()) setRestartRequired(true);
+            if (suffix.empty() && getOption(ProxyUseTor).toBool()) restart_required = true;
         }
         break;
     case ProxyPortTor:
@@ -589,7 +595,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             } else {
                 update(ProxyString(true, getOption(ProxyIPTor).toString(), value.toString()));
             }
-            if (suffix.empty() && getOption(ProxyUseTor).toBool()) setRestartRequired(true);
+            if (suffix.empty() && getOption(ProxyUseTor).toBool()) restart_required = true;
         }
         break;
 
@@ -597,13 +603,13 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
     case SpendZeroConfChange:
         if (changed()) {
             update(value.toBool());
-            setRestartRequired(true);
+            restart_required = true;
         }
         break;
     case ExternalSignerPath:
         if (changed()) {
             update(value.toString().toStdString());
-            setRestartRequired(true);
+            restart_required = true;
         }
         break;
     case SubFeeFromAmount:
@@ -618,13 +624,13 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
         if (strThirdPartyTxUrls != value.toString()) {
             strThirdPartyTxUrls = value.toString();
             settings.setValue("strThirdPartyTxUrls", strThirdPartyTxUrls);
-            setRestartRequired(true);
+            restart_required = true;
         }
         break;
     case Language:
         if (changed()) {
             update(value.toString().toStdString());
-            setRestartRequired(true);
+            restart_required = true;
         }
         break;
     case FontForMoney:
@@ -650,7 +656,7 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             if (suffix.empty() && !value.toBool()) setOption(option, true, "-prev");
             update(PruneSetting(value.toBool(), getOption(PruneSize).toInt()));
             if (suffix.empty() && value.toBool()) UpdateRwSetting(node(), option, "-prev", {});
-            if (suffix.empty()) setRestartRequired(true);
+            if (suffix.empty()) restart_required = true;
         }
         break;
     case PruneSize:
@@ -660,26 +666,26 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
             } else {
                 update(PruneSetting(true, ParsePruneSizeGB(value)));
             }
-            if (suffix.empty() && getOption(Prune).toBool()) setRestartRequired(true);
+            if (suffix.empty() && getOption(Prune).toBool()) restart_required = true;
         }
         break;
     case DatabaseCache:
         if (changed()) {
             update(static_cast<int64_t>(value.toLongLong()));
-            setRestartRequired(true);
+            restart_required = true;
         }
         break;
     case ThreadsScriptVerif:
         if (changed()) {
             update(static_cast<int64_t>(value.toLongLong()));
-            setRestartRequired(true);
+            restart_required = true;
         }
         break;
     case Listen:
     case Server:
         if (changed()) {
             update(value.toBool());
-            setRestartRequired(true);
+            restart_required = true;
         }
         break;
     case MaskValues:
@@ -689,6 +695,10 @@ bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::
     default:
         break;
     }
+
+    // Only ask for a restart if the value actually landed on disk, since a
+    // restart would otherwise drop the in-memory change instead of applying it.
+    if (restart_required && successful) setRestartRequired(true);
 
     return successful;
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -750,7 +750,10 @@ void OptionsModel::checkAndMigrate()
     }
 
     // Migrate and delete legacy GUI settings that have now moved to <datadir>/settings.json.
+    // With -nosettings there is nowhere to migrate them to, so leave them in
+    // place instead of dropping them.
     auto migrate_setting = [&](OptionID option, const QString& qt_name) {
+        if (!gArgs.GetSettingsPath()) return;
         if (!settings.contains(qt_name)) return;
         QVariant value = settings.value(qt_name);
         if (node().getPersistentSetting(SettingName(option)).isNull()) {

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -119,6 +119,10 @@ public:
     void setRestartRequired(bool fRequired);
     bool isRestartRequired() const;
 
+    /* Whether a settings write failed since the last clearWriteFailed(). */
+    bool writeFailed() const { return m_write_failed; }
+    void clearWriteFailed() { m_write_failed = false; }
+
     interfaces::Node& node() const { return m_node; }
 
 private:
@@ -135,6 +139,9 @@ private:
     bool m_sub_fee_from_amount;
     bool m_enable_psbt_controls;
     bool m_mask_values;
+
+    /* set when a settings write did not reach disk */
+    bool m_write_failed{false};
 
     /* settings that were overridden by command-line */
     QString strOverriddenByCommandLine;

--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -92,7 +92,7 @@ void OptionTests::disabledSettings()
     gArgs.ClearPathCache();
     QVERIFY(!gArgs.GetSettingsPath());
 
-    m_node.updateRwSetting("dbcache", 600);
+    QVERIFY(!m_node.updateRwSetting("dbcache", 600));
     m_node.resetSettings();
 
     // Legacy GUI settings survive, since there is nowhere to migrate them to.
@@ -101,10 +101,39 @@ void OptionTests::disabledSettings()
     settings.sync();
 
     bilingual_str error;
-    QVERIFY(OptionsModel{m_node}.Init(error));
+    OptionsModel options{m_node};
+    QVERIFY(options.Init(error));
     QVERIFY(settings.contains("nDatabaseCache"));
 
+    // A write that cannot reach disk is reported back to the caller, and does
+    // not ask for a restart that would drop the in-memory change.
+    options.clearWriteFailed();
+    QVERIFY(!options.setOption(OptionsModel::DatabaseCache, 123));
+    QVERIFY(options.writeFailed());
+    QVERIFY(!options.isRestartRequired());
+
     settings.remove("nDatabaseCache");
+}
+
+void OptionTests::unwritableSettings()
+{
+    // The same reporting has to hold when settings are enabled but the write
+    // fails, which is what a full disk or a read-only settings file looks like.
+    gArgs.LockSettings([&](common::Settings& s) {
+        s.forced_settings["settings"] = "nonexistent-directory/settings.json";
+    });
+    gArgs.ClearPathCache();
+    QVERIFY(gArgs.GetSettingsPath());
+
+    QVERIFY(!m_node.updateRwSetting("dbcache", 600));
+
+    bilingual_str error;
+    OptionsModel options{m_node};
+    QVERIFY(options.Init(error));
+    options.clearWriteFailed();
+    QVERIFY(!options.setOption(OptionsModel::DatabaseCache, 123));
+    QVERIFY(options.writeFailed());
+    QVERIFY(!options.isRestartRequired());
 }
 
 void OptionTests::integerGetArgBug()

--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -85,6 +85,28 @@ void OptionTests::migrateSettings()
         "}\n");
 }
 
+void OptionTests::disabledSettings()
+{
+    // Settings writes must not throw when dynamic settings are disabled.
+    gArgs.LockSettings([&](common::Settings& s) { s.forced_settings["settings"] = false; });
+    gArgs.ClearPathCache();
+    QVERIFY(!gArgs.GetSettingsPath());
+
+    m_node.updateRwSetting("dbcache", 600);
+    m_node.resetSettings();
+
+    // Legacy GUI settings survive, since there is nowhere to migrate them to.
+    QSettings settings;
+    settings.setValue("nDatabaseCache", 600);
+    settings.sync();
+
+    bilingual_str error;
+    QVERIFY(OptionsModel{m_node}.Init(error));
+    QVERIFY(settings.contains("nDatabaseCache"));
+
+    settings.remove("nDatabaseCache");
+}
+
 void OptionTests::integerGetArgBug()
 {
     // Test regression https://github.com/bitcoin/bitcoin/issues/24457. Ensure

--- a/src/qt/test/optiontests.h
+++ b/src/qt/test/optiontests.h
@@ -20,6 +20,7 @@ public:
 private Q_SLOTS:
     void init(); // called before each test function execution.
     void migrateSettings();
+    void disabledSettings();
     void integerGetArgBug();
     void parametersInteraction();
     void extractFilter();

--- a/src/qt/test/optiontests.h
+++ b/src/qt/test/optiontests.h
@@ -21,6 +21,7 @@ private Q_SLOTS:
     void init(); // called before each test function execution.
     void migrateSettings();
     void disabledSettings();
+    void unwritableSettings();
     void integerGetArgBug();
     void parametersInteraction();
     void extractFilter();


### PR DESCRIPTION
`ArgsManager::WriteSettingsFile` throws when dynamic settings are disabled, and three call sites in `NodeImpl` call it without checking first. So `bitcoin-qt -nosettings` aborts on `-resetguisettings`, and on the legacy GUI settings migration when an old Qt setting is still present, which comes back on every start because the abort happens before the key is removed.

The fourth call site in that file is the wallet path in `ChainImpl`, and #36176 guards it. These three are the options dialog, and I ran into them while testing that PR.

The flag is easier to reach than it looks, since the fatal error box suggests `-nosettings` when the settings file cannot be written.

Guarding the writes on its own is not enough, because three things then happen silently instead of aborting. The migration drops the legacy keys, since it removes them whether or not the write landed. The dialog closes reporting success, since `setOption` only reported parse errors and `QDataWidgetMapper::submit()` does not propagate what `setData` returns. And it asks for a restart that would discard the change rather than apply it, which is reachable today without the flag.

`bitcoin-qt -regtest -nosettings -resetguisettings` aborts on master and starts here. The Qt tests cover the guards and each of those, with settings disabled and with a write that fails, and each one fails without its change.

The second commit reports rather than fixes the abort, so it can be dropped if reviewers would rather keep this to the crash.
