### PR TITLE
kernel: Replace log callbacks with buffered reads

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -41,14 +41,16 @@ std::vector<std::byte> hex_string_to_byte_vec(std::string_view hex)
     return bytes;
 }
 
-class KernelLog
+void PrintLogMessages(Logger& logger)
 {
-public:
-    void LogMessage(std::string_view message)
-    {
+    auto messages{logger.Drain()};
+    if (messages.GetDiscarded() != 0) {
+        std::cerr << "kernel: " << messages.GetDiscarded() << " log messages discarded" << std::endl;
+    }
+    for (const auto message : messages.Messages()) {
         std::cout << "kernel: " << message;
     }
-};
+}
 
 class TestValidationInterface : public ValidationInterface
 {
@@ -168,7 +170,7 @@ int main(int argc, char* argv[])
 
     logging_set_options(logging_options);
 
-    Logger logger{std::make_unique<KernelLog>()};
+    Logger logger;
 
     ContextOptions options{};
     ChainParams params{has_regtest_flag ? ChainType::REGTEST : ChainType::MAINNET};
@@ -186,9 +188,11 @@ int main(int argc, char* argv[])
     try {
         chainman = std::make_unique<ChainMan>(context, chainman_opts);
     } catch (std::exception&) {
+        PrintLogMessages(logger);
         std::cerr << "Failed to instantiate ChainMan, exiting" << std::endl;
         return 1;
     }
+    PrintLogMessages(logger);
 
     std::cout << "Enter the block you want to validate on the next line:" << std::endl;
 
@@ -203,12 +207,14 @@ int main(int argc, char* argv[])
         try {
             block = std::make_unique<Block>(raw_block);
         } catch (std::exception&) {
+            PrintLogMessages(logger);
             std::cerr << "Block decode failed, try again:" << std::endl;
             continue;
         }
 
         bool new_block = false;
         bool accepted = chainman->ProcessBlock(*block, &new_block);
+        PrintLogMessages(logger);
         if (accepted) {
             std::cerr << "Block has not yet been rejected" << std::endl;
         } else {
@@ -218,4 +224,6 @@ int main(int argc, char* argv[])
             std::cerr << "Block is a duplicate" << std::endl;
         }
     }
+    chainman.reset();
+    PrintLogMessages(logger);
 }

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -34,6 +34,7 @@
 #include <util/fs.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
+#include <util/stdmutex.h>
 #include <util/task_runner.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -42,11 +43,13 @@
 
 #include <cstddef>
 #include <cstring>
+#include <deque>
 #include <exception>
 #include <functional>
 #include <limits>
 #include <list>
 #include <memory>
+#include <new>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -235,32 +238,68 @@ btck_Warning cast_btck_warning(kernel::Warning warning)
     assert(false);
 }
 
-struct LoggingConnection {
-    std::unique_ptr<std::list<std::function<void(const std::string&)>>::iterator> m_connection;
-    void* m_user_data;
-    std::function<void(void* user_data)> m_deleter;
+struct LogMessages {
+    std::deque<std::string> messages;
+    size_t discarded{0};
+};
 
-    LoggingConnection(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+class LoggingConnection
+{
+    const size_t m_max_buffer_bytes;
+    StdMutex m_mutex;
+    LogMessages m_buffer GUARDED_BY(m_mutex);
+    size_t m_buffer_bytes GUARDED_BY(m_mutex){0};
+    std::list<std::function<void(const std::string&)>>::iterator m_connection{};
+
+    // Called under the logger's mutex. Never log or call application code here.
+    void BufferMessage(const std::string& message) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
-        LOCK(cs_main);
-
-        auto connection{LogInstance().PushBackCallback([callback, user_data](const std::string& str) { callback(user_data, str.c_str(), str.length()); })};
-
-        // Only start logging if we just added the connection.
-        if (LogInstance().NumConnections() == 1 && !LogInstance().StartLogging()) {
-            LogError("Logger start failed.");
-            LogInstance().DeleteCallback(connection);
-            if (user_data && user_data_destroy_callback) {
-                user_data_destroy_callback(user_data);
-            }
-            throw std::runtime_error("Failed to start logging");
+        STDLOCK(m_mutex);
+        if (message.size() > m_max_buffer_bytes) {
+            ++m_buffer.discarded;
+            return;
         }
 
-        m_connection = std::make_unique<std::list<std::function<void(const std::string&)>>::iterator>(connection);
-        m_user_data = user_data;
-        m_deleter = user_data_destroy_callback;
+        while (m_buffer_bytes > m_max_buffer_bytes - message.size()) {
+            m_buffer_bytes -= m_buffer.messages.front().size();
+            m_buffer.messages.pop_front();
+            ++m_buffer.discarded;
+        }
+        try {
+            m_buffer.messages.push_back(message);
+            m_buffer_bytes += message.size();
+        } catch (const std::bad_alloc&) {
+            ++m_buffer.discarded;
+        }
+    }
 
-        LogDebug(BCLog::KERNEL, "Logger connected.");
+    void Disconnect() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    {
+        // Removing the sink under the logger's mutex waits for any in-flight
+        // BufferMessage call before the connection's storage is destroyed.
+        if (LogInstance().NumConnections() == 1) {
+            LogInstance().DisconnectTestLogger();
+        } else {
+            LogInstance().DeleteCallback(m_connection);
+        }
+    }
+
+public:
+    explicit LoggingConnection(size_t max_buffer_bytes) : m_max_buffer_bytes{max_buffer_bytes}
+    {
+        LOCK(cs_main);
+        m_connection = LogInstance().PushBackCallback([this](const std::string& message) { BufferMessage(message); });
+        try {
+            if (LogInstance().NumConnections() == 1 && !LogInstance().StartLogging()) {
+                throw std::runtime_error("Failed to start logging");
+            }
+
+            LogDebug(BCLog::KERNEL, "Logger connected.");
+        } catch (...) {
+            // The sink captures this, so it must not survive a failed constructor.
+            Disconnect();
+            throw;
+        }
     }
 
     ~LoggingConnection()
@@ -268,18 +307,19 @@ struct LoggingConnection {
         LOCK(cs_main);
         LogDebug(BCLog::KERNEL, "Logger disconnecting.");
 
-        // Switch back to buffering by calling DisconnectTestLogger if the
-        // connection that we are about to remove is the last one.
-        if (LogInstance().NumConnections() == 1) {
-            LogInstance().DisconnectTestLogger();
-        } else {
-            LogInstance().DeleteCallback(*m_connection);
-        }
+        Disconnect();
+    }
 
-        m_connection.reset();
-        if (m_user_data && m_deleter) {
-            m_deleter(m_user_data);
-        }
+    std::unique_ptr<LogMessages> Drain() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        // Allocate before removing anything so allocation failure leaves the
+        // pending messages and discard count untouched.
+        auto messages{std::make_unique<LogMessages>()};
+        STDLOCK(m_mutex);
+        messages->messages.swap(m_buffer.messages);
+        messages->discarded = std::exchange(m_buffer.discarded, 0);
+        m_buffer_bytes = 0;
+        return messages;
     }
 };
 
@@ -492,6 +532,7 @@ struct btck_Transaction : Handle<btck_Transaction, std::shared_ptr<const CTransa
 struct btck_TransactionOutput : Handle<btck_TransactionOutput, CTxOut> {};
 struct btck_ScriptPubkey : Handle<btck_ScriptPubkey, CScript> {};
 struct btck_LoggingConnection : Handle<btck_LoggingConnection, LoggingConnection> {};
+struct btck_LogMessages : Handle<btck_LogMessages, LogMessages> {};
 struct btck_ContextOptions : Handle<btck_ContextOptions, ContextOptions> {};
 struct btck_Context : Handle<btck_Context, std::shared_ptr<const Context>> {};
 struct btck_ChainParameters : Handle<btck_ChainParameters, CChainParams> {};
@@ -824,10 +865,10 @@ void btck_logging_disable()
     LogInstance().DisableLogging();
 }
 
-btck_LoggingConnection* btck_logging_connection_create(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+btck_LoggingConnection* btck_logging_connection_create(size_t max_buffer_bytes)
 {
     try {
-        return btck_LoggingConnection::create(callback, user_data, user_data_destroy_callback);
+        return btck_LoggingConnection::create(max_buffer_bytes);
     } catch (const std::exception&) {
         return nullptr;
     }
@@ -836,6 +877,39 @@ btck_LoggingConnection* btck_logging_connection_create(btck_LogCallback callback
 void btck_logging_connection_destroy(btck_LoggingConnection* connection)
 {
     delete connection;
+}
+
+btck_LogMessages* btck_logging_connection_drain(btck_LoggingConnection* connection)
+{
+    try {
+        return btck_LogMessages::ref(btck_LoggingConnection::get(connection).Drain().release());
+    } catch (const std::exception&) {
+        return nullptr;
+    }
+}
+
+void btck_log_messages_destroy(btck_LogMessages* messages)
+{
+    delete messages;
+}
+
+size_t btck_log_messages_count(const btck_LogMessages* messages)
+{
+    return btck_LogMessages::get(messages).messages.size();
+}
+
+const char* btck_log_messages_get_message_at(const btck_LogMessages* messages, size_t index, size_t* message_len)
+{
+    const auto& entries{btck_LogMessages::get(messages).messages};
+    assert(index < entries.size());
+    const auto& message{entries[index]};
+    *message_len = message.size();
+    return message.data();
+}
+
+size_t btck_log_messages_get_discarded(const btck_LogMessages* messages)
+{
+    return btck_LogMessages::get(messages).discarded;
 }
 
 btck_ChainParameters* btck_chain_parameters_create(const btck_ChainType chain_type)

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -146,7 +146,9 @@ typedef struct btck_TransactionOutput btck_TransactionOutput;
 /**
  * Opaque data structure for holding a logging connection.
  *
- * The logging connection can be used to manually stop logging.
+ * Each connection owns a bounded buffer of formatted log messages. Applications
+ * retrieve messages with btck_logging_connection_drain; logging never invokes
+ * application callbacks.
  *
  * Messages that were logged before a connection is created are buffered in a
  * 1MB buffer. Logging can alternatively be permanently disabled by calling
@@ -155,6 +157,13 @@ typedef struct btck_TransactionOutput btck_TransactionOutput;
  * instances.
  */
 typedef struct btck_LoggingConnection btck_LoggingConnection;
+
+/**
+ * An owned, immutable batch of log messages drained from a connection. The batch
+ * remains valid independently of the connection and is freed with
+ * btck_log_messages_destroy.
+ */
+typedef struct btck_LogMessages btck_LogMessages;
 
 /**
  * Opaque data structure for holding the chain parameters.
@@ -350,12 +359,6 @@ typedef uint8_t btck_Warning;
 #define btck_Warning_LARGE_WORK_INVALID_CHAIN ((btck_Warning)(1))
 
 /** Callback function types */
-
-/**
- * Function signature for the global logging callback. All bitcoin kernel
- * internal logs will pass through this callback.
- */
-typedef void (*btck_LogCallback)(void* user_data, const char* message, size_t message_len);
 
 /**
  * Function signature for freeing user data.
@@ -926,27 +929,67 @@ BITCOINKERNEL_API void btck_logging_enable_category(btck_LogCategory category);
 BITCOINKERNEL_API void btck_logging_disable_category(btck_LogCategory category);
 
 /**
- * @brief Start logging messages through the provided callback. Log messages
- * produced before this function is first called are buffered and on calling this
- * function are logged immediately.
+ * @brief Start buffering log messages for explicit retrieval.
  *
- * @param[in] log_callback               Non-null, function through which messages will be logged.
- * @param[in] user_data                  Nullable, holds a user-defined opaque structure. Is passed back
- *                                       to the user through the callback. If the user_data_destroy_callback
- *                                       is also defined it is assumed that ownership of the user_data is passed
- *                                       to the created logging connection.
- * @param[in] user_data_destroy_callback Nullable, function for freeing the user data.
- * @return                               A new kernel logging connection, or null on error.
+ * Each connection independently buffers messages in logging order. The first
+ * connection also receives any messages retained by the startup log buffer.
+ * Formatting and filtering settings remain global. No application code is
+ * invoked when a message is logged.
+ *
+ * The oldest pending messages are discarded when necessary to fit a new message.
+ * Messages larger than the limit are discarded whole without evicting pending
+ * messages. Allocation failures also discard messages. These losses are counted
+ * and reported by btck_log_messages_get_discarded on the next drained batch.
+ * Producers never wait for applications to drain the buffer.
+ *
+ * @param[in] max_buffer_bytes Maximum total bytes of pending formatted messages,
+ *                            excluding container overhead and null terminators.
+ *                            Zero discards all messages.
+ * @return                    A new logging connection, or null on error.
  */
 BITCOINKERNEL_API btck_LoggingConnection* BITCOINKERNEL_WARN_UNUSED_RESULT btck_logging_connection_create(
-    btck_LogCallback log_callback,
-    void* user_data,
-    btck_DestroyCallback user_data_destroy_callback) BITCOINKERNEL_ARG_NONNULL(1);
+    size_t max_buffer_bytes);
 
 /**
- * Stop logging and destroy the logging connection.
+ * Stop buffering and destroy the logging connection, discarding pending messages.
+ * Previously drained batches remain valid. Destruction must not run concurrently
+ * with calls that use the same connection. Other threads may continue logging.
  */
 BITCOINKERNEL_API void btck_logging_connection_destroy(btck_LoggingConnection* logging_connection);
+
+/**
+ * Atomically remove all pending messages and reset the discard count. This does
+ * not wait for new messages or invoke application code. Messages logged after
+ * the batch is removed remain pending for the next drain.
+ *
+ * May run concurrently with logging or other drains on the same connection.
+ * Each message is returned by at most one drain per connection. Applications
+ * control when to process the returned messages, outside kernel operations.
+ *
+ * @return An owned batch (possibly empty), or null on allocation failure, in
+ *         which case pending messages and the discard count are unchanged.
+ */
+BITCOINKERNEL_API btck_LogMessages* BITCOINKERNEL_WARN_UNUSED_RESULT btck_logging_connection_drain(
+    btck_LoggingConnection* connection) BITCOINKERNEL_ARG_NONNULL(1);
+
+/** Destroy a drained batch and invalidate all message pointers obtained from it. */
+BITCOINKERNEL_API void btck_log_messages_destroy(btck_LogMessages* messages);
+
+/** Return the number of messages in a drained batch. */
+BITCOINKERNEL_API size_t btck_log_messages_count(const btck_LogMessages* messages) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Return a view of a message, valid until the batch is destroyed.
+ * @param[in]  messages    Non-null batch.
+ * @param[in]  index       Must be less than btck_log_messages_count(messages).
+ * @param[out] message_len Non-null, receives the message length in bytes,
+ *                         excluding the terminating null byte.
+ */
+BITCOINKERNEL_API const char* btck_log_messages_get_message_at(
+    const btck_LogMessages* messages, size_t index, size_t* message_len) BITCOINKERNEL_ARG_NONNULL(1, 3);
+
+/** Return the number of messages discarded since the preceding drain or creation. */
+BITCOINKERNEL_API size_t btck_log_messages_get_discarded(const btck_LogMessages* messages) BITCOINKERNEL_ARG_NONNULL(1);
 
 ///@}
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -943,22 +943,32 @@ inline void logging_disable_category(LogCategory category)
     btck_logging_disable_category(static_cast<btck_LogCategory>(category));
 }
 
-template <typename T>
-concept Log = requires(T a, std::string_view message) {
-    { a.LogMessage(message) } -> std::same_as<void>;
-};
-
-template <Log T>
-class Logger : UniqueHandle<btck_LoggingConnection, btck_logging_connection_destroy>
+class LogMessages : public UniqueHandle<btck_LogMessages, btck_log_messages_destroy>
 {
 public:
-    Logger(std::unique_ptr<T> log)
-        : UniqueHandle{btck_logging_connection_create(
-              +[](void* user_data, const char* message, size_t message_len) { static_cast<T*>(user_data)->LogMessage({message, message_len}); },
-              log.release(),
-              +[](void* user_data) { delete static_cast<T*>(user_data); })}
+    explicit LogMessages(btck_LogMessages* messages) : UniqueHandle{messages} {}
+
+    size_t Count() const { return btck_log_messages_count(get()); }
+
+    size_t GetDiscarded() const { return btck_log_messages_get_discarded(get()); }
+
+    std::string_view GetMessageAt(size_t index) const
     {
+        size_t len;
+        const char* message{btck_log_messages_get_message_at(get(), index, &len)};
+        return {message, len};
     }
+
+    MAKE_RANGE_METHOD(Messages, LogMessages, &LogMessages::Count, &LogMessages::GetMessageAt, *this)
+};
+
+class Logger : public UniqueHandle<btck_LoggingConnection, btck_logging_connection_destroy>
+{
+public:
+    explicit Logger(size_t max_buffer_bytes = 1'000'000)
+        : UniqueHandle{btck_logging_connection_create(max_buffer_bytes)} {}
+
+    LogMessages Drain() { return LogMessages{btck_logging_connection_drain(get())}; }
 };
 
 class BlockTreeEntry : public View<btck_BlockTreeEntry>

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -10,12 +10,13 @@
 // Boost.Test's SIGSTKSZ alternate stack can be smaller than Linux requires on musl.
 #define BOOST_TEST_DISABLE_ALT_STACK
 #define BOOST_TEST_MODULE Bitcoin Kernel Test Suite
-#include <boost/test/included/unit_test.hpp>
-
 #include <test/kernel/block_data.h>
 #include <test/util/common.h>
 
+#include <boost/test/included/unit_test.hpp>
+
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -92,14 +93,21 @@ void check_equal(std::span<const std::byte> _actual, std::span<const std::byte> 
         expected.begin(), expected.end());
 }
 
-class TestLog
-{
-public:
-    void LogMessage(std::string_view message)
+struct LoggingSetup {
+    LoggingSetup()
     {
-        std::cout << "kernel: " << message;
+        logging_set_options({});
+        logging_set_level_category(LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
+        logging_enable_category(LogCategory::KERNEL);
     }
 };
+
+// Creating custom signet parameters emits an Info message containing the challenge.
+void LogTestMessage(uint8_t value)
+{
+    const std::byte challenge{value};
+    ChainParams params{std::span{&challenge, 1}};
+}
 
 struct TestDirectory {
     fs::path m_directory;
@@ -665,10 +673,101 @@ BOOST_AUTO_TEST_CASE(logging_tests)
     {
         logging_set_level_category(LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
         logging_enable_category(LogCategory::KERNEL);
-        Logger logger{std::make_unique<TestLog>()};
-        Logger logger_2{std::make_unique<TestLog>()};
+        Logger logger;
+        Logger logger_2;
+        auto messages{logger_2.Drain()};
+        BOOST_REQUIRE_EQUAL(messages.Count(), 1);
+        BOOST_CHECK(messages.GetMessageAt(0).ends_with("[kernel:debug] Logger connected.\n"));
+        BOOST_CHECK_EQUAL(messages.GetDiscarded(), 0);
+        BOOST_CHECK_GE(logger.Drain().Count(), 2);
     }
-    Logger logger{std::make_unique<TestLog>()};
+    Logger logger;
+    BOOST_CHECK_EQUAL(logger.Drain().Count(), 1);
+    BOOST_CHECK_EQUAL(logger.Drain().Count(), 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_buffer, LoggingSetup)
+{
+    Logger logger;
+    logger.Drain();
+    LogTestMessage(1);
+
+    // Formatting is captured when logging, not when draining.
+    btck_LoggingOptions options{};
+    options.always_print_category_levels = true;
+    logging_set_options(options);
+    LogTestMessage(2);
+    auto messages{logger.Drain()};
+    BOOST_REQUIRE_EQUAL(messages.Count(), 2);
+    BOOST_CHECK_EQUAL(messages.GetMessageAt(0), "Signet with challenge 01\n");
+    BOOST_CHECK_EQUAL(messages.GetMessageAt(1), "[all:info] Signet with challenge 02\n");
+    BOOST_CHECK_EQUAL(messages.GetDiscarded(), 0);
+
+    // Processing a drained batch can call APIs that log, without reentrancy.
+    for (const auto message : messages.Messages()) {
+        BOOST_CHECK(!message.empty());
+        LogTestMessage(3);
+    }
+    BOOST_CHECK_EQUAL(logger.Drain().Count(), 2);
+    BOOST_CHECK_EQUAL(messages.GetMessageAt(0), "Signet with challenge 01\n");
+    auto empty{logger.Drain()};
+    BOOST_CHECK_EQUAL(empty.Count(), 0);
+    BOOST_CHECK_EQUAL(empty.GetDiscarded(), 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_buffer_limits, LoggingSetup)
+{
+    const size_t message_size{std::string_view{"Signet with challenge 01\n"}.size()};
+    Logger logger{2 * message_size};
+    logger.Drain();
+    LogTestMessage(1);
+    LogTestMessage(2);
+    LogTestMessage(3);
+    auto messages{logger.Drain()};
+    BOOST_REQUIRE_EQUAL(messages.Count(), 2);
+    BOOST_CHECK_EQUAL(messages.GetMessageAt(0), "Signet with challenge 02\n");
+    BOOST_CHECK_EQUAL(messages.GetMessageAt(1), "Signet with challenge 03\n");
+    BOOST_CHECK_EQUAL(messages.GetDiscarded(), 1);
+    BOOST_CHECK_EQUAL(logger.Drain().GetDiscarded(), 0);
+
+    // An oversized message does not evict a pending message that fits.
+    LogTestMessage(4);
+    const std::vector<std::byte> large_challenge(100);
+    ChainParams params{large_challenge};
+    auto oversized{logger.Drain()};
+    BOOST_REQUIRE_EQUAL(oversized.Count(), 1);
+    BOOST_CHECK_EQUAL(oversized.GetMessageAt(0), "Signet with challenge 04\n");
+    BOOST_CHECK_EQUAL(oversized.GetDiscarded(), 1);
+
+    for (const size_t limit : {size_t{0}, message_size - 1, message_size}) {
+        Logger bounded{limit};
+        bounded.Drain();
+        LogTestMessage(5);
+        auto batch{bounded.Drain()};
+        const bool fits{limit == message_size};
+        BOOST_CHECK_EQUAL(batch.Count(), fits ? 1 : 0);
+        BOOST_CHECK_EQUAL(batch.GetDiscarded(), fits ? 0 : 1);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_buffer_lifetime, LoggingSetup)
+{
+    std::optional<LogMessages> saved;
+    std::string_view view;
+    {
+        Logger logger;
+        logger.Drain();
+        LogTestMessage(1);
+        saved.emplace(logger.Drain());
+        BOOST_REQUIRE_EQUAL(saved->Count(), 1);
+        view = saved->GetMessageAt(0);
+        LogTestMessage(2);
+        auto next{logger.Drain()};
+        BOOST_REQUIRE_EQUAL(next.Count(), 1);
+        BOOST_CHECK_EQUAL(next.GetMessageAt(0), "Signet with challenge 02\n");
+    }
+    BOOST_CHECK_EQUAL(view, "Signet with challenge 01\n");
+    BOOST_CHECK_EQUAL(saved->GetMessageAt(0), view);
 }
 
 BOOST_AUTO_TEST_CASE(btck_chainparams_tests)
@@ -774,7 +873,7 @@ Context create_context(std::shared_ptr<TestKernelNotifications> notifications, C
 
 BOOST_AUTO_TEST_CASE(btck_chainman_tests)
 {
-    Logger logger{std::make_unique<TestLog>()};
+    Logger logger;
     auto test_directory{TestDirectory{"chainman_test_bitcoin_kernel"}};
 
     { // test with default context
@@ -817,6 +916,11 @@ BOOST_AUTO_TEST_CASE(btck_chainman_tests)
     BOOST_CHECK(chainman_opts.SetWipeDbs(/*wipe_block_tree=*/false, /*wipe_chainstate=*/true));
     BOOST_CHECK(chainman_opts.SetWipeDbs(/*wipe_block_tree=*/false, /*wipe_chainstate=*/false));
     ChainMan chainman{context, chainman_opts};
+
+    auto messages{logger.Drain()};
+    for (const auto message : messages.Messages()) {
+        std::cout << "kernel: " << message;
+    }
 }
 
 std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -15,11 +15,15 @@
 
 #include <boost/test/included/unit_test.hpp>
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <charconv>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <latch>
 #include <memory>
 #include <optional>
 #include <random>
@@ -27,6 +31,8 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <thread>
+#include <utility>
 #include <vector>
 
 using namespace btck;
@@ -108,6 +114,18 @@ void LogTestMessage(uint8_t value)
     const std::byte challenge{value};
     ChainParams params{std::span{&challenge, 1}};
 }
+
+// Stop and join before referenced test state is destroyed, including on exceptions.
+struct LoggingThreads {
+    std::atomic<bool> m_stop{false};
+    std::vector<std::thread> m_threads;
+
+    ~LoggingThreads()
+    {
+        m_stop = true;
+        for (auto& thread : m_threads) thread.join();
+    }
+};
 
 struct TestDirectory {
     fs::path m_directory;
@@ -768,6 +786,99 @@ BOOST_FIXTURE_TEST_CASE(logging_buffer_lifetime, LoggingSetup)
     }
     BOOST_CHECK_EQUAL(view, "Signet with challenge 01\n");
     BOOST_CHECK_EQUAL(saved->GetMessageAt(0), view);
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_buffer_concurrent_drain, LoggingSetup)
+{
+    Logger logger;
+    Logger reference;
+    logger.Drain();
+    reference.Drain();
+
+    std::array<std::vector<LogMessages>, 2> batches;
+    {
+        LoggingThreads consumers;
+        for (size_t reader{0}; reader < batches.size(); ++reader) {
+            consumers.m_threads.emplace_back([&, reader] {
+                while (!consumers.m_stop) {
+                    auto messages{logger.Drain()};
+                    if (messages.Count() != 0 || messages.GetDiscarded() != 0) {
+                        batches[reader].push_back(std::move(messages));
+                    }
+                    std::this_thread::yield();
+                }
+            });
+        }
+        LoggingThreads producers;
+        for (size_t writer{0}; writer < 4; ++writer) {
+            producers.m_threads.emplace_back([writer] {
+                for (size_t i{0}; i < 64; ++i) {
+                    LogTestMessage(static_cast<uint8_t>(writer * 64 + i));
+                }
+            });
+        }
+    } // Join all producers before stopping the consumers.
+    batches[0].push_back(logger.Drain());
+
+    // An undrained connection provides the complete stream in logging order.
+    // Concurrent drains must partition that stream without loss or duplication.
+    auto complete{reference.Drain()};
+    BOOST_REQUIRE_EQUAL(complete.Count(), 256);
+    BOOST_CHECK_EQUAL(complete.GetDiscarded(), 0);
+    std::vector<std::string> expected;
+    for (const auto message : complete.Messages()) {
+        expected.emplace_back(message);
+    }
+    std::vector<std::string> received;
+    for (const auto& reader_batches : batches) {
+        auto next{expected.begin()};
+        for (const auto& batch : reader_batches) {
+            BOOST_CHECK_EQUAL(batch.GetDiscarded(), 0);
+            for (const auto message : batch.Messages()) {
+                // Every consumer also observes its messages in FIFO order.
+                next = std::find(next, expected.end(), message);
+                BOOST_REQUIRE(next != expected.end());
+                ++next;
+                received.emplace_back(message);
+            }
+        }
+    }
+    std::ranges::sort(expected);
+    std::ranges::sort(received);
+    BOOST_CHECK_EQUAL_COLLECTIONS(received.begin(), received.end(), expected.begin(), expected.end());
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_buffer_concurrent_disconnect, LoggingSetup)
+{
+    Logger observer;
+    observer.Drain();
+    std::latch started{1};
+    {
+        LoggingThreads producer;
+        producer.m_threads.emplace_back([&] {
+            LogTestMessage(1);
+            started.count_down();
+            while (!producer.m_stop) {
+                LogTestMessage(1);
+                std::this_thread::yield();
+            }
+        });
+        started.wait();
+
+        // Disconnect must unregister the internal sink before freeing its buffer,
+        // even with ongoing production and an application that never drains it.
+        for (int i{0}; i < 100; ++i) {
+            Logger transient{/*max_buffer_bytes=*/64};
+        }
+    }
+
+    // Other connections continue receiving logs after the transient ones leave.
+    observer.Drain();
+    LogTestMessage(2);
+    auto messages{observer.Drain()};
+    BOOST_REQUIRE_EQUAL(messages.Count(), 1);
+    BOOST_CHECK_EQUAL(messages.GetMessageAt(0), "Signet with challenge 02\n");
+    BOOST_CHECK_EQUAL(messages.GetDiscarded(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(btck_chainparams_tests)


### PR DESCRIPTION
Kernel logging currently calls application handlers while internal locks are held. Slow handlers can delay validation, and handlers that call back into the Kernel can deadlock.

The goal here is to avoid calling application log handlers while Kernel locks are held.

This draft creates a stronger separation between Kernel execution and application behavior by buffering messages per logging connection.

Applications retrieve messages with `Drain()` and process them independently. Buffers have configurable size limits, discard the oldest messages when full, and report losses. [Docker’s non-blocking logging](https://docs.docker.com/engine/logging/configure/#configure-the-delivery-mode-of-log-messages-from-container-to-log-driver) uses a similar buffering approach.

The `kernel/native-log-stream` branch below explores interruptible reads, allowing applications to consume messages continuously on a reader thread and eliminating the need for the `Drain()` approach used here:

https://github.com/w0xlt/bitcoin/tree/kernel/native-log-stream

However, this draft starts with explicit draining to keep the initial change smaller and easier to understand while that alternative is discussed and reviewed further.

Feedback on the concept and alternative approaches is welcome.