### PR TITLE
guix: cache GUI depends separately

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -151,8 +151,8 @@ If you perform a lot of builds and have a bunch of worktrees, you may find it
 more efficient to keep the depends tree's download cache, build cache, and SDKs
 outside of the worktrees to avoid duplicate downloads and unnecessary builds. To
 help with this situation, the `guix-build` script honours the `SOURCES_PATH`,
-`BASE_CACHE`, and `SDK_PATH` environment variables and will pass them on to the
-depends tree so that you can do something like:
+`BASE_CACHE`, and `SDK_PATH` environment variables so that you can do something
+like:
 
 ```sh
 env SOURCES_PATH="$HOME/depends-SOURCES_PATH" BASE_CACHE="$HOME/depends-BASE_CACHE" SDK_PATH="$HOME/macOS-SDKs" ./contrib/guix/guix-build
@@ -249,9 +249,10 @@ details.
 
 * _**BASE_CACHE**_
 
-  Set the depends tree cache for built packages. This is passed through to the
-  depends tree. Setting this to the same directory across multiple builds of the
-  depends tree can eliminate unnecessary building of packages.
+  Set the root directory for cached built packages. Non-GUI and GUI builds use
+  the `GUIX/BUILD` and `GUIX/GUI` subdirectories, respectively, so their caches do
+  not evict each other's packages. Setting this to the same directory across
+  multiple Guix builds can eliminate unnecessary building of packages.
 
   The path that this environment variable points to **must be a directory**, and
   **NOT a symlink to a directory**.

--- a/contrib/guix/libexec/build_linux.sh
+++ b/contrib/guix/libexec/build_linux.sh
@@ -11,6 +11,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 # setup gcc toolchain
 gcc_toolchain
 
+BASE_CACHE="${BASE_CACHE:-$PWD/depends/built}/GUIX/BUILD"
+
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \

--- a/contrib/guix/libexec/build_linux_gui.sh
+++ b/contrib/guix/libexec/build_linux_gui.sh
@@ -11,6 +11,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 # setup gcc toolchain
 gcc_toolchain
 
+BASE_CACHE="${BASE_CACHE:-$PWD/depends/built}/GUIX/GUI"
+
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \

--- a/contrib/guix/libexec/build_macos.sh
+++ b/contrib/guix/libexec/build_macos.sh
@@ -11,6 +11,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 # Setup toolchain
 llvm_toolchain
 
+BASE_CACHE="${BASE_CACHE:-$PWD/depends/built}/GUIX/BUILD"
+
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \

--- a/contrib/guix/libexec/build_macos_gui.sh
+++ b/contrib/guix/libexec/build_macos_gui.sh
@@ -11,6 +11,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 # Setup toolchain
 llvm_toolchain
 
+BASE_CACHE="${BASE_CACHE:-$PWD/depends/built}/GUIX/GUI"
+
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \

--- a/contrib/guix/libexec/build_win.sh
+++ b/contrib/guix/libexec/build_win.sh
@@ -11,6 +11,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 # setup mingw-w64 toolchain
 mingw_w64_toolchain
 
+BASE_CACHE="${BASE_CACHE:-$PWD/depends/built}/GUIX/BUILD"
+
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \

--- a/contrib/guix/libexec/build_win_gui.sh
+++ b/contrib/guix/libexec/build_win_gui.sh
@@ -11,6 +11,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/setup.sh"
 # setup mingw-w64 toolchain
 mingw_w64_toolchain
 
+BASE_CACHE="${BASE_CACHE:-$PWD/depends/built}/GUIX/GUI"
+
 # Build the depends tree
 make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    ${V:+V=1} \


### PR DESCRIPTION
Alternative to #35929

The GUI and non-GUI Guix profiles produce different depends build IDs. However, depends deletes the existing per-package cache directory when storing a new build. Sharing a cache root therefore causes each profile to evict the other's packages, forcing rebuilds on subsequent runs.

This PR keeps these packages in separate `GUIX/BUILD` and `GUIX/GUI` directories under the cache root. This also keeps them separate from ordinary developer builds when BASE_CACHE is being used there.

#35929 replaces `GUIX_ENVIRONMENT` in package ID generation with a hash of selected Guix inputs. Its current implementation covers the manifests, patches, pinned Guix revision and additional flags, but that list needs to stay aligned with how we construct the environment and may therefore be brittle to future changes.

In this version I prefer keeping the resolved environment in the cache key and simply keeping the caches separate.

#### Tradeoffs vs #35929

This PR means building and storing some dependencies twice, which I consider a reasonable cost for simpler cache tracking/invalidation. This is likely going to be the case for Linux anyway i.e after a change like #36193 or #25573.