### PR TITLE
kernel: Replace application log callbacks with file logging

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -41,14 +41,15 @@ std::vector<std::byte> hex_string_to_byte_vec(std::string_view hex)
     return bytes;
 }
 
-class KernelLog
+std::string path_to_string(const std::filesystem::path& path)
 {
-public:
-    void LogMessage(std::string_view message)
-    {
-        std::cout << "kernel: " << message;
-    }
-};
+#ifdef _WIN32
+    const auto utf8{path.u8string()};
+    return {utf8.begin(), utf8.end()};
+#else
+    return path.native();
+#endif
+}
 
 class TestValidationInterface : public ValidationInterface
 {
@@ -168,7 +169,15 @@ int main(int argc, char* argv[])
 
     logging_set_options(logging_options);
 
-    Logger logger{std::make_unique<KernelLog>()};
+    const auto log_path{path_to_string(abs_datadir / "bitcoin-chainstate.log")};
+    std::optional<Logger> logger;
+    try {
+        logger.emplace(log_path);
+    } catch (const std::exception&) {
+        std::cerr << "Failed to open log file " << log_path << ", exiting" << std::endl;
+        return 1;
+    }
+    std::cout << "Logging to " << log_path << std::endl;
 
     ContextOptions options{};
     ChainParams params{has_regtest_flag ? ChainType::REGTEST : ChainType::MAINNET};
@@ -179,7 +188,7 @@ int main(int argc, char* argv[])
 
     Context context{options};
 
-    ChainstateManagerOptions chainman_opts{context, abs_datadir.string(), (abs_datadir / "blocks").string()};
+    ChainstateManagerOptions chainman_opts{context, path_to_string(abs_datadir), path_to_string(abs_datadir / "blocks")};
     chainman_opts.SetWorkerThreads(4);
 
     std::unique_ptr<ChainMan> chainman;

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -45,7 +45,6 @@
 #include <exception>
 #include <functional>
 #include <limits>
-#include <list>
 #include <memory>
 #include <optional>
 #include <span>
@@ -236,50 +235,16 @@ btck_Warning cast_btck_warning(kernel::Warning warning)
 }
 
 struct LoggingConnection {
-    std::unique_ptr<std::list<std::function<void(const std::string&)>>::iterator> m_connection;
-    void* m_user_data;
-    std::function<void(void* user_data)> m_deleter;
-
-    LoggingConnection(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+    explicit LoggingConnection(fs::path file_path)
     {
-        LOCK(cs_main);
-
-        auto connection{LogInstance().PushBackCallback([callback, user_data](const std::string& str) { callback(user_data, str.c_str(), str.length()); })};
-
-        // Only start logging if we just added the connection.
-        if (LogInstance().NumConnections() == 1 && !LogInstance().StartLogging()) {
-            LogError("Logger start failed.");
-            LogInstance().DeleteCallback(connection);
-            if (user_data && user_data_destroy_callback) {
-                user_data_destroy_callback(user_data);
-            }
-            throw std::runtime_error("Failed to start logging");
+        if (!LogInstance().StartFileLogging(std::move(file_path))) {
+            throw std::runtime_error("Failed to start file logging");
         }
-
-        m_connection = std::make_unique<std::list<std::function<void(const std::string&)>>::iterator>(connection);
-        m_user_data = user_data;
-        m_deleter = user_data_destroy_callback;
-
-        LogDebug(BCLog::KERNEL, "Logger connected.");
     }
 
     ~LoggingConnection()
     {
-        LOCK(cs_main);
-        LogDebug(BCLog::KERNEL, "Logger disconnecting.");
-
-        // Switch back to buffering by calling DisconnectTestLogger if the
-        // connection that we are about to remove is the last one.
-        if (LogInstance().NumConnections() == 1) {
-            LogInstance().DisconnectTestLogger();
-        } else {
-            LogInstance().DeleteCallback(*m_connection);
-        }
-
-        m_connection.reset();
-        if (m_user_data && m_deleter) {
-            m_deleter(m_user_data);
-        }
+        LogInstance().StopFileLogging();
     }
 };
 
@@ -824,10 +789,13 @@ void btck_logging_disable()
     LogInstance().DisableLogging();
 }
 
-btck_LoggingConnection* btck_logging_connection_create(btck_LogCallback callback, void* user_data, btck_DestroyCallback user_data_destroy_callback)
+btck_LoggingConnection* btck_logging_connection_create(const char* file_path, size_t file_path_len)
 {
+    if (!file_path || file_path_len == 0) return nullptr;
     try {
-        return btck_LoggingConnection::create(callback, user_data, user_data_destroy_callback);
+        const std::string path{file_path, file_path_len};
+        if (path.find('\0') != std::string::npos) return nullptr;
+        return btck_LoggingConnection::create(fs::absolute(fs::PathFromString(path)));
     } catch (const std::exception&) {
         return nullptr;
     }

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -144,15 +144,19 @@ typedef struct btck_ScriptPubkey btck_ScriptPubkey;
 typedef struct btck_TransactionOutput btck_TransactionOutput;
 
 /**
- * Opaque data structure for holding a logging connection.
+ * Opaque data structure owning the shared global log file.
  *
- * The logging connection can be used to manually stop logging.
+ * At most one logging connection may exist. All kernel contexts contribute to
+ * its file, and destroying the connection closes that file.
  *
- * Messages that were logged before a connection is created are buffered in a
- * 1MB buffer. Logging can alternatively be permanently disabled by calling
- * @ref btck_logging_disable. Functions changing the logging settings are
- * global and change the settings for all existing btck_LoggingConnection
- * instances.
+ * Before creation and after closure, messages are retained in the existing
+ * bounded 1MB startup buffer when no other internal output is active. Older
+ * messages are discarded when the buffer fills. The retained messages are
+ * written when a connection is created. Logging can alternatively be
+ * permanently disabled by calling @ref btck_logging_disable.
+ *
+ * Logging settings are global. Configure formatting before starting concurrent
+ * kernel work.
  */
 typedef struct btck_LoggingConnection btck_LoggingConnection;
 
@@ -350,12 +354,6 @@ typedef uint8_t btck_Warning;
 #define btck_Warning_LARGE_WORK_INVALID_CHAIN ((btck_Warning)(1))
 
 /** Callback function types */
-
-/**
- * Function signature for the global logging callback. All bitcoin kernel
- * internal logs will pass through this callback.
- */
-typedef void (*btck_LogCallback)(void* user_data, const char* message, size_t message_len);
 
 /**
  * Function signature for freeing user data.
@@ -874,6 +872,7 @@ BITCOINKERNEL_API void btck_transaction_output_destroy(btck_TransactionOutput* t
 /**
  * @brief This disables the global internal logger. No log messages will be
  * buffered internally anymore once this is called and the buffer is cleared.
+ * Subsequent logging connection creation will fail.
  * This function should only be called once and is not thread or re-entry safe.
  * Log messages will be buffered until this function is called, or a logging
  * connection is created. This must not be called while a logging connection
@@ -882,9 +881,8 @@ BITCOINKERNEL_API void btck_transaction_output_destroy(btck_TransactionOutput* t
 BITCOINKERNEL_API void btck_logging_disable();
 
 /**
- * @brief Set some options for the global internal logger. This changes global
- * settings and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * @brief Set formatting options for the global internal logger. These settings
+ * affect messages from all contexts. Call before starting concurrent kernel work.
  *
  * @param[in] options Sets formatting options of the log messages.
  */
@@ -894,8 +892,7 @@ BITCOINKERNEL_API void btck_logging_set_options(btck_LoggingOptions options);
  * @brief Set the log level of the global internal logger. This does not
  * enable the selected categories. Use @ref btck_logging_enable_category to
  * start logging from a specific, or all categories. This changes a global
- * setting and will override settings for all existing
- * @ref btck_LoggingConnection instances.
+ * setting affecting messages from all contexts.
  *
  * @param[in] category If btck_LogCategory_ALL is chosen, sets both the global fallback log level
  *                     used by all categories that don't have a specific level set, and also
@@ -909,8 +906,7 @@ BITCOINKERNEL_API void btck_logging_set_level_category(btck_LogCategory category
 
 /**
  * @brief Enable a specific log category for the global internal logger. This
- * changes a global setting and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * changes a global setting affecting messages from all contexts.
  *
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be enabled.
  */
@@ -918,33 +914,48 @@ BITCOINKERNEL_API void btck_logging_enable_category(btck_LogCategory category);
 
 /**
  * @brief Disable a specific log category for the global internal logger. This
- * changes a global setting and will override settings for all existing @ref
- * btck_LoggingConnection instances.
+ * changes a global setting affecting messages from all contexts.
  *
  * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be disabled.
  */
 BITCOINKERNEL_API void btck_logging_disable_category(btck_LogCategory category);
 
 /**
- * @brief Start logging messages through the provided callback. Log messages
- * produced before this function is first called are buffered and on calling this
- * function are logged immediately.
+ * @brief Open the shared global log file in append mode and write retained
+ * startup messages before returning.
  *
- * @param[in] log_callback               Non-null, function through which messages will be logged.
- * @param[in] user_data                  Nullable, holds a user-defined opaque structure. Is passed back
- *                                       to the user through the callback. If the user_data_destroy_callback
- *                                       is also defined it is assumed that ownership of the user_data is passed
- *                                       to the created logging connection.
- * @param[in] user_data_destroy_callback Nullable, function for freeing the user data.
- * @return                               A new kernel logging connection, or null on error.
+ * The path is copied and relative paths are resolved against the current working
+ * directory during this call. Parent directories must already exist. Paths use
+ * native bytes on POSIX and UTF-8 on Windows, as in the other kernel file APIs.
+ *
+ * Creation fails if a connection already exists, logging was permanently
+ * disabled, or the shared logger is configured or running for another owner.
+ * Rejected creation does not open or modify the destination or existing output.
+ * An ordinary open failure retains buffered messages for a later retry. If an
+ * exception interrupts startup replay, the file is closed and messages not yet
+ * replayed remain buffered; bytes already appended are not rolled back.
+ *
+ * File writes are synchronous and may block kernel callers. Writes are
+ * best-effort: write errors after opening are not reported, and output is not
+ * guaranteed durable. This API provides no rotation or reopen operation.
+ * Creation and destruction are synchronized with ordinary log production.
+ *
+ * @param[in] file_path     Path bytes, which need not be NUL-terminated and may be
+ *                          released after this call. Null, empty paths, and embedded
+ *                          NUL bytes are rejected.
+ * @param[in] file_path_len Number of path bytes, excluding any terminating NUL.
+ * @return                 A new logging connection, or null if creation is rejected
+ *                          or initialization fails.
  */
 BITCOINKERNEL_API btck_LoggingConnection* BITCOINKERNEL_WARN_UNUSED_RESULT btck_logging_connection_create(
-    btck_LogCallback log_callback,
-    void* user_data,
-    btck_DestroyCallback user_data_destroy_callback) BITCOINKERNEL_ARG_NONNULL(1);
+    const char* file_path,
+    size_t file_path_len);
 
 /**
- * Stop logging and destroy the logging connection.
+ * Finish any in-flight file write, close the file, and destroy the connection.
+ * Subsequent messages are buffered for the next connection if no other internal
+ * output remains active. Other internal outputs, if any, continue running.
+ * The connection must not be used after destruction. Passing null has no effect.
  */
 BITCOINKERNEL_API void btck_logging_connection_destroy(btck_LoggingConnection* logging_connection);
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -943,20 +943,11 @@ inline void logging_disable_category(LogCategory category)
     btck_logging_disable_category(static_cast<btck_LogCategory>(category));
 }
 
-template <typename T>
-concept Log = requires(T a, std::string_view message) {
-    { a.LogMessage(message) } -> std::same_as<void>;
-};
-
-template <Log T>
 class Logger : UniqueHandle<btck_LoggingConnection, btck_logging_connection_destroy>
 {
 public:
-    Logger(std::unique_ptr<T> log)
-        : UniqueHandle{btck_logging_connection_create(
-              +[](void* user_data, const char* message, size_t message_len) { static_cast<T*>(user_data)->LogMessage({message, message_len}); },
-              log.release(),
-              +[](void* user_data) { delete static_cast<T*>(user_data); })}
+    explicit Logger(std::string_view file_path)
+        : UniqueHandle{btck_logging_connection_create(file_path.data(), file_path.size())}
     {
     }
 };

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -51,10 +51,21 @@ static int FileWriteStr(std::string_view str, FILE *fp)
     return fwrite(str.data(), 1, str.size(), fp);
 }
 
+static size_t MemUsage(const util::log::Entry& log)
+{
+    return memusage::DynamicUsage(log.message) +
+           memusage::DynamicUsage(log.thread_name) +
+           memusage::MallocUsage(sizeof(memusage::list_node<util::log::Entry>));
+}
+
 bool BCLog::Logger::StartLogging()
 {
     STDLOCK(m_cs);
+    return StartLogging_(SourceLocation{__func__});
+}
 
+bool BCLog::Logger::StartLogging_(const SourceLocation& source_loc)
+{
     assert(m_buffering);
     assert(m_fileout == nullptr);
 
@@ -79,13 +90,15 @@ bool BCLog::Logger::StartLogging()
             .category = BCLog::ALL,
             .level = Level::Info,
             .should_ratelimit = false,
-            .source_loc = SourceLocation{__func__},
+            .source_loc = source_loc,
             .message = strprintf("Early logging buffer overflowed, %d log lines discarded.", m_buffer_lines_discarded),
         });
+        m_buffer_lines_discarded = 0;
     }
     while (!m_msgs_before_open.empty()) {
         const auto& buflog = m_msgs_before_open.front();
         std::string s{Format(buflog)};
+        m_cur_buffer_memusage -= MemUsage(buflog);
         m_msgs_before_open.pop_front();
 
         if (m_print_to_file) FileWriteStr(s, m_fileout);
@@ -100,12 +113,53 @@ bool BCLog::Logger::StartLogging()
     return true;
 }
 
+bool BCLog::Logger::StartFileLogging(fs::path file_path)
+{
+    assert(!file_path.empty() && file_path.is_absolute());
+    STDLOCK(m_cs);
+    if (!m_buffering || m_fileout || m_print_to_file || m_print_to_console || !m_file_path.empty()) return false;
+
+    m_file_path = std::move(file_path);
+    m_print_to_file = true;
+    m_reopen_file = false;
+    try {
+        if (StartLogging_(SourceLocation{__func__})) return true;
+    } catch (...) {
+        CloseFile();
+        m_buffering = true;
+        m_print_to_file = false;
+        m_file_path.clear();
+        m_reopen_file = false;
+        throw;
+    }
+    m_print_to_file = false;
+    m_file_path.clear();
+    m_reopen_file = false;
+    return false;
+}
+
+void BCLog::Logger::CloseFile() noexcept
+{
+    if (m_fileout != nullptr) fclose(m_fileout);
+    m_fileout = nullptr;
+}
+
+void BCLog::Logger::StopFileLogging() noexcept
+{
+    STDLOCK(m_cs);
+    assert(m_fileout != nullptr);
+    CloseFile();
+    m_print_to_file = false;
+    m_file_path.clear();
+    m_reopen_file = false;
+    m_buffering = !m_print_to_console && m_print_callbacks.empty();
+}
+
 void BCLog::Logger::DisconnectTestLogger()
 {
     STDLOCK(m_cs);
     m_buffering = true;
-    if (m_fileout != nullptr) fclose(m_fileout);
-    m_fileout = nullptr;
+    CloseFile();
     m_print_callbacks.clear();
     m_max_buffer_memusage = DEFAULT_MAX_LOG_BUFFER;
     m_cur_buffer_memusage = 0;
@@ -372,13 +426,6 @@ std::string BCLog::Logger::GetLogPrefix(BCLog::LogFlags category, BCLog::Level l
 
     s += "] ";
     return s;
-}
-
-static size_t MemUsage(const util::log::Entry& log)
-{
-    return memusage::DynamicUsage(log.message) +
-           memusage::DynamicUsage(log.thread_name) +
-           memusage::MallocUsage(sizeof(memusage::list_node<util::log::Entry>));
 }
 
 BCLog::LogRateLimiter::LogRateLimiter(uint64_t max_bytes, std::chrono::seconds reset_window)

--- a/src/logging.h
+++ b/src/logging.h
@@ -162,6 +162,9 @@ namespace BCLog {
         /** Send an entry to the log output (internal) */
         void LogPrint_(util::log::Entry log_entry) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
 
+        bool StartLogging_(const SourceLocation& source_loc) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
+        void CloseFile() noexcept EXCLUSIVE_LOCKS_REQUIRED(m_cs);
+
         std::string GetLogPrefix(LogFlags category, Level level) const;
 
     public:
@@ -210,6 +213,24 @@ namespace BCLog {
 
         /** Start logging (and flush all buffered messages) */
         bool StartLogging() EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
+
+        /**
+         * Start an owned file output, replaying buffered messages. The path must be
+         * absolute, nonempty, and contain no embedded NUL characters.
+         * Return false if logging is disabled, already running, configured for
+         * another output, or the file cannot be opened. On failure, messages not
+         * yet replayed remain buffered. Exceptions during startup are rethrown
+         * after closing the file and restoring buffering.
+         */
+        bool StartFileLogging(fs::path file_path) EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
+
+        /**
+         * Close the file owned by a successful StartFileLogging call. The caller
+         * must own that output. Resume buffering unless console output or
+         * internal callbacks remain active; those outputs continue running.
+         */
+        void StopFileLogging() noexcept EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
+
         /** Only for testing */
         void DisconnectTestLogger() EXCLUSIVE_LOCKS_REQUIRED(!m_cs);
 

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -15,11 +15,14 @@
 #include <test/kernel/block_data.h>
 #include <test/util/common.h>
 
+#include <array>
 #include <charconv>
 #include <cstdint>
 #include <cstdlib>
+#include <exception>
 #include <fstream>
 #include <iostream>
+#include <latch>
 #include <memory>
 #include <optional>
 #include <random>
@@ -28,6 +31,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 using namespace btck;
@@ -96,8 +100,8 @@ void check_equal(std::span<const std::byte> _actual, std::span<const std::byte> 
 
 struct TestDirectory {
     fs::path m_directory;
-    TestDirectory(std::string directory_name)
-        : m_directory{fs::path{fs::temp_directory_path()} / fs::u8path(directory_name + "_🌽_" + random_string(16))}
+    TestDirectory(std::string directory_name, fs::path parent = fs::temp_directory_path())
+        : m_directory{parent / fs::u8path(directory_name + "_🌽_" + random_string(16))}
     {
         fs::create_directories(m_directory);
     }
@@ -107,6 +111,25 @@ struct TestDirectory {
         fs::remove_all(m_directory);
     }
 };
+
+std::string read_log_file(const fs::path& log_path)
+{
+    std::ifstream file{log_path.std_path()};
+    BOOST_REQUIRE(file.is_open());
+    std::ostringstream contents;
+    contents << file.rdbuf();
+    return contents.str();
+}
+
+size_t count_log_line(const std::string& contents, std::string_view message)
+{
+    std::istringstream stream{contents};
+    size_t count{0};
+    for (std::string line; std::getline(stream, line);) {
+        if (line == message) ++count;
+    }
+    return count;
+}
 
 class TestKernelNotifications : public KernelNotifications
 {
@@ -643,13 +666,10 @@ BOOST_AUTO_TEST_CASE(logging_tests)
     const TestDirectory test_directory{"logging_test_bitcoin_kernel"};
     const auto log_path{test_directory.m_directory / "kernel.log"};
     const auto file_path{PathToString(log_path)};
-    const auto read_log = [&] {
-        std::ifstream file{log_path.std_path()};
-        BOOST_REQUIRE(file.is_open());
-        std::ostringstream contents;
-        contents << file.rdbuf();
-        return contents.str();
-    };
+    {
+        std::ofstream file{log_path.std_path()};
+        file << "pre-existing log content\n";
+    }
     btck_LoggingOptions logging_options = {
         .log_timestamps = true,
         .log_time_micros = true,
@@ -669,20 +689,186 @@ BOOST_AUTO_TEST_CASE(logging_tests)
         logging_set_level_category(LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
         logging_enable_category(LogCategory::KERNEL);
         Logger logger{file_path};
+        const auto before_duplicate{read_log_file(log_path)};
         const auto rejected_path{test_directory.m_directory / "rejected.log"};
         BOOST_CHECK_THROW(Logger{PathToString(rejected_path)}, std::runtime_error);
         BOOST_CHECK(!fs::exists(rejected_path));
+        {
+            std::ofstream file{rejected_path.std_path()};
+            file << "other file content\n";
+        }
+        BOOST_CHECK_THROW(Logger{PathToString(rejected_path)}, std::runtime_error);
+        BOOST_CHECK_EQUAL(read_log_file(rejected_path), "other file content\n");
+        BOOST_CHECK_EQUAL(read_log_file(log_path), before_duplicate);
         ChainParams params{hex_string_to_byte_vec("5151")};
     }
-    const auto first_session{read_log()};
+    const auto first_session{read_log_file(log_path)};
+    BOOST_CHECK(first_session.starts_with("pre-existing log content\n"));
     BOOST_CHECK(first_session.find("Signet with challenge 5151") != std::string::npos);
+    ChainParams between_sessions{hex_string_to_byte_vec("5353")};
+    BOOST_CHECK_EQUAL(read_log_file(log_path), first_session);
     {
         Logger logger{file_path};
         ChainParams params{hex_string_to_byte_vec("5252")};
     }
-    const auto second_session{read_log()};
+    const auto second_session{read_log_file(log_path)};
     BOOST_CHECK(second_session.starts_with(first_session));
     BOOST_CHECK(second_session.find("Signet with challenge 5252") != std::string::npos);
+    const auto buffered_message{second_session.find("Signet with challenge 5353")};
+    BOOST_CHECK(buffered_message != std::string::npos);
+    BOOST_CHECK_EQUAL(buffered_message, second_session.rfind("Signet with challenge 5353"));
+}
+
+BOOST_AUTO_TEST_CASE(logging_path_tests)
+{
+    const TestDirectory test_directory{"logging_path_test_bitcoin_kernel"};
+    const auto log_path{test_directory.m_directory / "kernel.log"};
+    const auto file_path{PathToString(log_path)};
+    logging_set_options({});
+    ChainParams before_creation{hex_string_to_byte_vec("545556")};
+
+    using Connection = std::unique_ptr<btck_LoggingConnection, decltype(&btck_logging_connection_destroy)>;
+    const auto check_rejected = [](const char* path, size_t size) {
+        Connection connection{btck_logging_connection_create(path, size), btck_logging_connection_destroy};
+        BOOST_CHECK(!connection);
+    };
+    check_rejected(nullptr, 0);
+    check_rejected("", 0);
+    check_rejected(file_path.data(), 0);
+    check_rejected(file_path.c_str(), file_path.size() + 1); // Includes the terminating NUL.
+    const std::string embedded_nul{file_path + '\0' + "suffix"};
+    check_rejected(embedded_nul.data(), embedded_nul.size());
+    BOOST_CHECK(!fs::exists(log_path));
+    BOOST_CHECK_THROW(Logger{std::string_view{}}, std::runtime_error);
+
+    const auto missing_parent{test_directory.m_directory / "missing" / "kernel.log"};
+    const auto missing_path{PathToString(missing_parent)};
+    check_rejected(missing_path.data(), missing_path.size());
+    BOOST_CHECK(!fs::exists(missing_parent.parent_path()));
+    const auto directory_path{PathToString(test_directory.m_directory)};
+    check_rejected(directory_path.data(), directory_path.size());
+
+    Connection connection{nullptr, btck_logging_connection_destroy};
+    {
+        // The supplied path ends at the length boundary, with no NUL there.
+        // Its backing storage is destroyed before any subsequent logging.
+        const std::string storage{file_path + ".ignored"};
+        connection.reset(btck_logging_connection_create(storage.data(), file_path.size()));
+        BOOST_REQUIRE(connection);
+    }
+    ChainParams after_creation{hex_string_to_byte_vec("575859")};
+    connection.reset();
+    const auto contents{read_log_file(log_path)};
+    BOOST_CHECK_EQUAL(count_log_line(contents, "Signet with challenge 545556"), 1);
+    BOOST_CHECK_EQUAL(count_log_line(contents, "Signet with challenge 575859"), 1);
+    BOOST_CHECK(!fs::exists(log_path + ".ignored"));
+    btck_logging_connection_destroy(nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(logging_relative_path)
+{
+    // Using a directory below cwd also works when the system temporary
+    // directory is on a different Windows drive, without changing process cwd.
+    const TestDirectory test_directory{"logging_relative_test_bitcoin_kernel", fs::current_path()};
+    const auto log_path{test_directory.m_directory / "kernel.log"};
+    const fs::path relative_path{fs::relative(log_path, fs::current_path())};
+    BOOST_REQUIRE(relative_path.is_relative());
+    logging_set_options({});
+    {
+        Logger logger{PathToString(relative_path)};
+        ChainParams params{hex_string_to_byte_vec("616263")};
+    }
+    BOOST_CHECK_EQUAL(count_log_line(read_log_file(log_path), "Signet with challenge 616263"), 1);
+}
+
+BOOST_AUTO_TEST_CASE(logging_formatting_and_filtering)
+{
+    const TestDirectory test_directory{"logging_options_test_bitcoin_kernel"};
+    const auto log_path{test_directory.m_directory / "kernel.log"};
+    btck_LoggingOptions options{};
+    options.always_print_category_levels = true;
+    logging_set_options(options);
+    logging_set_level_category(LogCategory::KERNEL, LogLevel::DEBUG_LEVEL);
+    logging_disable_category(LogCategory::KERNEL);
+    Logger logger{PathToString(log_path)};
+    const auto initial{read_log_file(log_path)};
+    const auto emit_debug = [] {
+        const std::array invalid_block{std::byte{0}};
+        BOOST_CHECK_THROW(Block{invalid_block}, std::runtime_error);
+    };
+
+    emit_debug(); // A disabled category is suppressed even at DEBUG level.
+    BOOST_CHECK_EQUAL(read_log_file(log_path), initial);
+    logging_enable_category(LogCategory::KERNEL);
+    logging_set_level_category(LogCategory::KERNEL, LogLevel::INFO_LEVEL);
+    emit_debug();
+    BOOST_CHECK_EQUAL(read_log_file(log_path), initial);
+    logging_set_level_category(LogCategory::KERNEL, LogLevel::DEBUG_LEVEL);
+    emit_debug();
+    const auto formatted{read_log_file(log_path)};
+    BOOST_CHECK_EQUAL(formatted, initial + "[kernel:debug] Block decode failed.\n");
+    logging_disable_category(LogCategory::KERNEL);
+    emit_debug();
+    BOOST_CHECK_EQUAL(read_log_file(log_path), formatted);
+}
+
+BOOST_AUTO_TEST_CASE(logging_concurrent_close)
+{
+    const TestDirectory test_directory{"logging_close_test_bitcoin_kernel"};
+    const auto first_path{test_directory.m_directory / "first.log"};
+    const auto replay_path{test_directory.m_directory / "replay.log"};
+    logging_set_options({});
+    auto logger{std::make_unique<Logger>(PathToString(first_path))};
+    constexpr uint8_t last_message{65};
+    const auto emit = [](uint8_t sequence) {
+        const std::array challenge{std::byte{0xfa}, std::byte{sequence}};
+        ChainParams params{challenge};
+    };
+    emit(0);
+    std::latch ready{1};
+    std::exception_ptr producer_error;
+    std::thread producer{[&] {
+        try {
+            emit(1);
+        } catch (...) {
+            producer_error = std::current_exception();
+            ready.count_down();
+            return;
+        }
+        ready.count_down();
+        try {
+            for (uint8_t sequence{2}; sequence < last_message; ++sequence) emit(sequence);
+        } catch (...) {
+            producer_error = std::current_exception();
+        }
+    }};
+    try {
+        // The producer has written one record and can keep logging while the file closes.
+        ready.wait();
+        logger.reset();
+        emit(last_message);
+    } catch (...) {
+        producer.join();
+        throw;
+    }
+    producer.join();
+    if (producer_error) std::rethrow_exception(producer_error);
+
+    const auto first_session{read_log_file(first_path)};
+    {
+        Logger replay{PathToString(replay_path)};
+    }
+    const auto replay_session{read_log_file(replay_path)};
+    BOOST_CHECK_EQUAL(count_log_line(first_session, "Signet with challenge fa00"), 1);
+    BOOST_CHECK_EQUAL(count_log_line(first_session, "Signet with challenge fa01"), 1);
+    BOOST_CHECK_EQUAL(count_log_line(first_session, "Signet with challenge fa41"), 0);
+    BOOST_CHECK_EQUAL(count_log_line(replay_session, "Signet with challenge fa41"), 1);
+    const auto contents{first_session + replay_session};
+    constexpr std::string_view hex{"0123456789abcdef"};
+    for (uint8_t sequence{0}; sequence <= last_message; ++sequence) {
+        const auto message{std::string{"Signet with challenge fa"} + hex[sequence >> 4] + hex[sequence & 15]};
+        BOOST_CHECK_EQUAL(count_log_line(contents, message), 1);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(btck_chainparams_tests)

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -18,12 +18,14 @@
 #include <charconv>
 #include <cstdint>
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <random>
 #include <ranges>
 #include <span>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -91,15 +93,6 @@ void check_equal(std::span<const std::byte> _actual, std::span<const std::byte> 
         actual.begin(), actual.end(),
         expected.begin(), expected.end());
 }
-
-class TestLog
-{
-public:
-    void LogMessage(std::string_view message)
-    {
-        std::cout << "kernel: " << message;
-    }
-};
 
 struct TestDirectory {
     fs::path m_directory;
@@ -647,6 +640,16 @@ BOOST_AUTO_TEST_CASE(btck_script_verify_tests)
 
 BOOST_AUTO_TEST_CASE(logging_tests)
 {
+    const TestDirectory test_directory{"logging_test_bitcoin_kernel"};
+    const auto log_path{test_directory.m_directory / "kernel.log"};
+    const auto file_path{PathToString(log_path)};
+    const auto read_log = [&] {
+        std::ifstream file{log_path.std_path()};
+        BOOST_REQUIRE(file.is_open());
+        std::ostringstream contents;
+        contents << file.rdbuf();
+        return contents.str();
+    };
     btck_LoggingOptions logging_options = {
         .log_timestamps = true,
         .log_time_micros = true,
@@ -661,14 +664,25 @@ BOOST_AUTO_TEST_CASE(logging_tests)
     logging_enable_category(LogCategory::VALIDATION);
     logging_disable_category(LogCategory::VALIDATION);
 
-    // Check that connecting, connecting another, and then disconnecting and connecting a logger again works.
+    // A file has one owner, and closing it allows another connection to append.
     {
         logging_set_level_category(LogCategory::KERNEL, LogLevel::TRACE_LEVEL);
         logging_enable_category(LogCategory::KERNEL);
-        Logger logger{std::make_unique<TestLog>()};
-        Logger logger_2{std::make_unique<TestLog>()};
+        Logger logger{file_path};
+        const auto rejected_path{test_directory.m_directory / "rejected.log"};
+        BOOST_CHECK_THROW(Logger{PathToString(rejected_path)}, std::runtime_error);
+        BOOST_CHECK(!fs::exists(rejected_path));
+        ChainParams params{hex_string_to_byte_vec("5151")};
     }
-    Logger logger{std::make_unique<TestLog>()};
+    const auto first_session{read_log()};
+    BOOST_CHECK(first_session.find("Signet with challenge 5151") != std::string::npos);
+    {
+        Logger logger{file_path};
+        ChainParams params{hex_string_to_byte_vec("5252")};
+    }
+    const auto second_session{read_log()};
+    BOOST_CHECK(second_session.starts_with(first_session));
+    BOOST_CHECK(second_session.find("Signet with challenge 5252") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(btck_chainparams_tests)
@@ -774,8 +788,8 @@ Context create_context(std::shared_ptr<TestKernelNotifications> notifications, C
 
 BOOST_AUTO_TEST_CASE(btck_chainman_tests)
 {
-    Logger logger{std::make_unique<TestLog>()};
     auto test_directory{TestDirectory{"chainman_test_bitcoin_kernel"}};
+    Logger logger{PathToString(test_directory.m_directory / "kernel.log")};
 
     { // test with default context
         Context context{};

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -20,6 +20,7 @@
 #include <ios>
 #include <iostream>
 #include <source_location>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -38,14 +39,217 @@ static void ResetLogger()
     LogInstance().SetCategoryLogLevel({});
 }
 
-static std::vector<std::string> ReadDebugLogLines()
+static std::vector<std::string> ReadDebugLogLines(const fs::path& file_path = LogInstance().m_file_path)
 {
     std::vector<std::string> lines;
-    std::ifstream ifs{LogInstance().m_file_path.std_path()};
+    std::ifstream ifs{file_path.std_path()};
     for (std::string line; std::getline(ifs, line);) {
         lines.push_back(std::move(line));
     }
     return lines;
+}
+
+struct FileLogSetup : BasicTestingSetup {
+    BCLog::Logger logger;
+    const fs::path log_path{m_args.GetDataDirBase() / "file.log"};
+
+    FileLogSetup() { logger.m_log_timestamps = false; }
+    ~FileLogSetup() { logger.DisconnectTestLogger(); }
+
+    void Log(std::string message)
+    {
+        logger.LogPrint({.category = BCLog::ALL, .level = BCLog::Level::Info, .source_loc = SourceLocation{__func__}, .message = std::move(message)});
+    }
+
+    std::vector<std::string> Lines() const
+    {
+        auto lines{ReadDebugLogLines(log_path)};
+        std::erase(lines, std::string{}); // Ignore the session separators.
+        return lines;
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(logging_file_lifecycle, FileLogSetup)
+{
+    {
+        std::ofstream file{log_path.std_path()};
+        file << "existing\n";
+    }
+    Log("before opening");
+    BOOST_REQUIRE(logger.StartFileLogging(log_path));
+    Log("while open");
+    logger.m_reopen_file = true;
+    logger.StopFileLogging();
+    BOOST_CHECK(!logger.m_print_to_file);
+    BOOST_CHECK(logger.m_file_path.empty());
+    BOOST_CHECK(!logger.m_reopen_file);
+    BOOST_CHECK(logger.Enabled());
+    BOOST_CHECK(Lines() == (std::vector<std::string>{"existing", "before opening", "while open"}));
+
+    Log("after closing");
+    BOOST_CHECK(Lines() == (std::vector<std::string>{"existing", "before opening", "while open"}));
+    BOOST_REQUIRE(logger.StartFileLogging(log_path));
+    Log("after reopening");
+    logger.StopFileLogging();
+    BOOST_CHECK(Lines() == (std::vector<std::string>{"existing", "before opening", "while open", "after closing", "after reopening"}));
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_file_open_failure, FileLogSetup)
+{
+    Log("retained after failure");
+    const auto missing_parent{m_args.GetDataDirBase() / "missing" / "file.log"};
+    BOOST_CHECK(!logger.StartFileLogging(missing_parent));
+    BOOST_CHECK(!fs::exists(missing_parent));
+    BOOST_CHECK(!logger.m_print_to_file);
+    BOOST_CHECK(logger.m_file_path.empty());
+    BOOST_CHECK(!logger.m_reopen_file);
+    BOOST_REQUIRE(logger.StartFileLogging(log_path));
+    Log("after retry");
+    logger.StopFileLogging();
+    BOOST_CHECK(Lines() == (std::vector<std::string>{"retained after failure", "after retry"}));
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_file_duplicate, FileLogSetup)
+{
+    BOOST_REQUIRE(logger.StartFileLogging(log_path));
+    const auto rejected_path{m_args.GetDataDirBase() / "rejected.log"};
+    logger.m_reopen_file = true;
+    BOOST_CHECK(!logger.StartFileLogging(rejected_path));
+    BOOST_CHECK(logger.m_reopen_file);
+    BOOST_CHECK(logger.m_file_path == log_path);
+    BOOST_CHECK(!fs::exists(rejected_path));
+    {
+        std::ofstream file{rejected_path.std_path()};
+        file << "unchanged\n";
+    }
+    BOOST_CHECK(!logger.StartFileLogging(rejected_path));
+    BOOST_CHECK(ReadDebugLogLines(rejected_path) == (std::vector<std::string>{"unchanged"}));
+    Log("original output still active");
+    logger.StopFileLogging();
+    BOOST_CHECK(Lines() == (std::vector<std::string>{"original output still active"}));
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_file_disabled, FileLogSetup)
+{
+    logger.DisableLogging();
+    BOOST_CHECK(!logger.Enabled());
+    BOOST_CHECK(!logger.StartFileLogging(log_path));
+    BOOST_CHECK(!logger.Enabled());
+    BOOST_CHECK(!fs::exists(log_path));
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_file_existing_output, FileLogSetup)
+{
+    logger.m_print_to_file = true;
+    logger.m_file_path = log_path;
+    const auto rejected_path{m_args.GetDataDirBase() / "rejected.log"};
+    BOOST_CHECK(!logger.StartFileLogging(rejected_path));
+    BOOST_CHECK(logger.m_print_to_file);
+    BOOST_CHECK(logger.m_file_path == log_path);
+    BOOST_CHECK(!fs::exists(log_path));
+    BOOST_CHECK(!fs::exists(rejected_path));
+
+    BOOST_REQUIRE(logger.StartLogging());
+    BOOST_CHECK(!logger.StartFileLogging(rejected_path));
+    Log("node output still active");
+    BOOST_CHECK(Lines() == (std::vector<std::string>{"node output still active"}));
+    BOOST_CHECK(!fs::exists(rejected_path));
+
+    BCLog::Logger console;
+    console.m_print_to_console = true;
+    BOOST_CHECK(!console.StartFileLogging(rejected_path));
+    BOOST_CHECK(console.m_print_to_console);
+
+    BCLog::Logger configured_path;
+    configured_path.m_file_path = log_path;
+    BOOST_CHECK(!configured_path.StartFileLogging(rejected_path));
+    BOOST_CHECK(configured_path.m_file_path == log_path);
+    BOOST_CHECK(!fs::exists(rejected_path));
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_file_callbacks, FileLogSetup)
+{
+    std::vector<std::string> messages;
+    const auto connection{logger.PushBackCallback([&](const std::string& message) { messages.push_back(message); })};
+    Log("buffered");
+    BOOST_CHECK(messages.empty());
+    BOOST_REQUIRE(logger.StartFileLogging(log_path));
+    Log("both outputs");
+    logger.StopFileLogging();
+    BOOST_CHECK_EQUAL(logger.NumConnections(), 1);
+    Log("callback only");
+    BOOST_CHECK(messages == (std::vector<std::string>{"buffered\n", "both outputs\n", "callback only\n"}));
+    BOOST_CHECK(Lines() == (std::vector<std::string>{"buffered", "both outputs"}));
+    const auto rejected_path{m_args.GetDataDirBase() / "rejected.log"};
+    BOOST_CHECK(!logger.StartFileLogging(rejected_path));
+    BOOST_CHECK(!fs::exists(rejected_path));
+    logger.DeleteCallback(connection);
+    BOOST_CHECK_EQUAL(logger.NumConnections(), 0);
+    BOOST_CHECK(!logger.Enabled());
+    BOOST_CHECK(!logger.StartFileLogging(rejected_path));
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_file_console, FileLogSetup)
+{
+    BOOST_REQUIRE(logger.StartFileLogging(log_path));
+    logger.m_print_to_console = true;
+    logger.StopFileLogging();
+    BOOST_CHECK(logger.m_print_to_console);
+    std::string message;
+    const auto connection{logger.PushBackCallback([&](const std::string& value) { message = value; })};
+    Log("console output remains active");
+    BOOST_CHECK_EQUAL(message, "console output remains active\n");
+    BOOST_CHECK(Lines().empty());
+    logger.DeleteCallback(connection);
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_file_replay_exception, FileLogSetup)
+{
+    // Discard an oversized entry, then retain two entries well within the buffer limit.
+    Log(std::string(2 * BCLog::DEFAULT_MAX_LOG_BUFFER, 'x'));
+    const std::string first(BCLog::DEFAULT_MAX_LOG_BUFFER / 3, 'a');
+    const std::string retained(BCLog::DEFAULT_MAX_LOG_BUFFER / 3, 'b');
+    Log(first);
+    Log(retained);
+    bool throw_once{true};
+    const auto connection{logger.PushBackCallback([&](const std::string& message) {
+        if (throw_once && message.starts_with("aaa")) {
+            throw_once = false;
+            throw std::runtime_error("startup replay interrupted");
+        }
+    })};
+    BOOST_CHECK_THROW(logger.StartFileLogging(log_path), std::runtime_error);
+    BOOST_CHECK(!logger.m_print_to_file);
+    BOOST_CHECK(logger.m_file_path.empty());
+    BOOST_CHECK(!logger.m_reopen_file);
+    BOOST_CHECK_EQUAL(logger.NumConnections(), 1);
+    const auto partial{Lines()};
+    BOOST_REQUIRE_EQUAL(partial.size(), 2);
+    BOOST_CHECK(partial.front().starts_with("Early logging buffer overflowed, "));
+    BOOST_CHECK_EQUAL(partial.back(), first);
+
+    // This fits beside the retained entry only if the consumed entry's memory
+    // has been removed from the accounting. The old discard notice must not recur.
+    const std::string after_failure(BCLog::DEFAULT_MAX_LOG_BUFFER / 2, 'c');
+    Log(after_failure);
+    BOOST_REQUIRE(logger.StartFileLogging(log_path));
+    logger.StopFileLogging();
+    BOOST_CHECK(Lines() == (std::vector<std::string>{partial.front(), first, retained, after_failure}));
+    logger.DeleteCallback(connection);
+}
+
+BOOST_FIXTURE_TEST_CASE(logging_startup_overflow, FileLogSetup)
+{
+    logger.m_file_path = log_path;
+    logger.m_print_to_file = true;
+    logger.m_log_sourcelocations = true;
+    Log(std::string(2 * BCLog::DEFAULT_MAX_LOG_BUFFER, 'x'));
+    Log("retained");
+    BOOST_REQUIRE(logger.StartLogging());
+    const auto lines{Lines()};
+    BOOST_REQUIRE_EQUAL(lines.size(), 2);
+    BOOST_CHECK(lines.front().find("[StartLogging] Early logging buffer overflowed, 1 log lines discarded.") != std::string::npos);
+    BOOST_CHECK(lines.back().ends_with("retained"));
 }
 
 struct LogSetup : public BasicTestingSetup {

--- a/test/functional/tool_bitcoin_chainstate.py
+++ b/test/functional/tool_bitcoin_chainstate.py
@@ -12,6 +12,7 @@ snapshot and extend the snapshot chain with new blocks.
 """
 
 import subprocess
+from pathlib import Path
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -51,7 +52,9 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         assert_equal(n0.getbestblockhash(), SNAPSHOT_BASE_BLOCK_HASH)
         return n0.dumptxoutset('utxos.dat', "latest")
 
-    def add_block(self, datadir, input, *, expected_stderr=None, expected_stdout=None):
+    def add_block(self, datadir, input, *, expected_stderr=None, expected_stdout=None, expected_log=None):
+        log_path = Path(datadir) / "bitcoin-chainstate.log"
+        previous_log = log_path.read_bytes() if log_path.exists() else b""
         proc = subprocess.Popen(
             self.get_binaries().chainstate_argv() + ["-regtest", datadir],
             stdin=subprocess.PIPE,
@@ -62,6 +65,17 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         stdout, stderr = proc.communicate(input=input + "\n", timeout=5 * self.options.timeout_factor)
         self.log.debug("STDOUT: {0}".format(stdout.strip("\n")))
         self.log.info("STDERR: {0}".format(stderr.strip("\n")))
+        assert_equal(proc.returncode, 0)
+        assert f"Logging to {log_path}" in stdout
+        assert "Enter the block you want to validate on the next line:" in stdout
+        assert log_path.is_file()
+        current_log = log_path.read_bytes()
+        assert current_log.startswith(previous_log)
+        new_log = current_log[len(previous_log):].decode("utf-8")
+        assert "SHA256 implementation" in new_log
+        assert "Loaded best chain:" in new_log
+        if expected_log is not None:
+            assert expected_log in new_log
 
         if expected_stderr is not None and expected_stderr not in stderr:
             raise AssertionError(f"Expected stderr output '{expected_stderr}' does not partially match stderr:\n{stderr}")
@@ -73,9 +87,10 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         n1 = self.nodes[1]
         datadir = n1.chain_path
         n1.stop_node()
-        block = n0.getblock(n0.getblockhash(START_HEIGHT+1), 0)
+        block_hash = n0.getblockhash(START_HEIGHT+1)
+        block = n0.getblock(block_hash, 0)
         self.log.info(f"Test bitcoin-chainstate {self.get_binaries().chainstate_argv()} with datadir: {datadir}")
-        self.add_block(datadir, block, expected_stderr="Block has not yet been rejected")
+        self.add_block(datadir, block, expected_stderr="Block has not yet been rejected", expected_stdout="Valid block", expected_log=f"new best={block_hash}")
         self.add_block(datadir, block, expected_stderr="duplicate")
         self.add_block(datadir, "00", expected_stderr="Block decode failed")
         self.add_block(datadir, "", expected_stderr="Empty line found")
@@ -95,9 +110,27 @@ class BitcoinChainstateTest(BitcoinTestFramework):
         n1.stop_node()
         self.log.info(f"Test bitcoin-chainstate {self.get_binaries().chainstate_argv()} with an assumeutxo datadir: {datadir}")
         new_tip_hash = self.generate(n0, nblocks=1, sync_fun=self.no_op)[0]
-        self.add_block(datadir, n0.getblock(new_tip_hash, 0), expected_stdout="Block tip changed")
+        self.add_block(datadir, n0.getblock(new_tip_hash, 0), expected_stdout="Block tip changed", expected_log=f"new best={new_tip_hash}")
+
+    def logging_failure_test(self):
+        datadir = Path(self.options.tmpdir) / "logging_failure"
+        log_path = datadir / "bitcoin-chainstate.log"
+        log_path.mkdir(parents=True)
+        proc = subprocess.run(
+            self.get_binaries().chainstate_argv() + ["-regtest", str(datadir)],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=5 * self.options.timeout_factor,
+        )
+        assert_equal(proc.returncode, 1)
+        assert f"Failed to open log file {log_path}, exiting" in proc.stderr
+        assert "Enter the block" not in proc.stdout
+        assert not (datadir / "blocks").exists()
+        assert log_path.is_dir()
 
     def run_test(self):
+        self.logging_failure_test()
         dump_output = self.generate_snapshot_chain()
         self.basic_test()
         self.assumeutxo_test(dump_output['path'])


### PR DESCRIPTION
Kernel logging currently invokes application handlers while holding the logger mutex and, in some cases, validation locks. Slow handlers delay the caller, and handlers that call back into the kernel or acquire conflicting locks can deadlock.

This PR replaces those callbacks with the file writer already used by the node. Applications provide a file path through the C API or C++ wrapper, and the existing logger appends messages to that file. A single logging connection owns the file and closes it when destroyed.

This keeps application log handling out of kernel execution while reusing Core’s existing file writer and bounded startup buffer. It also avoids adding a separate delivery queue with its own capacity, overflow, and consumer lifecycle concerns. Applications can read the file independently and forward messages elsewhere.

File output keeps the node’s existing logging behavior: synchronous, best-effort writes with bounded startup buffering.