### PR TITLE
streams: Include the OS error when AutoFile I/O fails

### DIFF
--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -9,6 +9,7 @@
 #include <util/obfuscation.h>
 
 #include <array>
+#include <cerrno>
 
 AutoFile::AutoFile(std::FILE* file, const Obfuscation& obfuscation) : m_file{file}, m_obfuscation{obfuscation}
 {
@@ -74,7 +75,8 @@ int64_t AutoFile::size()
 void AutoFile::read(std::span<std::byte> dst)
 {
     if (detail_fread(dst) != dst.size()) {
-        throw std::ios_base::failure(feof() ? "AutoFile::read: end of file" : "AutoFile::read: fread failed");
+        const int err{errno};
+        throw std::ios_base::failure(feof() ? "AutoFile::read: end of file" : "AutoFile::read: fread failed: " + SysErrorString(err));
     }
 }
 
@@ -85,7 +87,8 @@ void AutoFile::ignore(size_t nSize)
     while (nSize > 0) {
         size_t nNow = std::min<size_t>(nSize, sizeof(data));
         if (std::fread(data, 1, nNow, m_file) != nNow) {
-            throw std::ios_base::failure(feof() ? "AutoFile::ignore: end of file" : "AutoFile::ignore: fread failed");
+            const int err{errno};
+            throw std::ios_base::failure(feof() ? "AutoFile::ignore: end of file" : "AutoFile::ignore: fread failed: " + SysErrorString(err));
         }
         nSize -= nNow;
         if (m_position.has_value()) *m_position += nNow;
@@ -97,7 +100,8 @@ void AutoFile::write(std::span<const std::byte> src)
     if (!m_file) throw std::ios_base::failure("AutoFile::write: file handle is nullptr");
     if (!m_obfuscation) {
         if (std::fwrite(src.data(), 1, src.size(), m_file) != src.size()) {
-            throw std::ios_base::failure("AutoFile::write: write failed");
+            const int err{errno};
+            throw std::ios_base::failure("AutoFile::write: write failed: " + SysErrorString(err));
         }
         m_was_written = true;
         if (m_position.has_value()) *m_position += src.size();
@@ -120,7 +124,8 @@ void AutoFile::write_buffer(std::span<std::byte> src)
         m_obfuscation(src, *m_position); // obfuscate in-place
     }
     if (std::fwrite(src.data(), 1, src.size(), m_file) != src.size()) {
-        throw std::ios_base::failure("AutoFile::write_buffer: write failed");
+        const int err{errno};
+        throw std::ios_base::failure("AutoFile::write_buffer: write failed: " + SysErrorString(err));
     }
     m_was_written = true;
     if (m_position) *m_position += src.size();

--- a/src/streams.h
+++ b/src/streams.h
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -522,7 +523,8 @@ private:
             return false;
         size_t nBytes{m_src.detail_fread(std::span{vchBuf}.subspan(pos, readNow))};
         if (nBytes == 0) {
-            throw std::ios_base::failure{m_src.feof() ? "BufferedFile::Fill: end of file" : "BufferedFile::Fill: fread failed"};
+            const int err{errno};
+            throw std::ios_base::failure{m_src.feof() ? "BufferedFile::Fill: end of file" : "BufferedFile::Fill: fread failed: " + SysErrorString(err)};
         }
         nSrcPos += nBytes;
         return true;

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -183,16 +183,13 @@ BOOST_AUTO_TEST_CASE(autofile_io_error_detail)
     const std::string errno_suffix{"(" + util::ToString(EBADF) + ")"};
 
     // Checks that fn() throws std::ios_base::failure on a genuine (non-EOF)
-    // I/O failure.
-    // TODO: currently the OS error is discarded; flip to
-    // BOOST_CHECK(HasReason{errno_suffix}(e)) once AutoFile/BufferedFile are
-    // fixed to include it.
+    // I/O failure, and that the OS error is included in the message.
     auto check_io_failure = [&](auto&& fn) {
         try {
             fn();
             BOOST_ERROR("expected std::ios_base::failure was not thrown");
         } catch (const std::ios_base::failure& e) {
-            BOOST_CHECK(!HasReason{errno_suffix}(e));
+            BOOST_CHECK(HasReason{errno_suffix}(e));
         }
     };
 

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -14,6 +14,11 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <cerrno>
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
 using namespace std::string_literals;
 using namespace util::hex_literals;
 
@@ -165,6 +170,102 @@ BOOST_AUTO_TEST_CASE(xor_file)
         BOOST_CHECK_EXCEPTION(xor_file.ignore(1), std::ios_base::failure, HasReason{"AutoFile::ignore: end of file"});
         BOOST_CHECK_EXCEPTION(xor_file >> std::byte{}, std::ios_base::failure, HasReason{"AutoFile::read: end of file"});
         BOOST_CHECK_EQUAL(xor_file.size(), 7);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(autofile_io_error_detail)
+{
+    fs::path path{m_args.GetDataDirBase() / "test_io_error_detail.bin"};
+    auto raw_file{[&](const auto& mode) { return fsbridge::fopen(path, mode); }};
+    const Obfuscation obfuscation{"ff00ff00ff00ff00"_hex};
+    // SysErrorString() renders as "<message> (<errno>)"; match on the errno
+    // suffix so this doesn't depend on the exact OS-provided wording.
+    const std::string errno_suffix{"(" + util::ToString(EBADF) + ")"};
+
+    // Checks that fn() throws std::ios_base::failure on a genuine (non-EOF)
+    // I/O failure.
+    // TODO: currently the OS error is discarded; flip to
+    // BOOST_CHECK(HasReason{errno_suffix}(e)) once AutoFile/BufferedFile are
+    // fixed to include it.
+    auto check_io_failure = [&](auto&& fn) {
+        try {
+            fn();
+            BOOST_ERROR("expected std::ios_base::failure was not thrown");
+        } catch (const std::ios_base::failure& e) {
+            BOOST_CHECK(!HasReason{errno_suffix}(e));
+        }
+    };
+
+    {
+        // Create a non-empty file so opening it below succeeds.
+        AutoFile f{raw_file("wb")};
+        std::byte one{1};
+        f.write(std::span{&one, 1});
+        BOOST_REQUIRE_EQUAL(f.fclose(), 0);
+    }
+
+    // Force a genuine (kernel-level) I/O failure so errno is reliably set:
+    // on POSIX, close the underlying fd out from under a correctly-opened
+    // FILE*, so the next read/write hits a real EBADF from the kernel --
+    // this bypasses musl's __towrite()/__toread(), which never touch errno
+    // for a same-direction file (unlike glibc's, which do). On Windows,
+    // opening in the wrong direction already produces a genuine,
+    // errno-bearing failure.
+#ifdef WIN32
+    auto open_for_failing_write{[&] { return raw_file("rb"); }};
+    auto open_for_failing_read{[&] { return raw_file("wb"); }};
+    auto break_direction{[](std::FILE*) {}};
+#else
+    // Fully unbuffered, so every fwrite()/fread() call reaches the real
+    // syscall immediately instead of silently succeeding into libc's own
+    // buffer without ever touching the (about to be closed) fd.
+    auto open_unbuffered{[&](const auto& mode) {
+        std::FILE* raw{raw_file(mode)};
+        BOOST_REQUIRE_EQUAL(setvbuf(raw, nullptr, _IONBF, 0), 0);
+        return raw;
+    }};
+    auto open_for_failing_write{[&] { return open_unbuffered("wb"); }};
+    auto open_for_failing_read{[&] { return open_unbuffered("wb"); }};
+    auto break_direction{[](std::FILE* raw) { BOOST_REQUIRE_EQUAL(close(fileno(raw)), 0); }};
+#endif
+
+    // Writing fails with a real OS error, both with and without obfuscation.
+    {
+        std::FILE* raw{open_for_failing_write()};
+        AutoFile f{raw};
+        break_direction(raw);
+        std::byte one{1};
+        check_io_failure([&] { f.write(std::span{&one, 1}); });
+    }
+    {
+        std::FILE* raw{open_for_failing_write()};
+        AutoFile f{raw, obfuscation};
+        break_direction(raw);
+        std::byte one{1};
+        check_io_failure([&] { f.write(std::span{&one, 1}); });
+    }
+
+    // Reading fails with a real OS error, distinguishable from EOF.
+    {
+        std::FILE* raw{open_for_failing_read()};
+        AutoFile f{raw};
+        break_direction(raw);
+        std::byte one{};
+        check_io_failure([&] { f.read(std::span{&one, 1}); });
+    }
+    {
+        std::FILE* raw{open_for_failing_read()};
+        AutoFile f{raw};
+        break_direction(raw);
+        check_io_failure([&] { f.ignore(1); });
+    }
+    {
+        std::FILE* raw{open_for_failing_read()};
+        AutoFile f{raw};
+        break_direction(raw);
+        BufferedFile bf{f, 8, 4};
+        std::byte one{};
+        check_io_failure([&] { bf.read(std::span{&one, 1}); });
     }
 }
 


### PR DESCRIPTION
This came up during review of #35492 (wallet: fail dump on incomplete writes), which switches `DumpWallet` from `std::ofstream` to `AutoFile` so a failed `write`/`close`/`fsync` properly aborts the dump. While reviewing that switch, I noticed the underlying `AutoFile`/`BufferedFile` exception messages themselves don't carry the actual reason a `fread()`/`fwrite()` call failed — only a fixed string like "AutoFile::write: write failed" — the errno that would explain why the call failed is discarded. Any caller that surfaces `e.what()` to a log or an error message (including the dump path in #35492, once that's wired up) loses that detail.

This PR captures errno right after the failing call and folds SysErrorString() into the thrown message for:
- `AutoFile::write()` / `write_buffer()`
- `AutoFile::read()` (via `detail_fread`())
- `AutoFile::ignore()`
- `BufferedFile::Fill()`

`AutoFile::seek()` is intentionally left unchanged — forcing a real, portable `fseek()` failure (as opposed to a null handle or EOF) across this project's CI platforms isn't practical, so it has no equivalent test coverage.

Two commits: the first adds `streams_tests.cpp` coverage that asserts the current behavior — the OS error is discarded on a genuine (non-EOF) I/O failure — with a TODO marking the assertion that gets flipped; the second is the fix itself, flipping that same assertion to confirm the OS error is now present.

Out of scope for this PR: wiring `DumpWallet` in #35492 to actually surface this detail in its own error message — that PR's `dump.cpp` doesn't exist in its AutoFile-based form on master yet, so that wiring has to wait for whichever of the two merges first.