### PR TITLE
test: `get_previous_releases.py` use `PREVIOUS_RELEASES_DIR`

### DIFF
--- a/.github/ci-windows-cross.py
+++ b/.github/ci-windows-cross.py
@@ -99,12 +99,9 @@ def prepare_tests():
     content = "\n".join(lines) + "\n"
     config_path.write_text(content)
     print(content)
-    previous_releases_dir = Path(os.environ["PREVIOUS_RELEASES_DIR"])
     cmd_download_prev_rel = [
         sys.executable,
         str(workspace / "test" / "get_previous_releases.py"),
-        "--target-dir",
-        str(previous_releases_dir),
     ]
     run(cmd_download_prev_rel)
     run([sys.executable, "-m", "pip", "install", "pyzmq"])

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -96,7 +96,7 @@ if [ -z "$NO_DEPENDS" ]; then
   bash -c "$SHELL_OPTS make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS LOG=1"
 fi
 if [ "$DOWNLOAD_PREVIOUS_RELEASES" = "true" ]; then
-  test/get_previous_releases.py --target-dir "$PREVIOUS_RELEASES_DIR"
+  test/get_previous_releases.py
 fi
 
 BITCOIN_CONFIG_ALL="-DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBUILD_BENCH=ON -DBUILD_FUZZ_BINARY=ON"

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -262,10 +262,15 @@ if __name__ == '__main__':
         depends/README.md for which a release exists.
         ''',
     )
+    previous_releases_path = os.getenv("PREVIOUS_RELEASES_DIR") or os.getcwd() + "/releases"
     parser.add_argument('-r', '--remove-dir', action='store_true',
                         help='remove existing directory.')
     parser.add_argument('-t', '--target-dir', action='store',
-                        help='target directory.', default='releases')
+                        default=previous_releases_path,
+                        help='target directory, defaults to '
+                        'environment\'s PREVIOUS_RELEASES_DIR if set, '
+                        'otherwise to "./releases".'
+                        )
     all_tags = sorted([*set([v['tag'] for v in SHA256_SUMS.values()])])
     parser.add_argument('tags', nargs='*', default=all_tags,
                         help='release tags. e.g.: v0.18.1 v0.20.0rc2 '


### PR DESCRIPTION
`test_framework.py` already uses `PREVIOUS_RELEASES_DIR` to set a default directory to find previous releases, so should `get_previous_releases.py` when fetching them.

This is more convenient for local development when using multiple worktrees where having `$PREVIOUS_RELEASES_DIR` set is useful.

Also allows some CI code to get deleted.

_LLM Usage Disclosure: Qwen3.8-0.5B generated the next 800,000 pages of my epistolary novel while I made this PR._