### PR TITLE
rpc: invalid credentials can occupy every HTTP worker

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -214,12 +214,6 @@ static void HTTPReq_JSONRPC(const std::any& context, HTTPRequest* req)
     jreq.URI = req->GetURI();
     if (!RPCAuthorized(*auth_header, jreq.authUser)) {
         LogWarning("ThreadRPCServer incorrect password attempt from %s", jreq.peerAddr);
-
-        /* Deter brute-forcing
-           If this results in a DoS the user really
-           shouldn't have their RPC port exposed. */
-        UninterruptibleSleep(std::chrono::milliseconds{250});
-
         req->WriteHeader("WWW-Authenticate", WWW_AUTH_HEADER_DATA);
         req->WriteReply(HTTP_UNAUTHORIZED);
         return;

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -146,6 +146,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         self.check_auth_required()
         self.check_wrong_credentials()
         self.check_malformed_auth_headers()
+        self.check_auth_failures_do_not_block_worker()
         self.check_disallowed_http_methods()
         self.check_path_traversal()
         self.check_request_smuggling_cl_te()
@@ -499,6 +500,41 @@ class HTTPBasicsTest (BitcoinTestFramework):
             response = conn.post('/', '{"method": "getbestblockhash"}')
             assert_equal(response.status, http.client.UNAUTHORIZED)
             assert response.getheader('WWW-Authenticate') is not None
+
+
+    def check_auth_failures_do_not_block_worker(self):
+        self.log.info("Check that authentication failures do not delay valid RPCs with one worker")
+        self.restart_node(0, extra_args=["-rpcthreads=1"])
+
+        conn = BitcoinHTTPConnection(self.node)
+        invalid_auth_values = [
+            "Basic !!!notbase64!!!",
+            f"Basic {str_to_b64str(f'{conn.url.username}_unknown:password')}",
+            f"Basic {str_to_b64str(f'{conn.url.username}:wrong_password')}",
+        ]
+        for auth_value in invalid_auth_values:
+            invalid_conn = BitcoinHTTPConnection(self.node)
+            invalid_conn.headers = {"Authorization": auth_value}
+            with self.node.busy_wait_for_debug_log([b"incorrect password attempt"]):
+                invalid_conn.conn.request(
+                    method="POST",
+                    url="/",
+                    body='{"method": "getblockcount"}',
+                    headers=invalid_conn.headers,
+                )
+
+            valid_conn = BitcoinHTTPConnection(self.node)
+            start = time.perf_counter()
+            valid_response = valid_conn.post('/', '{"method": "getblockcount"}')
+            valid_response.read()
+            latency = time.perf_counter() - start
+
+            assert_equal(valid_response.status, http.client.OK)
+            assert latency < 0.2, f"Valid RPC was delayed by an authentication failure: {latency:.3f}s"
+
+            invalid_response = invalid_conn.conn.getresponse()
+            invalid_response.read()
+            assert_equal(invalid_response.status, http.client.UNAUTHORIZED)
 
 
     def check_disallowed_http_methods(self):


### PR DESCRIPTION
#### Problem

RPC clients are able to easily DoS the HTTP server due to an obligatory worker thread sleep upon authentication failure.

#### Solution

Remove the sleep.

While this allows the guess rate to increase, it also fixes the DoS vector and reduces production code.

#### History

fe98cf8dc5066368b78e9ce208118c3532598dd2 from 2010 introduced RPC authentication along with the sleep. At that point the password authentication was timing-sensitive depending on the length, so the credentials could have been brute-forced. A sleep was added to help mitigate these timing attacks (and also reduce the guess rate).

The same author then introduced `TimingResistantEqual()` in 42656ea2e552b027e174fdceab7348ffcb8245c4 / https://github.com/bitcoin/bitcoin/pull/2886 in 2013 to solve the timing attack once and for all (https://github.com/bitcoin/bitcoin/issues/2838 / CVE-2013-4165). That made the sleep only serve to reduce the guess rate.

#### Severity

Low since the attack requires RPC clients to be granted network access to a node.