### PR TITLE
contrib: reject truncated UTXO snapshots during SQLite conversion

### DIFF
--- a/contrib/utxo-tools/test_utxo_to_sqlite.py
+++ b/contrib/utxo-tools/test_utxo_to_sqlite.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Run with python3 contrib/utxo-tools/test_utxo_to_sqlite.py."""
+
+import io
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from utxo_to_sqlite import decompress_script, read_compactsize, read_varint
+
+
+class UtxoToSqliteTest(unittest.TestCase):
+    def test_compactsize_truncation(self):
+        for encoded, expected in [
+            (b'\xfd\xfd\x00', 253),
+            (b'\xfe\x00\x00\x01\x00', 65536),
+            (b'\xff\x00\x00\x00\x00\x01\x00\x00\x00', 2**32),
+        ]:
+            self.assertEqual(read_compactsize(io.BytesIO(encoded)), expected)
+            for size in range(len(encoded)):
+                with self.subTest(encoded=encoded, size=size), self.assertRaises(ValueError):
+                    read_compactsize(io.BytesIO(encoded[:size]))
+
+    def test_varint_truncation(self):
+        self.assertEqual(read_varint(io.BytesIO(b'\x80\x00')), 128)
+        for encoded in [b'', b'\x80']:
+            with self.subTest(encoded=encoded), self.assertRaises(ValueError):
+                read_varint(io.BytesIO(encoded))
+
+    def test_script_truncation(self):
+        generator_x = bytes.fromhex('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798')
+        for encoded, script_size in [
+            (b'\x00' + bytes(20), 25),
+            (b'\x01' + bytes(20), 23),
+            (b'\x02' + generator_x, 35),
+            (b'\x03' + generator_x, 35),
+            (b'\x04' + generator_x, 67),
+            (b'\x05' + generator_x, 67),
+            (b'\x0a' + b'\x51' * 4, 4),
+        ]:
+            self.assertEqual(len(decompress_script(io.BytesIO(encoded))), script_size)
+            for size in range(len(encoded)):
+                with self.subTest(tag=encoded[0], size=size), self.assertRaises(ValueError):
+                    decompress_script(io.BytesIO(encoded[:size]))
+        self.assertEqual(decompress_script(io.BytesIO(b'\x06')), b'')
+
+    def test_snapshot_conversion(self):
+        # Version 2, regtest, one coin, one txid group, vout 0, height 1,
+        # non-coinbase, amount code 1, and a four-byte uncompressed script.
+        header = b'utxo\xff' + (2).to_bytes(2, 'little') + bytes.fromhex('fabfb5da')
+        header += bytes(32) + (1).to_bytes(8, 'little')
+        coin = bytes(32) + bytes([1, 0, 2, 1, 10]) + b'\x51' * 4
+        snapshot = header + coin
+        for data in [snapshot, snapshot[:-3], header[:-1]]:
+            with self.subTest(length=len(data)), tempfile.TemporaryDirectory() as directory:
+                source = Path(directory) / 'snapshot.dat'
+                output = Path(directory) / 'snapshot.sqlite'
+                source.write_bytes(data)
+                result = subprocess.run(
+                    [sys.executable, str(Path(__file__).with_name('utxo_to_sqlite.py')), str(source), str(output)],
+                    capture_output=True, text=True, check=False,
+                )
+                if data == snapshot:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    with sqlite3.connect(output) as connection:
+                        self.assertEqual(connection.execute('SELECT scriptpubkey FROM utxos').fetchall(), [('51515151',)])
+                else:
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn('Truncated UTXO snapshot', result.stderr)
+                    self.assertNotIn('TOTAL:', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contrib/utxo-tools/utxo_to_sqlite.py
+++ b/contrib/utxo-tools/utxo_to_sqlite.py
@@ -31,11 +31,19 @@ NET_MAGIC_BYTES = {
 }
 
 
+def read_exact(f, size):
+    """Read a complete field, rejecting truncated snapshots."""
+    data = f.read(size)
+    if len(data) != size:
+        raise ValueError(f"Truncated UTXO snapshot: expected {size} bytes, got {len(data)}")
+    return data
+
+
 def read_varint(f):
     """Equivalent of `ReadVarInt()` (see serialization module)."""
     n = 0
     while True:
-        dat = f.read(1)[0]
+        dat = read_exact(f, 1)[0]
         n = (n << 7) | (dat & 0x7f)
         if (dat & 0x80) > 0:
             n += 1
@@ -45,13 +53,13 @@ def read_varint(f):
 
 def read_compactsize(f):
     """Equivalent of `ReadCompactSize()` (see serialization module)."""
-    n = f.read(1)[0]
+    n = read_exact(f, 1)[0]
     if n == 253:
-        n = int.from_bytes(f.read(2), "little")
+        n = int.from_bytes(read_exact(f, 2), "little")
     elif n == 254:
-        n = int.from_bytes(f.read(4), "little")
+        n = int.from_bytes(read_exact(f, 4), "little")
     elif n == 255:
-        n = int.from_bytes(f.read(8), "little")
+        n = int.from_bytes(read_exact(f, 8), "little")
     return n
 
 
@@ -79,18 +87,18 @@ def decompress_script(f):
     """Equivalent of `DecompressScript()` (see compressor module)."""
     size = read_varint(f)  # sizes 0-5 encode compressed script types
     if size == 0:  # P2PKH
-        return bytes([0x76, 0xa9, 20]) + f.read(20) + bytes([0x88, 0xac])
+        return bytes([0x76, 0xa9, 20]) + read_exact(f, 20) + bytes([0x88, 0xac])
     elif size == 1:  # P2SH
-        return bytes([0xa9, 20]) + f.read(20) + bytes([0x87])
+        return bytes([0xa9, 20]) + read_exact(f, 20) + bytes([0x87])
     elif size in (2, 3):  # P2PK (compressed)
-        return bytes([33, size]) + f.read(32) + bytes([0xac])
+        return bytes([33, size]) + read_exact(f, 32) + bytes([0xac])
     elif size in (4, 5):  # P2PK (uncompressed)
-        compressed_pubkey = bytes([size - 2]) + f.read(32)
+        compressed_pubkey = bytes([size - 2]) + read_exact(f, 32)
         return bytes([65]) + decompress_pubkey(compressed_pubkey) + bytes([0xac])
     else:  # others (bare multisig, segwit etc.)
         size -= 6
         assert size <= 10000, f"too long script with size {size}"
-        return f.read(size)
+        return read_exact(f, size)
 
 
 def decompress_pubkey(compressed_pubkey):
@@ -139,11 +147,11 @@ def main():
 
     # read metadata (magic bytes, version, network magic, block hash, UTXO count)
     f = open(args.infile, 'rb')
-    magic_bytes = f.read(5)
-    version = int.from_bytes(f.read(2), 'little')
-    network_magic = f.read(4)
-    block_hash = f.read(32)
-    num_utxos = int.from_bytes(f.read(8), 'little')
+    magic_bytes = read_exact(f, 5)
+    version = int.from_bytes(read_exact(f, 2), 'little')
+    network_magic = read_exact(f, 4)
+    block_hash = read_exact(f, 32)
+    num_utxos = int.from_bytes(read_exact(f, 8), 'little')
     if magic_bytes != UTXO_DUMP_MAGIC:
         print(f"Error: provided input file '{args.infile}' is not an UTXO dump.")
         sys.exit(1)
@@ -164,7 +172,7 @@ def main():
     for coin_idx in range(1, num_utxos+1):
         # read key (COutPoint)
         if coins_per_hash_left == 0:  # read next prevout hash
-            prevout_hash = f.read(32)
+            prevout_hash = read_exact(f, 32)
             coins_per_hash_left = read_compactsize(f)
         prevout_index = read_compactsize(f)
         # read value (Coin)


### PR DESCRIPTION
The converter accepts short reads, so a truncated snapshot can be reported as successfully converted while storing incomplete script data. For example, a final script declaring four bytes but containing only one is written to SQLite and the process exits successfully.

Read each serialized field at its expected length and fail when the input ends early. Keep the final EOF probe unchanged.

Add regression coverage for truncated metadata, CompactSize and VarInt values, all compressed script types, and end-to-end conversion of valid and truncated snapshots.

Validation: `python3 contrib/utxo-tools/test_utxo_to_sqlite.py` passes all four test methods with this change and fails against the unchanged base revision. The full Bitcoin Core test suite was not run.

This change and its tests were prepared with AI assistance. It does not make output creation atomic; an earlier committed batch may remain after a later input error.