### PR TITLE
cli: Display warning arrays in -getinfo

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -1516,7 +1516,10 @@ static void ParseGetInfoResult(UniValue& result)
         result_string += "\n";
     }
 
-    const std::string warnings{result["warnings"].getValStr()};
+    const UniValue& warnings_value{result["warnings"]};
+    const std::string warnings{warnings_value.isArray()
+        ? Join(warnings_value.getValues(), "\n", [](const UniValue& warning) { return warning.get_str(); })
+        : warnings_value.getValStr()};
     result_string += strprintf("%sWarnings:%s %s", YELLOW, RESET, warnings.empty() ? "(none)" : warnings);
 
     result.setStr(result_string);

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -114,6 +114,9 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         # Check that get*info() shows the versionbits unknown rules warning
         assert WARN_UNKNOWN_RULES_ACTIVE in ",".join(node.getmininginfo()["warnings"])
         assert WARN_UNKNOWN_RULES_ACTIVE in ",".join(node.getnetworkinfo()["warnings"])
+        if self.is_cli_compiled():
+            expected_warnings = "\n".join(node.getnetworkinfo()["warnings"])
+            assert node.cli('-getinfo', '-color=never').send_cli().endswith(f"Warnings: {expected_warnings}")
         # Check that the alert file shows the versionbits unknown rules warning
         self.wait_until(lambda: self.versionbits_in_alert_file())
 

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -114,9 +114,6 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         # Check that get*info() shows the versionbits unknown rules warning
         assert WARN_UNKNOWN_RULES_ACTIVE in ",".join(node.getmininginfo()["warnings"])
         assert WARN_UNKNOWN_RULES_ACTIVE in ",".join(node.getnetworkinfo()["warnings"])
-        if self.is_cli_compiled():
-            expected_warnings = "\n".join(node.getnetworkinfo()["warnings"])
-            assert node.cli('-getinfo', '-color=never').send_cli().endswith(f"Warnings: {expected_warnings}")
         # Check that the alert file shows the versionbits unknown rules warning
         self.wait_until(lambda: self.versionbits_in_alert_file())
 

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -42,13 +42,17 @@ WALLET_NOT_SPECIFIED = (
 def cli_get_info_string_to_dict(cli_get_info_string):
     """Helper method to convert human-readable -getinfo into a dictionary"""
     cli_get_info = {}
-    lines = cli_get_info_string.splitlines()
-    line_idx = 0
+    # Remove ansi colour codes
     ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
+    lines = ansi_escape.sub('', cli_get_info_string).splitlines()
+    line_idx = 0
     while line_idx < len(lines):
-        # Remove ansi colour code
-        line = ansi_escape.sub('', lines[line_idx])
-        if "Balances" in line:
+        line = lines[line_idx]
+        if line.startswith("Warnings: "):
+            # Warnings is the final section and can span multiple lines.
+            cli_get_info["Warnings"] = "\n".join(lines[line_idx:]).removeprefix("Warnings: ")
+            break
+        elif "Balances" in line:
             # When "Balances" appears in a line, all of the following lines contain "balance: wallet" until an empty line
             cli_get_info["Balances"] = {}
             while line_idx < len(lines) and not (lines[line_idx + 1] == ''):
@@ -240,12 +244,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(Decimal(cli_get_info['Difficulty']), blockchain_info['difficulty'])
         assert_equal(cli_get_info['Chain'], blockchain_info['chain'])
         expected_warnings = "\n".join(network_info['warnings']) or "(none)"
-        assert cli_get_info_string.endswith(f"Warnings: {expected_warnings}")
-
-        self.log.info("Test -getinfo with deprecated string warnings")
-        self.restart_node(0, extra_args=["-deprecatedrpc=warnings"])
-        expected_warnings = self.nodes[0].getnetworkinfo()['warnings'] or "(none)"
-        assert self.nodes[0].cli('-getinfo', '-color=never').send_cli().endswith(f"Warnings: {expected_warnings}")
+        assert_equal(cli_get_info['Warnings'], expected_warnings)
 
         self.log.info("Test -getinfo and bitcoin-cli return all proxies")
         self.restart_node(0, extra_args=["-proxy=127.0.0.1:9050", "-i2psam=127.0.0.1:7656"])

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -239,6 +239,13 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(cli_get_info['Proxies'], network_info['networks'][0]['proxy'])
         assert_equal(Decimal(cli_get_info['Difficulty']), blockchain_info['difficulty'])
         assert_equal(cli_get_info['Chain'], blockchain_info['chain'])
+        expected_warnings = "\n".join(network_info['warnings']) or "(none)"
+        assert cli_get_info_string.endswith(f"Warnings: {expected_warnings}")
+
+        self.log.info("Test -getinfo with deprecated string warnings")
+        self.restart_node(0, extra_args=["-deprecatedrpc=warnings"])
+        expected_warnings = self.nodes[0].getnetworkinfo()['warnings'] or "(none)"
+        assert self.nodes[0].cli('-getinfo', '-color=never').send_cli().endswith(f"Warnings: {expected_warnings}")
 
         self.log.info("Test -getinfo and bitcoin-cli return all proxies")
         self.restart_node(0, extra_args=["-proxy=127.0.0.1:9050", "-i2psam=127.0.0.1:7656"])


### PR DESCRIPTION
`-getinfo` swallowed warnings when `getnetworkinfo` returns an array instead of string, showing `(none)` even with active prerelease warnings on regtest.

Just join array items with newline and keep the fallback for legacy strings / empty cases. Threw together a quick test to cover it.

Tested on m1 mac, regtest warning shows up fine now and py tests pass.