### PR TITLE
addrman: apply time penalty in nTime check

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -555,7 +555,8 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, std::c
         pinfo->nServices = ServiceFlags(pinfo->nServices | addr.nServices);
 
         // do not update if no new information is present
-        if (addr.nTime <= pinfo->nTime) {
+        // (the stored nTime already had the time penalty applied, so apply it here too)
+        if (addr.nTime - time_penalty <= pinfo->nTime) {
             return false;
         }
 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -394,6 +394,18 @@ BOOST_AUTO_TEST_CASE(addrman_new_multiplicity)
     BOOST_CHECK_EQUAL(addr_pos.multiplicity, 1U);
     BOOST_CHECK_EQUAL(addrman->Size(), 1U);
 
+    // the same holds if a time penalty is applied (e.g. when the same announcement
+    // is received from several peers due to addr gossip relay)
+    CAddress addr_penalty{CAddress(ResolveService("253.4.4.4", 8333), NODE_NONE)};
+    addr_penalty.nTime = start_time;
+    for (unsigned int i = 1; i < 20; ++i) {
+        CNetAddr source{ResolveIP(ToString(i) + ".2.2.2")};
+        addrman->Add({addr_penalty}, source, /*time_penalty=*/2h);
+    }
+    AddressPosition addr_pos_penalty = addrman->FindAddressEntry(addr_penalty).value();
+    BOOST_CHECK_EQUAL(addr_pos_penalty.multiplicity, 1U);
+    BOOST_CHECK_EQUAL(addrman->Size(), 2U);
+
     // if nTime increases, an addr can occur in up to 8 buckets
     // The acceptance probability decreases exponentially with existing multiplicity -
     // choose number of iterations such that it gets to 8 with deterministic addrman.
@@ -406,7 +418,7 @@ BOOST_AUTO_TEST_CASE(addrman_new_multiplicity)
     AddressPosition addr_pos_multi = addrman->FindAddressEntry(addr).value();
     BOOST_CHECK_EQUAL(addr_pos_multi.multiplicity, 8U);
     // multiplicity doesn't affect size
-    BOOST_CHECK_EQUAL(addrman->Size(), 1U);
+    BOOST_CHECK_EQUAL(addrman->Size(), 2U);
 }
 
 BOOST_AUTO_TEST_CASE(addrman_tried_collisions)


### PR DESCRIPTION
There is an existing check in `AddSingle()` that prevents us from increasing the `RefCount` of an address when the same announcement is received again from a different peer, which regularly happens with gossip relay - an addr can take different routes through the network to us.

However, the check is ineffective: when the entry was first added, its `nTime` was stored with a [2h time penalty](https://github.com/bitcoin/bitcoin/blob/9d4325f40316d2c81d34418dc075b235173d0cec/src/net_processing.cpp#L6044) applied, so `addr.nTime > pinfo->nTime` holds even for an identical announcement. As a result, a single announcement relayed to us by several peers could increase an address's multiplicity in the new table, up to 8.

Fix this by applying the penalty in the comparison too, matching the `nTime` update check a few lines above.

This is just a small logic bugfix, it doesn't change things in adversarial scenarios, since peers can just do multiple announcements with changed `nTime` if they want to boost their `RefCount` artificially.