### PR TITLE
http: Restore requirement of IPv4 bind success

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1362,10 +1362,13 @@ bool InitHTTPServer()
         }
     };
     for (const auto& [address_string, port, required] : endpoints) {
-        LogInfo("Binding RPC on address %s port %i", address_string, port);
-        const std::optional<CService> addr{Lookup(address_string, port, false)};
+        // Don't allow hostname lookups when binding to local interfaces. This
+        // means numeric collisions on available interfaces detected by endpoints_seen
+        // are probably just repeated instances - skip without logging why.
+        const std::optional<CService> addr{Lookup(address_string, port, /*fAllowLookup=*/false)};
         if (addr) {
             if (!endpoints_seen.insert(*addr).second) continue;
+            LogInfo("Binding RPC on address %s port %i", address_string, port);
             if (addr->IsBindAny()) {
                 LogWarning("The RPC server is not safe to expose to untrusted networks such as the public internet");
             }
@@ -1380,7 +1383,8 @@ bool InitHTTPServer()
             }
         } else {
             on_failure(required,
-                       strprintf("Could not bind RPC on %s address %s port %i: Address lookup failed.",
+                       strprintf("Could not bind RPC on %s address \"%s\" port %i: Address lookup failed "
+                                 "(only numeric addresses are allowed).",
                                  required ? "required" : "optional",
                                  address_string, port));
         }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <memory>
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
 #include <string_view>
@@ -205,19 +206,34 @@ static void RejectRequest(std::unique_ptr<HTTPRequest> hreq)
     WriteNoStoreErrorReply(*hreq, HTTP_SERVICE_UNAVAILABLE);
 }
 
-static std::vector<std::pair<std::string, uint16_t>> GetBindAddresses()
+struct BindAddress {
+    std::string address;
+    uint16_t port;
+    bool required{true};
+};
+
+static bool BindDefaultLoopbackAddresses()
+{
+    // Default to loopback if not allowing external IPs
+    return gArgs.GetArgs("-rpcallowip").empty() || gArgs.GetArgs("-rpcbind").empty();
+}
+
+static std::vector<BindAddress> GetBindAddresses()
 {
     uint16_t http_port{static_cast<uint16_t>(gArgs.GetIntArg("-rpcport", BaseParams().RPCPort()))};
-    std::vector<std::pair<std::string, uint16_t>> endpoints;
+    std::vector<BindAddress> endpoints;
 
     // Determine what addresses to bind to
     // To prevent misconfiguration and accidental exposure of the RPC
     // interface, require -rpcallowip and -rpcbind to both be specified
     // together. If either is missing, ignore both values, bind to localhost
     // instead, and log warnings.
-    if (gArgs.GetArgs("-rpcallowip").empty() || gArgs.GetArgs("-rpcbind").empty()) { // Default to loopback if not allowing external IPs
-        endpoints.emplace_back("::1", http_port);
-        endpoints.emplace_back("127.0.0.1", http_port);
+    if (BindDefaultLoopbackAddresses()) {
+        // We allow the default IPv6 bind to fail, but IPv4 is required even
+        // with the default port as bitcoin-cli will default to handing RPC
+        // credentials in plaintext to whatever process is running on that port.
+        endpoints.push_back({.address = "::1",       .port = http_port, .required = false});
+        endpoints.push_back({.address = "127.0.0.1", .port = http_port, .required = true});
         if (!gArgs.GetArgs("-rpcallowip").empty()) {
             LogWarning("Option -rpcallowip was specified without -rpcbind; this doesn't usually make sense");
         }
@@ -1333,28 +1349,54 @@ bool InitHTTPServer()
     g_http_server->SetMaxConnections(std::max(gArgs.GetArg<int>("-rpcmaxconnections", DEFAULT_MAX_HTTP_CONNECTIONS), 1));
 
     // Bind HTTP server to specified addresses
-    std::vector<std::pair<std::string, uint16_t>> endpoints{GetBindAddresses()};
+    std::vector<BindAddress> endpoints{GetBindAddresses()};
+    std::set<CService> endpoints_seen;
     bool bind_success{false};
-    for (const auto& [address_string, port] : endpoints) {
+    bool required_failure{false};
+    auto on_failure = [&required_failure](bool required, std::string_view msg) {
+        if (required) {
+            LogError("%s", msg);
+            required_failure = true;
+        } else {
+            LogWarning("%s", msg);
+        }
+    };
+    for (const auto& [address_string, port, required] : endpoints) {
         LogInfo("Binding RPC on address %s port %i", address_string, port);
         const std::optional<CService> addr{Lookup(address_string, port, false)};
         if (addr) {
+            if (!endpoints_seen.insert(*addr).second) continue;
             if (addr->IsBindAny()) {
                 LogWarning("The RPC server is not safe to expose to untrusted networks such as the public internet");
             }
             auto result{g_http_server->BindAndStartListening(addr.value())};
             if (!result) {
-                LogWarning("Binding RPC on address %s failed: %s", addr->ToStringAddrPort(), result.error());
+                on_failure(required,
+                           strprintf("Binding RPC on %s address %s failed: %s",
+                                     required ? "required" : "optional",
+                                     addr->ToStringAddrPort(), result.error()));
             } else {
                 bind_success = true;
             }
         } else {
-            LogWarning("Could not bind RPC on address %s port %i: Address lookup failed.", address_string, port);
+            on_failure(required,
+                       strprintf("Could not bind RPC on %s address %s port %i: Address lookup failed.",
+                                 required ? "required" : "optional",
+                                 address_string, port));
         }
     }
 
     if (!bind_success) {
         LogError("Unable to bind any endpoint for RPC server");
+        return false;
+    } else if (required_failure) {
+        g_http_server->StopListening();
+        if (BindDefaultLoopbackAddresses()) {
+            LogError("Unable to bind default required IPv4 endpoint. Ensure the "
+                     "port is free and retry, or specify endpoints via -rpcbind.");
+        } else {
+            LogError("Unable to bind all specified endpoints for RPC server.");
+        }
         return false;
     }
 

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -255,7 +255,6 @@ class ConfArgsTest(BitcoinTestFramework):
             self.start_node(0, extra_args=[
                 '-addnode=some.node',
                 '-rpcauth=alice:f7efda5c189b999524f151318c0c86$d5b51b3beffbc0',
-                '-rpcbind=127.1.1.1',
                 '-rpcbind=127.0.0.1',
                 "-rpcallowip=127.0.0.1",
                 '-rpcpassword=',

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -118,8 +118,9 @@ class RPCBindTest(BitcoinTestFramework):
                 self.cleanup_partially_started_nodes()
         self.nodes[0].rpchost = None
 
-        assert_equal(started, True)  # TODO: an occupied RPC listener must abort startup to protect credentials
-        assert_equal(credential_captured, True)  # TODO: a client credential must not reach another process's listener
+        assert_equal(started, False)
+        assert_equal(credential_captured, False)
+        assert 'Unable to start HTTP server' in error
 
     def run_allowip_test(self, allow_ips, rpchost, rpcport):
         '''

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -4,10 +4,14 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test running bitcoind with the -rpcbind and -rpcallowip options."""
 
+import socket
+import subprocess
+import time
+
 from test_framework.netutil import NETWORK_ERRORS, all_interfaces, addr_to_hex, get_bind_addrs, test_ipv6_local
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
-from test_framework.test_node import ErrorMatch
-from test_framework.util import assert_equal, rpc_port
+from test_framework.test_node import ErrorMatch, FailedToStartError
+from test_framework.util import assert_equal, get_auth_cookie, rpc_port, str_to_b64str
 
 class RPCBindTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -57,6 +61,65 @@ class RPCBindTest(BitcoinTestFramework):
         init_error = 'Error: Invalid port specified in -rpcbind: '
         for addr in addresses:
             self.nodes[0].assert_start_raises_init_error(base_args + [f'-rpcbind={addr}'], init_error + f"'{addr}'")
+
+    def run_partial_bind_test(self, explicit_binds):
+        self.log.info(f'Check startup when the {"explicit" if explicit_binds else "default IPv4"} RPC address is already owned')
+        self.nodes[0].rpchost = '[::1]'
+        error = ''
+        credential_captured = False
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(('127.0.0.1', self.defaultport))
+            sock.listen()
+            sock.settimeout(0.1)
+            try:
+                extra_args = ['-disablewallet', '-nolisten']
+                if explicit_binds:
+                    extra_args += ['-rpcallowip=127.0.0.1', '-rpcbind=127.0.0.1', '-rpcbind=[::1]']
+                self.start_node(0, extra_args=extra_args)
+                started = True
+                cli = subprocess.Popen([
+                    self.nodes[0].binaries.paths.bitcoincli,
+                    f'-datadir={self.nodes[0].datadir_path}',
+                    '-noipcconnect',
+                    '-rpcclienttimeout=2',
+                    'getblockcount',
+                ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                try:
+                    conn = None
+                    deadline = time.monotonic() + 5
+                    while conn is None and time.monotonic() < deadline:
+                        try:
+                            conn = sock.accept()[0]
+                        except TimeoutError:
+                            if cli.poll() is not None:
+                                _, stderr = cli.communicate()
+                                raise AssertionError(f'bitcoin-cli exited before connecting: {stderr.decode()}')
+                    assert conn is not None
+                    with conn:
+                        conn.settimeout(5)
+                        request = b''
+                        while b'\r\n\r\n' not in request:
+                            chunk = conn.recv(4096)
+                            assert chunk
+                            request += chunk
+                        conn.sendall(b'HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n')
+                    cli.communicate(timeout=5)
+                finally:
+                    if cli.poll() is None:
+                        cli.kill()
+                        cli.wait()
+                user, password = get_auth_cookie(self.nodes[0].datadir_path, self.chain)
+                credential_captured = f'Authorization: Basic {str_to_b64str(f"{user}:{password}")}\r\n'.encode() in request
+                self.stop_node(0)
+            except FailedToStartError as e:
+                started = False
+                error = str(e)
+                self.cleanup_partially_started_nodes()
+        self.nodes[0].rpchost = None
+
+        assert_equal(started, True)  # TODO: an occupied RPC listener must abort startup to protect credentials
+        assert_equal(credential_captured, True)  # TODO: a client credential must not reach another process's listener
 
     def run_allowip_test(self, allow_ips, rpchost, rpcport):
         '''
@@ -124,6 +187,9 @@ class RPCBindTest(BitcoinTestFramework):
         self.defaultport = rpc_port(0)
 
         if not self.options.run_nonloopback:
+            if not self.options.run_ipv4:
+                for explicit_binds in [False, True]:
+                    self.run_partial_bind_test(explicit_binds)
             self._run_loopback_tests()
             if self.options.run_ipv4:
                 self.run_invalid_bind_test(['127.0.0.1'], ['127.0.0.1:notaport', '127.0.0.1:-18443', '127.0.0.1:0', '127.0.0.1:65536'])
@@ -140,6 +206,8 @@ class RPCBindTest(BitcoinTestFramework):
         if self.options.run_ipv4:
             # check only IPv4 localhost (explicit)
             self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1'],
+                [('127.0.0.1', self.defaultport)])
+            self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1', '127.0.0.1'],
                 [('127.0.0.1', self.defaultport)])
             # check only IPv4 localhost (explicit) with alternative port
             self.run_bind_test(['127.0.0.1'], '127.0.0.1:32171', ['127.0.0.1:32171'],


### PR DESCRIPTION
#### Problem

When bitcoind starts and the HTTP IPv4 listen address is occupied by another process, but the IPv6 address is available, the server fails open and generates a cookie file. When bitcoin-cli runs it picks up the cookie file and sends the credentials in plain text to the non-bitcoind process running on the default IPv4 port. An attacker can then use the credentials to commandeer bitcoind over IPv6.

#### Solution

*Safe defaults*:
* When running with default settings, require that the IPv4 bind succeeds.
* When `-rpcbind` is specified, require that all HTTP listen socket binds succeed (fail closed-behavior).

Node runners who only have IPv6 are now required to override `-rpcbind` to only specify the working interface if they were not doing so already.

The problem of bitcoin-cli sending the credentials to what could possibly be the wrong process remains **only in non-default setups**.

#### History

40b556d3742a1f65d67e2d4c760d0b13fe8be5b7 from 2015 switched the HTTP server from Boost Asio to LibEvent, and binding switched from an attempt at dual-binding IPv4+v6 and falling back to IPv4-only (rpcserver.cpp / `StartRPCThreads()`), to binding IPv4 *or* IPv6 (httpserver.cpp / `HTTPBindAddresses()`). **The current PR restores the prior behavior of IPv4 being mandatory.**

#14968 from 2018 was an attempt to change the behavior to require *all* binds to succeed. But it ran into issues with poor IPv6 support on CI.

#### Severity

This credential exfiltration attack requires capability to launch processes on the bitcoind host. If we are on the same account we can already read the cookie credentials off disk. So it's only really interesting when an attacker is on a different user account on the same host.