### PR TITLE
fs: use ftruncate on OpenBSD in AllocateFileRange

### DIFF
--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -228,6 +228,10 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
     // Version using posix_fallocate
     off_t nEndPos = (off_t)offset + length;
     if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
+#elif defined(__OpenBSD__)
+    // OpenBSD doesn't have fallocate or posix_fallocate, use ftruncate instead
+    off_t nEndPos = (off_t)offset + length;
+    if (0 == ftruncate(fileno(file), nEndPos)) return;
 #endif
     // Fallback version
     // TODO: just write one byte per block


### PR DESCRIPTION
## Summary

OpenBSD provides neither `fallocate` nor `posix_fallocate`, so `AllocateFileRange()` always fell through to the slow fallback path there: writing the entire range one 64KiB buffer at a time instead of just advising the OS of the eventual file size.

This adds an `__OpenBSD__` branch that uses `ftruncate`, matching the guidance in #32643 and the same pattern already used for the macOS branch just above it in this function.

Fixes #32643

## Test plan

I don't have OpenBSD hardware to run this on directly, so it's verified by:
- The "OpenBSD Cross" CI job, which compiles this exact branch for the target and passes.
- Full local build (macOS, Clang) with no new warnings.
- Full unit test suite (`test_bitcoin`, 825 cases) passes.
- `test/lint/lint-files.py`, `lint-includes.py`, and `lint-locale-dependence.py` all pass.

The approach mirrors a previous attempt at this issue (#32645, closed unmerged) which was hand-tested on real OpenBSD 7.7 via a signet IBD run, confirming the fallback path is no longer hit.