### PR TITLE
crypto: plug hardware optimized SHA256 into libsecp256k1's context

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(bitcoin_consensus STATIC EXCLUDE_FROM_ALL
   arith_uint256.cpp
   consensus/merkle.cpp
   consensus/tx_check.cpp
+  ecc_context.cpp
   hash.cpp
   primitives/block.cpp
   primitives/transaction.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   common/args.cpp
   common/bloom.cpp
   common/config.cpp
+  common/ecc_init.cpp
   common/init.cpp
   common/interfaces.cpp
   common/license_info.cpp

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(bench_bitcoin
   descriptors.cpp
   disconnected_transactions.cpp
   duplicate_inputs.cpp
+  ecc_sign_verify.cpp
   ellswift.cpp
   examples.cpp
   gcs_filter.cpp

--- a/src/bench/bip324_ecdh.cpp
+++ b/src/bench/bip324_ecdh.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <common/ecc_init.h>
 #include <key.h>
 #include <pubkey.h>
 #include <random.h>
@@ -15,7 +16,7 @@
 
 static void BIP324_ECDH(benchmark::Bench& bench)
 {
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
     FastRandomContext rng;
 
     std::array<std::byte, 32> key_data;

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -4,9 +4,9 @@
 
 #include <bench/bench.h>
 #include <coins.h>
+#include <common/ecc_init.h>
 #include <consensus/amount.h>
 #include <consensus/validation.h>
-#include <key.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -25,7 +25,7 @@
 // (https://github.com/bitcoin/bitcoin/issues/7883#issuecomment-224807484)
 static void CCoinsCaching(benchmark::Bench& bench)
 {
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
 
     FillableSigningProvider keystore;
     CCoinsViewCache coins{&CoinsViewEmpty::Get()};

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -4,8 +4,8 @@
 
 #include <bench/bench.h>
 #include <checkqueue.h>
+#include <common/ecc_init.h>
 #include <common/system.h>
-#include <key.h>
 #include <prevector.h>
 #include <random.h>
 #include <script/script.h>
@@ -28,7 +28,7 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::Bench& bench)
     // We shouldn't ever be running with the checkqueue on a single core machine.
     if (GetNumCores() <= 1) return;
 
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
 
     struct PrevectorJob {
         prevector<CScriptBase::STATIC_SIZE, uint8_t> p;

--- a/src/bench/descriptors.cpp
+++ b/src/bench/descriptors.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <key.h>
+#include <common/ecc_init.h>
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
@@ -18,7 +18,7 @@
 
 static void ExpandDescriptor(benchmark::Bench& bench)
 {
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
 
     constexpr std::string_view desc_str{"sh(wsh(multi(16,03669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0,0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600,0362a74e399c39ed5593852a30147f2959b56bb827dfa3e60e464b02ccf87dc5e8,0261345b53de74a4d721ef877c255429961b7e43714171ac06168d7e08c542a8b8,02da72e8b46901a65d4374fe6315538d8f368557dda3a1dcf9ea903f3afe7314c8,0318c82dd0b53fd3a932d16e0ba9e278fcc937c582d5781be626ff16e201f72286,0297ccef1ef99f9d73dec9ad37476ddb232f1238aff877af19e72ba04493361009,02e502cfd5c3f972fe9a3e2a18827820638f96b6f347e54d63deb839011fd5765d,03e687710f0e3ebe81c1037074da939d409c0025f17eb86adb9427d28f0f7ae0e9,02c04d3a5274952acdbc76987f3184b346a483d43be40874624b29e3692c1df5af,02ed06e0f418b5b43a7ec01d1d7d27290fa15f75771cb69b642a51471c29c84acd,036d46073cbb9ffee90473f3da429abc8de7f8751199da44485682a989a4bebb24,02f5d1ff7c9029a80a4e36b9a5497027ef7f3e73384a4a94fbfe7c4e9164eec8bc,02e41deffd1b7cce11cde209a781adcffdabd1b91c0ba0375857a2bfd9302419f3,02d76625f7956a7fc505ab02556c23ee72d832f1bac391bcd2d3abce5710a13d06,0399eb0a5487515802dc14544cf10b3666623762fbed2ec38a3975716e2c29c232)))"};
     const std::pair<int64_t, int64_t> range = {0, 1000};

--- a/src/bench/ecc_sign_verify.cpp
+++ b/src/bench/ecc_sign_verify.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <common/ecc_init.h>
+#include <key.h>
+#include <pubkey.h>
+#include <random.h>
+#include <span.h>
+#include <uint256.h>
+
+#include <cassert>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+// Verification is variable-time, so each iteration checks a different signature.
+static constexpr size_t NUM_SIGS{64};
+
+static CKey DeterministicKey(FastRandomContext& rng)
+{
+    const auto bytes{rng.randbytes<std::byte>(32)};
+    CKey key;
+    key.Set(bytes.begin(), bytes.end(), /*fCompressedIn=*/true);
+    assert(key.IsValid());
+    return key;
+}
+
+static void ECDSASign(benchmark::Bench& bench)
+{
+    const auto ecc_context{MakeContextECC()};
+    FastRandomContext rng{/*fDeterministic=*/true};
+    const CKey key{DeterministicKey(rng)};
+    uint256 msg;
+    std::vector<unsigned char> sig;
+
+    bench.minEpochIterations(200).run([&] {
+        msg = rng.rand256(); // new message each time so low-R grinding takes ~2 attempts on average
+        const bool ok{key.Sign(msg, sig)};
+        assert(ok);
+    });
+}
+
+static void SchnorrSign(benchmark::Bench& bench)
+{
+    const auto ecc_context{MakeContextECC()};
+    FastRandomContext rng{/*fDeterministic=*/true};
+    const KeyPair keypair{DeterministicKey(rng).ComputeKeyPair(/*merkle_root=*/nullptr)};
+    const uint256 aux{rng.rand256()};
+    uint256 msg;
+    std::vector<unsigned char> sig(64);
+
+    bench.minEpochIterations(200).run([&] {
+        msg = rng.rand256();
+        const bool ok{keypair.SignSchnorr(msg, sig, aux)};
+        assert(ok);
+    });
+}
+
+static void ECDSAVerify(benchmark::Bench& bench)
+{
+    const auto ecc_context{MakeContextECC()};
+    FastRandomContext rng{/*fDeterministic=*/true};
+    const CKey key{DeterministicKey(rng)};
+    const CPubKey pubkey{key.GetPubKey()};
+    std::vector<uint256> msgs;
+    std::vector<std::vector<unsigned char>> sigs;
+    for (size_t i{0}; i < NUM_SIGS; ++i) {
+        msgs.push_back(rng.rand256());
+        const bool ok{key.Sign(msgs.back(), sigs.emplace_back())};
+        assert(ok);
+    }
+
+    size_t i{0};
+    bench.minEpochIterations(200).run([&] {
+        const bool valid{pubkey.Verify(msgs[i % NUM_SIGS], sigs[i % NUM_SIGS])};
+        assert(valid);
+        ++i;
+    });
+}
+
+static void SchnorrVerify(benchmark::Bench& bench)
+{
+    const auto ecc_context{MakeContextECC()};
+    FastRandomContext rng{/*fDeterministic=*/true};
+    const CKey key{DeterministicKey(rng)};
+    const XOnlyPubKey pubkey{key.GetPubKey()};
+    const uint256 aux{rng.rand256()};
+    std::vector<uint256> msgs;
+    std::vector<std::vector<unsigned char>> sigs;
+    for (size_t i{0}; i < NUM_SIGS; ++i) {
+        msgs.push_back(rng.rand256());
+        sigs.emplace_back(64);
+        const bool ok{key.SignSchnorr(msgs.back(), sigs.back(), /*merkle_root=*/nullptr, aux)};
+        assert(ok);
+    }
+
+    size_t i{0};
+    bench.minEpochIterations(200).run([&] {
+        const bool valid{pubkey.VerifySchnorr(msgs[i % NUM_SIGS], sigs[i % NUM_SIGS])};
+        assert(valid);
+        ++i;
+    });
+}
+
+static void ECCContextCreate(benchmark::Bench& bench)
+{
+    bench.run([&] {
+        const auto ecc_context{MakeContextECC()};
+    });
+}
+
+BENCHMARK(ECDSASign);
+BENCHMARK(SchnorrSign);
+BENCHMARK(ECDSAVerify);
+BENCHMARK(SchnorrVerify);
+BENCHMARK(ECCContextCreate);

--- a/src/bench/ellswift.cpp
+++ b/src/bench/ellswift.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <common/ecc_init.h>
 #include <key.h>
 #include <pubkey.h>
 #include <random.h>
@@ -15,7 +16,7 @@
 
 static void EllSwiftCreate(benchmark::Bench& bench)
 {
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
 
     CKey key = GenerateRandomKey();
     uint256 entropy = GetRandHash();

--- a/src/bench/sign_transaction.cpp
+++ b/src/bench/sign_transaction.cpp
@@ -5,6 +5,7 @@
 #include <addresstype.h>
 #include <bench/bench.h>
 #include <coins.h>
+#include <common/ecc_init.h>
 #include <key.h>
 #include <primitives/transaction.h>
 #include <pubkey.h>
@@ -28,7 +29,7 @@ enum class InputType {
 
 static void SignTransactionSingleInput(benchmark::Bench& bench, InputType input_type)
 {
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
 
     FlatSigningProvider keystore;
     std::vector<CScript> prev_spks;
@@ -79,7 +80,7 @@ static void SignTransactionSchnorr(benchmark::Bench& bench) { SignTransactionSin
 static void SignSchnorrTapTweakBenchmark(benchmark::Bench& bench, bool use_null_merkle_root)
 {
     FastRandomContext rng;
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
 
     auto key = GenerateRandomKey();
     auto msg = rng.rand256();

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -5,6 +5,7 @@
 #include <addresstype.h>
 #include <bench/bench.h>
 #include <coins.h>
+#include <common/ecc_init.h>
 #include <key.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
@@ -45,7 +46,7 @@ static size_t ExpectedWitnessStackSize(ScriptType script_type)
 // Microbenchmark for verification of standard scripts.
 static void VerifyScriptBench(benchmark::Bench& bench, ScriptType script_type)
 {
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
 
     // Create deterministic key material needed for output script creation / signing
     CKey privkey;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -8,6 +8,7 @@
 #include <clientversion.h>
 #include <coins.h>
 #include <common/args.h>
+#include <common/ecc_init.h>
 #include <common/license_info.h>
 #include <common/system.h>
 #include <compat/compat.h>
@@ -696,7 +697,6 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 static void MutateTx(CMutableTransaction& tx, const std::string& command,
                      const std::string& commandVal)
 {
-    std::unique_ptr<ECC_Context> ecc;
 
     if (command == "nversion")
         MutateTxVersion(tx, commandVal);
@@ -716,10 +716,10 @@ static void MutateTx(CMutableTransaction& tx, const std::string& command,
     else if (command == "outaddr")
         MutateTxAddOutAddr(tx, commandVal);
     else if (command == "outpubkey") {
-        ecc.reset(new ECC_Context());
+        const auto ecc{MakeContextECC()};
         MutateTxAddOutPubKey(tx, commandVal);
     } else if (command == "outmultisig") {
-        ecc.reset(new ECC_Context());
+        const auto ecc{MakeContextECC()};
         MutateTxAddOutMultiSig(tx, commandVal);
     } else if (command == "outscript")
         MutateTxAddOutScript(tx, commandVal);
@@ -727,7 +727,7 @@ static void MutateTx(CMutableTransaction& tx, const std::string& command,
         MutateTxAddOutData(tx, commandVal);
 
     else if (command == "sign") {
-        ecc.reset(new ECC_Context());
+        const auto ecc{MakeContextECC()};
         MutateTxSign(tx, commandVal);
     }
 

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,11 +8,11 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/ecc_init.h>
 #include <common/license_info.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <interfaces/init.h>
-#include <key.h>
 #include <logging.h>
 #include <pubkey.h>
 #include <tinyformat.h>
@@ -124,7 +124,7 @@ MAIN_FUNCTION
         return EXIT_FAILURE;
     }
 
-    ECC_Context ecc_context{};
+    const auto ecc_context{MakeContextECC()};
     if (!wallet::WalletTool::ExecuteWalletToolFunc(args, command->command)) {
         return EXIT_FAILURE;
     }

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -8,6 +8,7 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/ecc_init.h>
 #include <common/init.h>
 #include <common/license_info.h>
 #include <common/system.h>
@@ -199,7 +200,7 @@ static bool AppInit(NodeContext& node)
         node.warnings = std::make_unique<node::Warnings>();
 
         node.kernel = std::make_unique<kernel::Context>();
-        node.ecc_context = std::make_unique<ECC_Context>();
+        node.ecc_context = MakeContextECC();
         if (!AppInitSanityChecks(*node.kernel))
         {
             // InitError will have been called with detailed error, which ends up on console

--- a/src/common/ecc_init.cpp
+++ b/src/common/ecc_init.cpp
@@ -4,6 +4,7 @@
 
 #include <common/ecc_init.h>
 
+#include <ecc_context.h>
 #include <key.h>
 #include <pubkey.h>
 #include <random.h>

--- a/src/common/ecc_init.cpp
+++ b/src/common/ecc_init.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/ecc_init.h>
+
+#include <key.h>
+#include <pubkey.h>
+
+#include <memory>
+
+bool ECC_InitSanityCheck() {
+    CKey key = GenerateRandomKey();
+    CPubKey pubkey = key.GetPubKey();
+    return key.VerifyPubKey(pubkey);
+}
+
+void ECC_ContextDeleter::operator()(ECC_Context* ctx) const { delete ctx; }
+
+std::unique_ptr<ECC_Context, ECC_ContextDeleter> MakeContextECC()
+{
+    return std::unique_ptr<ECC_Context, ECC_ContextDeleter>{new ECC_Context{}};
+}

--- a/src/common/ecc_init.cpp
+++ b/src/common/ecc_init.cpp
@@ -6,8 +6,12 @@
 
 #include <key.h>
 #include <pubkey.h>
+#include <random.h>
+#include <support/allocators/secure.h>
 
 #include <memory>
+#include <span>
+#include <vector>
 
 bool ECC_InitSanityCheck() {
     CKey key = GenerateRandomKey();
@@ -15,9 +19,16 @@ bool ECC_InitSanityCheck() {
     return key.VerifyPubKey(pubkey);
 }
 
+static std::vector<unsigned char, secure_allocator<unsigned char>> RandSeed32()
+{
+    std::vector<unsigned char, secure_allocator<unsigned char>> rng_seed(32);
+    GetRandBytes(rng_seed);
+    return rng_seed;
+}
+
 void ECC_ContextDeleter::operator()(ECC_Context* ctx) const { delete ctx; }
 
 std::unique_ptr<ECC_Context, ECC_ContextDeleter> MakeContextECC()
 {
-    return std::unique_ptr<ECC_Context, ECC_ContextDeleter>{new ECC_Context{}};
+    return std::unique_ptr<ECC_Context, ECC_ContextDeleter>{new ECC_Context{RandSeed32()}};
 }

--- a/src/common/ecc_init.h
+++ b/src/common/ecc_init.h
@@ -1,0 +1,21 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_ECC_INIT_H
+#define BITCOIN_COMMON_ECC_INIT_H
+
+#include <memory>
+
+class ECC_Context;
+struct ECC_ContextDeleter {
+    void operator()(ECC_Context*) const;
+};
+
+/** Check that required EC support is available at runtime. */
+bool ECC_InitSanityCheck();
+
+/** Initialize elliptic curve support. */
+std::unique_ptr<ECC_Context, ECC_ContextDeleter> MakeContextECC();
+
+#endif // BITCOIN_COMMON_ECC_INIT_H

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -779,3 +779,8 @@ void SHA256D64(unsigned char* out, const unsigned char* in, size_t blocks)
         --blocks;
     }
 }
+
+void SHA256Transform(uint32_t* state, const unsigned char* blocks64, size_t n_blocks)
+{
+    Transform(state, blocks64, n_blocks);
+}

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -50,4 +50,7 @@ std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implem
  */
 void SHA256D64(unsigned char* output, const unsigned char* input, size_t blocks);
 
+/** The implementation selected by SHA256AutoDetect(), or the portable one until it runs */
+void SHA256Transform(uint32_t* state, const unsigned char* blocks64, size_t n_blocks);
+
 #endif // BITCOIN_CRYPTO_SHA256_H

--- a/src/ecc_context.cpp
+++ b/src/ecc_context.cpp
@@ -4,6 +4,7 @@
 
 #include <ecc_context.h>
 
+#include <crypto/sha256.h>
 #include <secp256k1.h>
 
 #include <cassert>
@@ -22,6 +23,9 @@ static secp256k1_context* ECC_Start(std::span<const unsigned char> rng_seed32) {
 
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     assert(ctx != nullptr);
+
+    SHA256AutoDetect();
+    secp256k1_context_set_sha256_compression(ctx, SHA256Transform);
 
     if (!rng_seed32.empty()){
         // Pass in a random blinding seed to the secp256k1 context.

--- a/src/ecc_context.cpp
+++ b/src/ecc_context.cpp
@@ -17,6 +17,11 @@ secp256k1_context* GetSecp256k1SignContext()
     return g_ecc_context ? g_ecc_context->SignContext() : nullptr;
 }
 
+const secp256k1_context* GetSecp256k1VerifyContext()
+{
+    return g_ecc_context ? g_ecc_context->VerifyContext() : secp256k1_context_static;
+}
+
 /** Create an elliptic curve context. Provide rng seed for blinding factor if needed */
 static secp256k1_context* ECC_Start(std::span<const unsigned char> rng_seed32) {
     assert(rng_seed32.empty() || rng_seed32.size() == 32);
@@ -40,6 +45,7 @@ ECC_Context::ECC_Context(std::span<const unsigned char> rng_seed32)
 {
     assert(g_ecc_context == nullptr);
     m_sign_ctx = ECC_Start(rng_seed32);
+    m_verify_ctx = ECC_Start(/*rng_seed32=*/{});
     g_ecc_context = this;
 }
 
@@ -47,5 +53,6 @@ ECC_Context::~ECC_Context()
 {
     assert(g_ecc_context == this);
     g_ecc_context = nullptr;
+    secp256k1_context_destroy(m_verify_ctx);
     secp256k1_context_destroy(m_sign_ctx);
 }

--- a/src/ecc_context.cpp
+++ b/src/ecc_context.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <ecc_context.h>
+
+#include <secp256k1.h>
+
+#include <cassert>
+#include <span>
+
+static const ECC_Context* g_ecc_context = nullptr;
+
+secp256k1_context* GetSecp256k1SignContext()
+{
+    return g_ecc_context ? g_ecc_context->SignContext() : nullptr;
+}
+
+/** Create an elliptic curve context. Provide rng seed for blinding factor if needed */
+static secp256k1_context* ECC_Start(std::span<const unsigned char> rng_seed32) {
+    assert(rng_seed32.empty() || rng_seed32.size() == 32);
+
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+    assert(ctx != nullptr);
+
+    if (!rng_seed32.empty()){
+        // Pass in a random blinding seed to the secp256k1 context.
+        bool ret = secp256k1_context_randomize(ctx, rng_seed32.data());
+        assert(ret);
+    }
+
+    return ctx;
+}
+
+ECC_Context::ECC_Context(std::span<const unsigned char> rng_seed32)
+{
+    assert(g_ecc_context == nullptr);
+    m_sign_ctx = ECC_Start(rng_seed32);
+    g_ecc_context = this;
+}
+
+ECC_Context::~ECC_Context()
+{
+    assert(g_ecc_context == this);
+    g_ecc_context = nullptr;
+    secp256k1_context_destroy(m_sign_ctx);
+}

--- a/src/ecc_context.h
+++ b/src/ecc_context.h
@@ -1,0 +1,35 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ECC_CONTEXT_H
+#define BITCOIN_ECC_CONTEXT_H
+
+#include <span>
+
+struct secp256k1_context_struct;
+typedef struct secp256k1_context_struct secp256k1_context;
+
+/** Access the secp256k1 context used for signing and MuSig2 nonce generation. */
+secp256k1_context* GetSecp256k1SignContext();
+
+/**
+ * RAII class initializing and deinitializing global state for elliptic curve support.
+ * Only one instance may be initialized at a time.
+ */
+class ECC_Context
+{
+public:
+    explicit ECC_Context(std::span<const unsigned char> rng_seed32);
+    ECC_Context(const ECC_Context&) = delete;
+    ECC_Context& operator=(const ECC_Context&) = delete;
+
+    ~ECC_Context();
+
+    secp256k1_context* SignContext() const { return m_sign_ctx; }
+
+private:
+    secp256k1_context* m_sign_ctx{nullptr};
+};
+
+#endif // BITCOIN_ECC_CONTEXT_H

--- a/src/ecc_context.h
+++ b/src/ecc_context.h
@@ -13,6 +13,10 @@ typedef struct secp256k1_context_struct secp256k1_context;
 /** Access the secp256k1 context used for signing and MuSig2 nonce generation. */
 secp256k1_context* GetSecp256k1SignContext();
 
+/** Access the secp256k1 context used for verification: the ECC_Context's, or
+ *  secp256k1_context_static without one. */
+const secp256k1_context* GetSecp256k1VerifyContext();
+
 /**
  * RAII class initializing and deinitializing global state for elliptic curve support.
  * Only one instance may be initialized at a time.
@@ -27,9 +31,11 @@ public:
     ~ECC_Context();
 
     secp256k1_context* SignContext() const { return m_sign_ctx; }
+    const secp256k1_context* VerifyContext() const { return m_verify_ctx; }
 
 private:
     secp256k1_context* m_sign_ctx{nullptr};
+    secp256k1_context* m_verify_ctx{nullptr};
 };
 
 #endif // BITCOIN_ECC_CONTEXT_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,6 +16,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/ecc_init.h>
 #include <common/messages.h>
 #include <common/system.h>
 #include <compat/compat.h>
@@ -42,7 +43,6 @@
 #include <kernel/checks.h>
 #include <kernel/context.h>
 #include <kernel/notifications_interface.h>
-#include <key.h>
 #include <logging.h>
 #include <mapport.h>
 #include <net.h>

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(bitcoinkernel
   ../dbwrapper.cpp
   ../deploymentinfo.cpp
   ../deploymentstatus.cpp
+  ../ecc_context.cpp
   ../flatfile.cpp
   ../hash.cpp
   ../logging.cpp

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -17,6 +17,7 @@
 #include <secp256k1_schnorrsig.h>
 
 #include <algorithm>
+#include <span>
 
 static secp256k1_context* secp256k1_context_sign = nullptr;
 
@@ -464,40 +465,38 @@ secp256k1_context* GetSecp256k1SignContext()
     return secp256k1_context_sign;
 }
 
-/** Initialize the elliptic curve support. May not be called twice without calling ECC_Stop first. */
-static void ECC_Start() {
-    assert(secp256k1_context_sign == nullptr);
+/** Create an elliptic curve context. Provide rng seed for blinding factor if needed */
+static secp256k1_context* ECC_Start(std::span<const unsigned char> rng_seed32) {
+    assert(rng_seed32.empty() || rng_seed32.size() == 32);
 
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     assert(ctx != nullptr);
 
-    {
+    if (!rng_seed32.empty()){
         // Pass in a random blinding seed to the secp256k1 context.
-        std::vector<unsigned char, secure_allocator<unsigned char>> vseed(32);
-        GetRandBytes(vseed);
-        bool ret = secp256k1_context_randomize(ctx, vseed.data());
+        bool ret = secp256k1_context_randomize(ctx, rng_seed32.data());
         assert(ret);
     }
 
-    secp256k1_context_sign = ctx;
+    return ctx;
 }
 
-/** Deinitialize the elliptic curve support. No-op if ECC_Start wasn't called first. */
-static void ECC_Stop() {
-    secp256k1_context *ctx = secp256k1_context_sign;
-    secp256k1_context_sign = nullptr;
-
-    if (ctx) {
-        secp256k1_context_destroy(ctx);
-    }
+static std::vector<unsigned char, secure_allocator<unsigned char>> RandSeed32()
+{
+    std::vector<unsigned char, secure_allocator<unsigned char>> rng_seed(32);
+    GetRandBytes(rng_seed);
+    return rng_seed;
 }
 
 ECC_Context::ECC_Context()
 {
-    ECC_Start();
+    assert(secp256k1_context_sign == nullptr);
+    secp256k1_context_sign = ECC_Start(RandSeed32());
 }
 
 ECC_Context::~ECC_Context()
 {
-    ECC_Stop();
+    secp256k1_context* ctx = secp256k1_context_sign;
+    secp256k1_context_sign = nullptr;
+    secp256k1_context_destroy(ctx);
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -7,6 +7,7 @@
 
 #include <crypto/common.h>
 #include <crypto/hmac_sha512.h>
+#include <ecc_context.h>
 #include <hash.h>
 #include <random.h>
 
@@ -18,8 +19,6 @@
 
 #include <algorithm>
 #include <span>
-
-static const ECC_Context* g_ecc_context = nullptr;
 
 /** These functions are taken from the libsecp256k1 distribution and are very ugly. */
 
@@ -452,39 +451,4 @@ bool KeyPair::SignSchnorr(const uint256& hash, std::span<unsigned char> sig, con
     }
     if (!ret) memory_cleanse(sig.data(), sig.size());
     return ret;
-}
-
-secp256k1_context* GetSecp256k1SignContext()
-{
-    return g_ecc_context ? g_ecc_context->SignContext() : nullptr;
-}
-
-/** Create an elliptic curve context. Provide rng seed for blinding factor if needed */
-static secp256k1_context* ECC_Start(std::span<const unsigned char> rng_seed32) {
-    assert(rng_seed32.empty() || rng_seed32.size() == 32);
-
-    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
-    assert(ctx != nullptr);
-
-    if (!rng_seed32.empty()){
-        // Pass in a random blinding seed to the secp256k1 context.
-        bool ret = secp256k1_context_randomize(ctx, rng_seed32.data());
-        assert(ret);
-    }
-
-    return ctx;
-}
-
-ECC_Context::ECC_Context(std::span<const unsigned char> rng_seed32)
-{
-    assert(g_ecc_context == nullptr);
-    m_sign_ctx = ECC_Start(rng_seed32);
-    g_ecc_context = this;
-}
-
-ECC_Context::~ECC_Context()
-{
-    assert(g_ecc_context == this);
-    g_ecc_context = nullptr;
-    secp256k1_context_destroy(m_sign_ctx);
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -454,12 +454,6 @@ bool KeyPair::SignSchnorr(const uint256& hash, std::span<unsigned char> sig, con
     return ret;
 }
 
-bool ECC_InitSanityCheck() {
-    CKey key = GenerateRandomKey();
-    CPubKey pubkey = key.GetPubKey();
-    return key.VerifyPubKey(pubkey);
-}
-
 secp256k1_context* GetSecp256k1SignContext()
 {
     return g_ecc_context ? g_ecc_context->SignContext() : nullptr;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <span>
 
-static secp256k1_context* secp256k1_context_sign = nullptr;
+static const ECC_Context* g_ecc_context = nullptr;
 
 /** These functions are taken from the libsecp256k1 distribution and are very ugly. */
 
@@ -176,7 +176,7 @@ CPrivKey CKey::GetPrivKey() const {
     size_t seckeylen;
     seckey.resize(SIZE);
     seckeylen = SIZE;
-    ret = ec_seckey_export_der(secp256k1_context_sign, seckey.data(), &seckeylen, UCharCast(begin()), fCompressed);
+    ret = ec_seckey_export_der(GetSecp256k1SignContext(), seckey.data(), &seckeylen, UCharCast(begin()), fCompressed);
     assert(ret);
     seckey.resize(seckeylen);
     return seckey;
@@ -187,7 +187,7 @@ CPubKey CKey::GetPubKey() const {
     secp256k1_pubkey pubkey;
     size_t clen = CPubKey::SIZE;
     CPubKey result;
-    int ret = secp256k1_ec_pubkey_create(secp256k1_context_sign, &pubkey, UCharCast(begin()));
+    int ret = secp256k1_ec_pubkey_create(GetSecp256k1SignContext(), &pubkey, UCharCast(begin()));
     assert(ret);
     secp256k1_ec_pubkey_serialize(secp256k1_context_static, (unsigned char*)result.begin(), &clen, &pubkey, fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
     assert(result.size() == clen);
@@ -217,19 +217,19 @@ bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, bool gr
     WriteLE32(extra_entropy, test_case);
     secp256k1_ecdsa_signature sig;
     uint32_t counter = 0;
-    int ret = secp256k1_ecdsa_sign(secp256k1_context_sign, &sig, hash.begin(), UCharCast(begin()), secp256k1_nonce_function_rfc6979, (!grind && test_case) ? extra_entropy : nullptr);
+    int ret = secp256k1_ecdsa_sign(GetSecp256k1SignContext(), &sig, hash.begin(), UCharCast(begin()), secp256k1_nonce_function_rfc6979, (!grind && test_case) ? extra_entropy : nullptr);
 
     // Grind for low R
     while (ret && !SigHasLowR(&sig) && grind) {
         WriteLE32(extra_entropy, ++counter);
-        ret = secp256k1_ecdsa_sign(secp256k1_context_sign, &sig, hash.begin(), UCharCast(begin()), secp256k1_nonce_function_rfc6979, extra_entropy);
+        ret = secp256k1_ecdsa_sign(GetSecp256k1SignContext(), &sig, hash.begin(), UCharCast(begin()), secp256k1_nonce_function_rfc6979, extra_entropy);
     }
     assert(ret);
     secp256k1_ecdsa_signature_serialize_der(secp256k1_context_static, vchSig.data(), &nSigLen, &sig);
     vchSig.resize(nSigLen);
     // Additional verification step to prevent using a potentially corrupted signature
     secp256k1_pubkey pk;
-    ret = secp256k1_ec_pubkey_create(secp256k1_context_sign, &pk, UCharCast(begin()));
+    ret = secp256k1_ec_pubkey_create(GetSecp256k1SignContext(), &pk, UCharCast(begin()));
     assert(ret);
     ret = secp256k1_ecdsa_verify(secp256k1_context_static, &sig, hash.begin(), &pk);
     assert(ret);
@@ -255,7 +255,7 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) 
     vchSig.resize(CPubKey::COMPACT_SIGNATURE_SIZE);
     int rec = -1;
     secp256k1_ecdsa_recoverable_signature rsig;
-    int ret = secp256k1_ecdsa_sign_recoverable(secp256k1_context_sign, &rsig, hash.begin(), UCharCast(begin()), secp256k1_nonce_function_rfc6979, nullptr);
+    int ret = secp256k1_ecdsa_sign_recoverable(GetSecp256k1SignContext(), &rsig, hash.begin(), UCharCast(begin()), secp256k1_nonce_function_rfc6979, nullptr);
     assert(ret);
     ret = secp256k1_ecdsa_recoverable_signature_serialize_compact(secp256k1_context_static, &vchSig[1], &rec, &rsig);
     assert(ret);
@@ -263,7 +263,7 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) 
     vchSig[0] = 27 + rec + (fCompressed ? 4 : 0);
     // Additional verification step to prevent using a potentially corrupted signature
     secp256k1_pubkey epk, rpk;
-    ret = secp256k1_ec_pubkey_create(secp256k1_context_sign, &epk, UCharCast(begin()));
+    ret = secp256k1_ec_pubkey_create(GetSecp256k1SignContext(), &epk, UCharCast(begin()));
     assert(ret);
     ret = secp256k1_ecdsa_recover(secp256k1_context_static, &rpk, &rsig, hash.begin());
     assert(ret);
@@ -317,7 +317,7 @@ EllSwiftPubKey CKey::EllSwiftCreate(std::span<const std::byte> ent32) const
     assert(ent32.size() == 32);
     std::array<std::byte, EllSwiftPubKey::size()> encoded_pubkey;
 
-    auto success = secp256k1_ellswift_create(secp256k1_context_sign,
+    auto success = secp256k1_ellswift_create(GetSecp256k1SignContext(),
                                              UCharCast(encoded_pubkey.data()),
                                              keydata->data(),
                                              UCharCast(ent32.data()));
@@ -426,7 +426,7 @@ KeyPair::KeyPair(const CKey& key, const uint256* merkle_root)
     static_assert(std::tuple_size<KeyType>() == sizeof(secp256k1_keypair));
     MakeKeyPairData();
     auto keypair = reinterpret_cast<secp256k1_keypair*>(m_keypair->data());
-    bool success = secp256k1_keypair_create(secp256k1_context_sign, keypair, UCharCast(key.data()));
+    bool success = secp256k1_keypair_create(GetSecp256k1SignContext(), keypair, UCharCast(key.data()));
     if (success && merkle_root) {
         secp256k1_xonly_pubkey pubkey;
         unsigned char pubkey_bytes[32];
@@ -443,7 +443,7 @@ bool KeyPair::SignSchnorr(const uint256& hash, std::span<unsigned char> sig, con
     assert(sig.size() == 64);
     if (!IsValid()) return false;
     auto keypair = reinterpret_cast<const secp256k1_keypair*>(m_keypair->data());
-    bool ret = secp256k1_schnorrsig_sign32(secp256k1_context_sign, sig.data(), hash.data(), keypair, aux.data());
+    bool ret = secp256k1_schnorrsig_sign32(GetSecp256k1SignContext(), sig.data(), hash.data(), keypair, aux.data());
     if (ret) {
         // Additional verification step to prevent using a potentially corrupted signature
         secp256k1_xonly_pubkey pubkey_verify;
@@ -462,7 +462,7 @@ bool ECC_InitSanityCheck() {
 
 secp256k1_context* GetSecp256k1SignContext()
 {
-    return secp256k1_context_sign;
+    return g_ecc_context ? g_ecc_context->SignContext() : nullptr;
 }
 
 /** Create an elliptic curve context. Provide rng seed for blinding factor if needed */
@@ -490,13 +490,14 @@ static std::vector<unsigned char, secure_allocator<unsigned char>> RandSeed32()
 
 ECC_Context::ECC_Context()
 {
-    assert(secp256k1_context_sign == nullptr);
-    secp256k1_context_sign = ECC_Start(RandSeed32());
+    assert(g_ecc_context == nullptr);
+    m_sign_ctx = ECC_Start(RandSeed32());
+    g_ecc_context = this;
 }
 
 ECC_Context::~ECC_Context()
 {
-    secp256k1_context* ctx = secp256k1_context_sign;
-    secp256k1_context_sign = nullptr;
-    secp256k1_context_destroy(ctx);
+    assert(g_ecc_context == this);
+    g_ecc_context = nullptr;
+    secp256k1_context_destroy(m_sign_ctx);
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -333,7 +333,7 @@ ECDHSecret CKey::ComputeBIP324ECDHSecret(const EllSwiftPubKey& their_ellswift, c
     ECDHSecret output;
     // BIP324 uses the initiator as party A, and the responder as party B. Remap the inputs
     // accordingly:
-    bool success = secp256k1_ellswift_xdh(secp256k1_context_static,
+    bool success = secp256k1_ellswift_xdh(GetSecp256k1SignContext(),
                                           UCharCast(output.data()),
                                           UCharCast(initiating ? our_ellswift.data() : their_ellswift.data()),
                                           UCharCast(initiating ? their_ellswift.data() : our_ellswift.data()),
@@ -447,7 +447,7 @@ bool KeyPair::SignSchnorr(const uint256& hash, std::span<unsigned char> sig, con
         // Additional verification step to prevent using a potentially corrupted signature
         secp256k1_xonly_pubkey pubkey_verify;
         ret = secp256k1_keypair_xonly_pub(secp256k1_context_static, &pubkey_verify, nullptr, keypair);
-        ret &= secp256k1_schnorrsig_verify(secp256k1_context_static, sig.data(), hash.begin(), 32, &pubkey_verify);
+        ret &= secp256k1_schnorrsig_verify(GetSecp256k1VerifyContext(), sig.data(), hash.begin(), 32, &pubkey_verify);
     }
     if (!ret) memory_cleanse(sig.data(), sig.size());
     return ret;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -475,17 +475,10 @@ static secp256k1_context* ECC_Start(std::span<const unsigned char> rng_seed32) {
     return ctx;
 }
 
-static std::vector<unsigned char, secure_allocator<unsigned char>> RandSeed32()
-{
-    std::vector<unsigned char, secure_allocator<unsigned char>> rng_seed(32);
-    GetRandBytes(rng_seed);
-    return rng_seed;
-}
-
-ECC_Context::ECC_Context()
+ECC_Context::ECC_Context(std::span<const unsigned char> rng_seed32)
 {
     assert(g_ecc_context == nullptr);
-    m_sign_ctx = ECC_Start(RandSeed32());
+    m_sign_ctx = ECC_Start(rng_seed32);
     g_ecc_context = this;
 }
 

--- a/src/key.h
+++ b/src/key.h
@@ -338,6 +338,9 @@ class ECC_Context
 {
 public:
     ECC_Context();
+    ECC_Context(const ECC_Context&) = delete;
+    ECC_Context& operator=(const ECC_Context&) = delete;
+
     ~ECC_Context();
 };
 

--- a/src/key.h
+++ b/src/key.h
@@ -331,7 +331,7 @@ secp256k1_context* GetSecp256k1SignContext();
 class ECC_Context
 {
 public:
-    ECC_Context();
+    explicit ECC_Context(std::span<const unsigned char> rng_seed32);
     ECC_Context(const ECC_Context&) = delete;
     ECC_Context& operator=(const ECC_Context&) = delete;
 

--- a/src/key.h
+++ b/src/key.h
@@ -321,9 +321,6 @@ private:
     }
 };
 
-/** Check that required EC support is available at runtime. */
-bool ECC_InitSanityCheck();
-
 /** Access the secp256k1 context used for signing and MuSig2 nonce generation. */
 secp256k1_context* GetSecp256k1SignContext();
 

--- a/src/key.h
+++ b/src/key.h
@@ -330,9 +330,6 @@ secp256k1_context* GetSecp256k1SignContext();
 /**
  * RAII class initializing and deinitializing global state for elliptic curve support.
  * Only one instance may be initialized at a time.
- *
- * In the future global ECC state could be removed, and this class could contain
- * state and be passed as an argument to ECC key functions.
  */
 class ECC_Context
 {
@@ -342,6 +339,11 @@ public:
     ECC_Context& operator=(const ECC_Context&) = delete;
 
     ~ECC_Context();
+
+    secp256k1_context* SignContext() const { return m_sign_ctx; }
+
+private:
+    secp256k1_context* m_sign_ctx{nullptr};
 };
 
 #endif // BITCOIN_KEY_H

--- a/src/key.h
+++ b/src/key.h
@@ -18,9 +18,6 @@
 #include <utility>
 #include <vector>
 
-struct secp256k1_context_struct;
-typedef struct secp256k1_context_struct secp256k1_context;
-
 /**
  * CPrivKey is a serialized private key, with all parameters included
  * (SIZE bytes)
@@ -319,28 +316,6 @@ private:
     {
         m_keypair.reset();
     }
-};
-
-/** Access the secp256k1 context used for signing and MuSig2 nonce generation. */
-secp256k1_context* GetSecp256k1SignContext();
-
-/**
- * RAII class initializing and deinitializing global state for elliptic curve support.
- * Only one instance may be initialized at a time.
- */
-class ECC_Context
-{
-public:
-    explicit ECC_Context(std::span<const unsigned char> rng_seed32);
-    ECC_Context(const ECC_Context&) = delete;
-    ECC_Context& operator=(const ECC_Context&) = delete;
-
-    ~ECC_Context();
-
-    secp256k1_context* SignContext() const { return m_sign_ctx; }
-
-private:
-    secp256k1_context* m_sign_ctx{nullptr};
 };
 
 #endif // BITCOIN_KEY_H

--- a/src/musig.cpp
+++ b/src/musig.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <musig.h>
+#include <ecc_context.h>
 #include <key.h>
 #include <random.h>
 #include <support/allocators/secure.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -9,7 +9,6 @@
 #include <interfaces/chain.h>
 #include <interfaces/mining.h>
 #include <kernel/context.h>
-#include <key.h>
 #include <net.h>
 #include <net_processing.h>
 #include <netgroup.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_NODE_CONTEXT_H
 #define BITCOIN_NODE_CONTEXT_H
 
+#include <common/ecc_init.h>
 #include <node/mining_types.h>
 
 #include <atomic>
@@ -24,7 +25,6 @@ class ValidationSignals;
 class CScheduler;
 class CTxMemPool;
 class ChainstateManager;
-class ECC_Context;
 class NetGroupManager;
 class PeerManager;
 class TorController;
@@ -59,7 +59,7 @@ class Warnings;
 struct NodeContext {
     //! libbitcoin_kernel context
     std::unique_ptr<kernel::Context> kernel;
-    std::unique_ptr<ECC_Context> ecc_context;
+    std::unique_ptr<ECC_Context, ECC_ContextDeleter> ecc_context;
     //! Init interface for initializing current process and connecting to other processes.
     interfaces::Init* init{nullptr};
     //! Function to request a shutdown.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -10,6 +10,7 @@
 #include <chainparams.h>
 #include <coins.h>
 #include <common/args.h>
+#include <common/ecc_init.h>
 #include <common/settings.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>
@@ -25,7 +26,6 @@
 #include <interfaces/rpc.h>
 #include <interfaces/types.h>
 #include <kernel/context.h>
-#include <key.h>
 #include <logging.h>
 #include <mapport.h>
 #include <net.h>
@@ -133,7 +133,7 @@ public:
 
         m_context->warnings = std::make_unique<node::Warnings>();
         m_context->kernel = std::make_unique<kernel::Context>();
-        m_context->ecc_context = std::make_unique<ECC_Context>();
+        m_context->ecc_context = MakeContextECC();
         if (!AppInitSanityChecks(*m_context->kernel)) return false;
 
         if (!AppInitLockDirectories()) return false;

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -5,6 +5,7 @@
 
 #include <pubkey.h>
 
+#include <ecc_context.h>
 #include <hash.h>
 #include <secp256k1.h>
 #include <secp256k1_ellswift.h>
@@ -50,7 +51,7 @@ int ecdsa_signature_parse_der_lax(secp256k1_ecdsa_signature* sig, const unsigned
     int overflow = 0;
 
     /* Hack to initialize sig with a correctly-parsed but invalid signature. */
-    secp256k1_ecdsa_signature_parse_compact(secp256k1_context_static, sig, tmpsig);
+    secp256k1_ecdsa_signature_parse_compact(GetSecp256k1VerifyContext(), sig, tmpsig);
 
     /* Sequence tag byte */
     if (pos == inputlen || input[pos] != 0x30) {
@@ -173,13 +174,13 @@ int ecdsa_signature_parse_der_lax(secp256k1_ecdsa_signature* sig, const unsigned
     }
 
     if (!overflow) {
-        overflow = !secp256k1_ecdsa_signature_parse_compact(secp256k1_context_static, sig, tmpsig);
+        overflow = !secp256k1_ecdsa_signature_parse_compact(GetSecp256k1VerifyContext(), sig, tmpsig);
     }
     if (overflow) {
         /* Overwrite the result again with a correctly-parsed but invalid
            signature if parsing failed. */
         memset(tmpsig, 0, 64);
-        secp256k1_ecdsa_signature_parse_compact(secp256k1_context_static, sig, tmpsig);
+        secp256k1_ecdsa_signature_parse_compact(GetSecp256k1VerifyContext(), sig, tmpsig);
     }
     return 1;
 }
@@ -230,15 +231,15 @@ CPubKey XOnlyPubKey::GetEvenCorrespondingCPubKey() const
 bool XOnlyPubKey::IsFullyValid() const
 {
     secp256k1_xonly_pubkey pubkey;
-    return secp256k1_xonly_pubkey_parse(secp256k1_context_static, &pubkey, m_keydata.data());
+    return secp256k1_xonly_pubkey_parse(GetSecp256k1VerifyContext(), &pubkey, m_keydata.data());
 }
 
 bool XOnlyPubKey::VerifySchnorr(const uint256& msg, std::span<const unsigned char> sigbytes) const
 {
     assert(sigbytes.size() == 64);
     secp256k1_xonly_pubkey pubkey;
-    if (!secp256k1_xonly_pubkey_parse(secp256k1_context_static, &pubkey, m_keydata.data())) return false;
-    return secp256k1_schnorrsig_verify(secp256k1_context_static, sigbytes.data(), msg.begin(), 32, &pubkey);
+    if (!secp256k1_xonly_pubkey_parse(GetSecp256k1VerifyContext(), &pubkey, m_keydata.data())) return false;
+    return secp256k1_schnorrsig_verify(GetSecp256k1VerifyContext(), sigbytes.data(), msg.begin(), 32, &pubkey);
 }
 
 static const HashWriter HASHER_TAPTWEAK{TaggedHash("TapTweak")};
@@ -257,23 +258,23 @@ uint256 XOnlyPubKey::ComputeTapTweakHash(const uint256* merkle_root) const
 bool XOnlyPubKey::CheckTapTweak(const XOnlyPubKey& internal, const uint256& merkle_root, bool parity) const
 {
     secp256k1_xonly_pubkey internal_key;
-    if (!secp256k1_xonly_pubkey_parse(secp256k1_context_static, &internal_key, internal.data())) return false;
+    if (!secp256k1_xonly_pubkey_parse(GetSecp256k1VerifyContext(), &internal_key, internal.data())) return false;
     uint256 tweak = internal.ComputeTapTweakHash(&merkle_root);
-    return secp256k1_xonly_pubkey_tweak_add_check(secp256k1_context_static, m_keydata.begin(), parity, &internal_key, tweak.begin());
+    return secp256k1_xonly_pubkey_tweak_add_check(GetSecp256k1VerifyContext(), m_keydata.begin(), parity, &internal_key, tweak.begin());
 }
 
 std::optional<std::pair<XOnlyPubKey, bool>> XOnlyPubKey::CreateTapTweak(const uint256* merkle_root) const
 {
     secp256k1_xonly_pubkey base_point;
-    if (!secp256k1_xonly_pubkey_parse(secp256k1_context_static, &base_point, data())) return std::nullopt;
+    if (!secp256k1_xonly_pubkey_parse(GetSecp256k1VerifyContext(), &base_point, data())) return std::nullopt;
     secp256k1_pubkey out;
     uint256 tweak = ComputeTapTweakHash(merkle_root);
-    if (!secp256k1_xonly_pubkey_tweak_add(secp256k1_context_static, &out, &base_point, tweak.data())) return std::nullopt;
+    if (!secp256k1_xonly_pubkey_tweak_add(GetSecp256k1VerifyContext(), &out, &base_point, tweak.data())) return std::nullopt;
     int parity = -1;
     std::pair<XOnlyPubKey, bool> ret;
     secp256k1_xonly_pubkey out_xonly;
-    if (!secp256k1_xonly_pubkey_from_pubkey(secp256k1_context_static, &out_xonly, &parity, &out)) return std::nullopt;
-    secp256k1_xonly_pubkey_serialize(secp256k1_context_static, ret.first.begin(), &out_xonly);
+    if (!secp256k1_xonly_pubkey_from_pubkey(GetSecp256k1VerifyContext(), &out_xonly, &parity, &out)) return std::nullopt;
+    secp256k1_xonly_pubkey_serialize(GetSecp256k1VerifyContext(), ret.first.begin(), &out_xonly);
     assert(parity == 0 || parity == 1);
     ret.second = parity;
     return ret;
@@ -285,7 +286,7 @@ bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchS
         return false;
     secp256k1_pubkey pubkey;
     secp256k1_ecdsa_signature sig;
-    if (!secp256k1_ec_pubkey_parse(secp256k1_context_static, &pubkey, vch, size())) {
+    if (!secp256k1_ec_pubkey_parse(GetSecp256k1VerifyContext(), &pubkey, vch, size())) {
         return false;
     }
     if (!ecdsa_signature_parse_der_lax(&sig, vchSig.data(), vchSig.size())) {
@@ -293,8 +294,8 @@ bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchS
     }
     /* libsecp256k1's ECDSA verification requires lower-S signatures, which have
      * not historically been enforced in Bitcoin, so normalize them first. */
-    secp256k1_ecdsa_signature_normalize(secp256k1_context_static, &sig, &sig);
-    return secp256k1_ecdsa_verify(secp256k1_context_static, &sig, hash.begin(), &pubkey);
+    secp256k1_ecdsa_signature_normalize(GetSecp256k1VerifyContext(), &sig, &sig);
+    return secp256k1_ecdsa_verify(GetSecp256k1VerifyContext(), &sig, hash.begin(), &pubkey);
 }
 
 bool CPubKey::RecoverCompact(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
@@ -304,15 +305,15 @@ bool CPubKey::RecoverCompact(const uint256 &hash, const std::vector<unsigned cha
     bool fComp = ((vchSig[0] - 27) & 4) != 0;
     secp256k1_pubkey pubkey;
     secp256k1_ecdsa_recoverable_signature sig;
-    if (!secp256k1_ecdsa_recoverable_signature_parse_compact(secp256k1_context_static, &sig, &vchSig[1], recid)) {
+    if (!secp256k1_ecdsa_recoverable_signature_parse_compact(GetSecp256k1VerifyContext(), &sig, &vchSig[1], recid)) {
         return false;
     }
-    if (!secp256k1_ecdsa_recover(secp256k1_context_static, &pubkey, &sig, hash.begin())) {
+    if (!secp256k1_ecdsa_recover(GetSecp256k1VerifyContext(), &pubkey, &sig, hash.begin())) {
         return false;
     }
     unsigned char pub[SIZE];
     size_t publen = SIZE;
-    secp256k1_ec_pubkey_serialize(secp256k1_context_static, pub, &publen, &pubkey, fComp ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+    secp256k1_ec_pubkey_serialize(GetSecp256k1VerifyContext(), pub, &publen, &pubkey, fComp ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
     Set(pub, pub + publen);
     return true;
 }
@@ -321,19 +322,19 @@ bool CPubKey::IsFullyValid() const {
     if (!IsValid())
         return false;
     secp256k1_pubkey pubkey;
-    return secp256k1_ec_pubkey_parse(secp256k1_context_static, &pubkey, vch, size());
+    return secp256k1_ec_pubkey_parse(GetSecp256k1VerifyContext(), &pubkey, vch, size());
 }
 
 bool CPubKey::Decompress() {
     if (!IsValid())
         return false;
     secp256k1_pubkey pubkey;
-    if (!secp256k1_ec_pubkey_parse(secp256k1_context_static, &pubkey, vch, size())) {
+    if (!secp256k1_ec_pubkey_parse(GetSecp256k1VerifyContext(), &pubkey, vch, size())) {
         return false;
     }
     unsigned char pub[SIZE];
     size_t publen = SIZE;
-    secp256k1_ec_pubkey_serialize(secp256k1_context_static, pub, &publen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
+    secp256k1_ec_pubkey_serialize(GetSecp256k1VerifyContext(), pub, &publen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
     Set(pub, pub + publen);
     return true;
 }
@@ -349,15 +350,15 @@ bool CPubKey::Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChi
         memcpy(bip32_tweak_out->begin(), out, 32);
     }
     secp256k1_pubkey pubkey;
-    if (!secp256k1_ec_pubkey_parse(secp256k1_context_static, &pubkey, vch, size())) {
+    if (!secp256k1_ec_pubkey_parse(GetSecp256k1VerifyContext(), &pubkey, vch, size())) {
         return false;
     }
-    if (!secp256k1_ec_pubkey_tweak_add(secp256k1_context_static, &pubkey, out)) {
+    if (!secp256k1_ec_pubkey_tweak_add(GetSecp256k1VerifyContext(), &pubkey, out)) {
         return false;
     }
     unsigned char pub[COMPRESSED_SIZE];
     size_t publen = COMPRESSED_SIZE;
-    secp256k1_ec_pubkey_serialize(secp256k1_context_static, pub, &publen, &pubkey, SECP256K1_EC_COMPRESSED);
+    secp256k1_ec_pubkey_serialize(GetSecp256k1VerifyContext(), pub, &publen, &pubkey, SECP256K1_EC_COMPRESSED);
     pubkeyChild.Set(pub, pub + publen);
     return true;
 }
@@ -371,12 +372,12 @@ EllSwiftPubKey::EllSwiftPubKey(std::span<const std::byte> ellswift) noexcept
 CPubKey EllSwiftPubKey::Decode() const
 {
     secp256k1_pubkey pubkey;
-    secp256k1_ellswift_decode(secp256k1_context_static, &pubkey, UCharCast(m_pubkey.data()));
+    secp256k1_ellswift_decode(GetSecp256k1VerifyContext(), &pubkey, UCharCast(m_pubkey.data()));
 
     size_t sz = CPubKey::COMPRESSED_SIZE;
     std::array<uint8_t, CPubKey::COMPRESSED_SIZE> vch_bytes;
 
-    secp256k1_ec_pubkey_serialize(secp256k1_context_static, vch_bytes.data(), &sz, &pubkey, SECP256K1_EC_COMPRESSED);
+    secp256k1_ec_pubkey_serialize(GetSecp256k1VerifyContext(), vch_bytes.data(), &sz, &pubkey, SECP256K1_EC_COMPRESSED);
     assert(sz == vch_bytes.size());
 
     return CPubKey{vch_bytes.begin(), vch_bytes.end()};
@@ -425,5 +426,5 @@ bool CExtPubKey::Derive(CExtPubKey &out, unsigned int _nChild, uint256* bip32_tw
     if (!ecdsa_signature_parse_der_lax(&sig, vchSig.data(), vchSig.size())) {
         return false;
     }
-    return (!secp256k1_ecdsa_signature_normalize(secp256k1_context_static, nullptr, &sig));
+    return (!secp256k1_ecdsa_signature_normalize(GetSecp256k1VerifyContext(), nullptr, &sig));
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(test_bitcoin
   denialofservice_tests.cpp
   descriptor_tests.cpp
   disconnected_transactions.cpp
+  ecc_context_tests.cpp
   fees_util_tests.cpp
   feefrac_tests.cpp
   feerounder_tests.cpp

--- a/src/test/ecc_context_tests.cpp
+++ b/src/test/ecc_context_tests.cpp
@@ -3,13 +3,17 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/ecc_init.h>
+#include <crypto/sha256.h>
 #include <ecc_context.h>
 #include <key.h>
+#include <pubkey.h>
 #include <secp256k1.h>
 #include <uint256.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -32,6 +36,27 @@ BOOST_AUTO_TEST_CASE(context_lifecycle)
     }
     BOOST_CHECK(GetSecp256k1SignContext() == nullptr);
     BOOST_CHECK(GetSecp256k1VerifyContext() == secp256k1_context_static);
+}
+
+int g_sha256_transform_calls{0};
+void CountingSHA256Transform(uint32_t* state, const unsigned char* blocks64, size_t n_blocks)
+{
+    ++g_sha256_transform_calls;
+    SHA256Transform(state, blocks64, n_blocks);
+}
+
+BOOST_AUTO_TEST_CASE(verify_context_sha256)
+{
+    const auto ecc_context{MakeContextECC()};
+    const CKey key{GenerateRandomKey()};
+    std::vector<unsigned char> sig(64);
+    BOOST_REQUIRE(key.SignSchnorr(uint256::ONE, sig, /*merkle_root=*/nullptr, uint256::ZERO));
+
+    secp256k1_context_set_sha256_compression(const_cast<secp256k1_context*>(ecc_context->VerifyContext()), CountingSHA256Transform);
+
+    g_sha256_transform_calls = 0;
+    BOOST_CHECK(XOnlyPubKey{key.GetPubKey()}.VerifySchnorr(uint256::ONE, sig));
+    BOOST_CHECK_GT(g_sha256_transform_calls, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ecc_context_tests.cpp
+++ b/src/test/ecc_context_tests.cpp
@@ -5,6 +5,7 @@
 #include <common/ecc_init.h>
 #include <ecc_context.h>
 #include <key.h>
+#include <secp256k1.h>
 #include <uint256.h>
 
 #include <boost/test/unit_test.hpp>
@@ -17,14 +18,20 @@ BOOST_AUTO_TEST_SUITE(ecc_context_tests)
 BOOST_AUTO_TEST_CASE(context_lifecycle)
 {
     BOOST_CHECK(GetSecp256k1SignContext() == nullptr);
+    BOOST_CHECK(GetSecp256k1VerifyContext() == secp256k1_context_static);
     {
         const auto ecc_context{MakeContextECC()};
-        BOOST_CHECK(GetSecp256k1SignContext() != nullptr);
         BOOST_CHECK(GetSecp256k1SignContext() == ecc_context->SignContext());
+        BOOST_CHECK(GetSecp256k1VerifyContext() == ecc_context->VerifyContext());
+        BOOST_CHECK(ecc_context->SignContext() != nullptr);
+        BOOST_CHECK(ecc_context->VerifyContext() != nullptr);
+        BOOST_CHECK(ecc_context->VerifyContext() != ecc_context->SignContext());
+        BOOST_CHECK(ecc_context->VerifyContext() != secp256k1_context_static);
         std::vector<unsigned char> sig;
         BOOST_CHECK(GenerateRandomKey().Sign(uint256::ONE, sig));
     }
     BOOST_CHECK(GetSecp256k1SignContext() == nullptr);
+    BOOST_CHECK(GetSecp256k1VerifyContext() == secp256k1_context_static);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ecc_context_tests.cpp
+++ b/src/test/ecc_context_tests.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2026-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/ecc_init.h>
+#include <ecc_context.h>
+#include <key.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(ecc_context_tests)
+
+BOOST_AUTO_TEST_CASE(context_lifecycle)
+{
+    BOOST_CHECK(GetSecp256k1SignContext() == nullptr);
+    {
+        const auto ecc_context{MakeContextECC()};
+        BOOST_CHECK(GetSecp256k1SignContext() != nullptr);
+        BOOST_CHECK(GetSecp256k1SignContext() == ecc_context->SignContext());
+        std::vector<unsigned char> sig;
+        BOOST_CHECK(GenerateRandomKey().Sign(uint256::ONE, sig));
+    }
+    BOOST_CHECK(GetSecp256k1SignContext() == nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/bip324.cpp
+++ b/src/test/fuzz/bip324.cpp
@@ -4,6 +4,7 @@
 
 #include <bip324.h>
 #include <chainparams.h>
+#include <common/ecc_init.h>
 #include <random.h>
 #include <span.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -18,7 +19,7 @@ namespace {
 
 void Initialize()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     SelectParams(ChainType::MAIN);
 }
 

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/ecc_init.h>
 #include <key_io.h>
 #include <pubkey.h>
 #include <script/descriptor.h>
@@ -73,7 +74,7 @@ static void TestDescriptor(const Descriptor& desc, FlatSigningProvider& sig_prov
 
 void initialize_descriptor_parse()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     SelectParams(ChainType::MAIN);
 }
 

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/ecc_init.h>
 #include <key.h>
 #include <key_io.h>
 #include <outputtype.h>
@@ -33,7 +34,7 @@
 
 void initialize_key()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     SelectParams(ChainType::REGTEST);
 }
 

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/ecc_init.h>
 #include <key_io.h>
 #include <test/fuzz/fuzz.h>
 #include <util/chaintype.h>
@@ -14,7 +15,7 @@
 
 void initialize_key_io()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     SelectParams(ChainType::MAIN);
 }
 

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/ecc_init.h>
 #include <common/signmessage.h>
 #include <key_io.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -19,7 +20,7 @@
 
 void initialize_message()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     SelectParams(ChainType::REGTEST);
 }
 

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/ecc_init.h>
 #include <core_io.h>
 #include <hash.h>
 #include <key.h>
@@ -1196,7 +1197,7 @@ void TestNode(const MsCtx script_ctx, const std::optional<Node>& node, FuzzedDat
 
 void FuzzInit()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     TEST_DATA.Init();
 }
 

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/ecc_init.h>
 #include <hash.h>
 #include <net.h>
 #include <netmessagemaker.h>
@@ -25,7 +26,7 @@ auto g_all_messages = ALL_NET_MESSAGE_TYPES;
 
 void initialize_p2p_transport_serialization()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     SelectParams(ChainType::REGTEST);
     std::sort(g_all_messages.begin(), g_all_messages.end());
 }

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -4,6 +4,7 @@
 
 #include <test/fuzz/fuzz.h>
 
+#include <common/ecc_init.h>
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
@@ -186,7 +187,10 @@ void Test(const std::string& str)
     }
 }
 
-void test_init() {}
+void test_init()
+{
+    static const auto ecc_context{MakeContextECC()};
+}
 
 FUZZ_TARGET(script_assets_test_minimizer, .init = test_init, .hidden = true)
 {

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/ecc_init.h>
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -24,7 +25,12 @@ static SpanReader& operator>>(SpanReader& ds, script_verify_flags& f)
     return ds;
 }
 
-FUZZ_TARGET(script_flags)
+void initialize_script_flags()
+{
+    static const auto ecc_context{MakeContextECC()};
+}
+
+FUZZ_TARGET(script_flags, .init = initialize_script_flags)
 {
     if (buffer.size() > 100'000) return;
     SpanReader ds{buffer};

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/ecc_init.h>
 #include <key.h>
 #include <psbt.h>
 #include <pubkey.h>
@@ -27,7 +28,7 @@
 
 void initialize_script_sign()
 {
-    static ECC_Context ecc_context{};
+    static const auto ecc_context{MakeContextECC()};
     SelectParams(ChainType::REGTEST);
 }
 

--- a/src/test/fuzz/secp256k1_ecdsa_signature_parse_der_lax.cpp
+++ b/src/test/fuzz/secp256k1_ecdsa_signature_parse_der_lax.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <key.h>
+#include <common/ecc_init.h>
 #include <secp256k1.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -26,7 +26,7 @@ FUZZ_TARGET(secp256k1_ecdsa_signature_parse_der_lax)
     secp256k1_ecdsa_signature sig_der_lax;
     const bool parsed_der_lax = ecdsa_signature_parse_der_lax(&sig_der_lax, signature_bytes.data(), signature_bytes.size()) == 1;
     if (parsed_der_lax) {
-        ECC_Context ecc_context{};
+        const auto ecc_context{MakeContextECC()};
         (void)SigHasLowR(&sig_der_lax);
     }
 }

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <key.h>
+#include <common/ecc_init.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -9,6 +9,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <coins.h>
+#include <common/ecc_init.h>
 #include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
@@ -237,7 +238,7 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, TestOpts opts)
     LogInstance().StartLogging();
     m_node.warnings = std::make_unique<node::Warnings>();
     m_node.kernel = std::make_unique<kernel::Context>();
-    m_node.ecc_context = std::make_unique<ECC_Context>();
+    m_node.ecc_context = MakeContextECC();
     SetupEnvironment();
 
     m_node.chain = interfaces::MakeChain(m_node);


### PR DESCRIPTION
Since https://github.com/bitcoin-core/secp256k1/pull//1777 , libsecp256k1 allows an externally provided SHA256 compression function. This PR plug ours in, so it runs on our SHA-NI/ARMv8/SSE4 hardware optimized implementation instead of the libsecp bare internal one.

The biggest gains are at the signing side, not at the verification side.

The first commits restructure how the libsecp context is encapsulated and initialized. `ECC_Context` now properly handles the libsecp context lifecycle and fully behaves as a singleton, getting decoupled from the `key.h/cpp` primitive (which is no longer accessed by upper layers just to init ECC), allowing us to introduce a verification context within the same object, and moving the singleton initialization to `ecc_init.h` which simplifies usage to a single entry point for all users.

Benchmarks at the bench introduction commit (43c9bdbf8ada1b581b5ab1f0a102517c243a60da) and at the tip:

On ARM64, `arm_shani` implementation

| benchmark | before | after | change |
|---|---|---|---|
| `ECDSASign` | 79.2 µs | 69.3 µs | -13% |
| `SchnorrSign` | 39.9 µs | 37.1 µs | -7% |
| `ECDSAVerify` | 27.4 µs | 27.3 µs | -0% |
| `SchnorrVerify` | 28.1 µs | 27.8 µs | -1% |
| `EllSwiftCreate` | 29.8 µs | 28.8 µs | -3% |
| `BIP324_ECDH` | 30.4 µs | 30.1 µs | -1% |