### PR TITLE
asmap: Make version match externally computed hashes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1701,7 +1701,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                     return false;
                 #endif
             }
-            LogInfo("Using asmap version %s for IP bucketing", asmap_version.ToString());
+            LogInfo("Using asmap version %s for IP bucketing", HexStr(asmap_version));
         } else {
             node.netgroupman = std::make_unique<NetGroupManager>(NetGroupManager::NoAsmap());
             LogInfo("Using /16 prefix for IP bucketing");

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -349,5 +349,5 @@ uint256 AsmapVersion(const std::span<const std::byte> data)
 
     HashWriter asmap_hasher;
     asmap_hasher << data;
-    return asmap_hasher.GetHash();
+    return asmap_hasher.GetSHA256();
 }

--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -22,7 +22,7 @@ from test_framework.util import (
 )
 
 ASMAP = 'src/test/data/asmap.raw' # path to unit test skeleton asmap
-VERSION = 'bafc9da308f45179443bd1d22325400ac9104f741522d003e3fac86700f68895'
+VERSION = '55dcec00c72b8a33a271dad20271e14cfbe5526aa1dc12e2559f30c376d85a35'
 
 def expected_messages(filename):
     return [f'Opened asmap file "{filename}" (59 bytes) from disk',


### PR DESCRIPTION
#### Problem

Running CLI utilities such as `sha256sum` on the encoded asmap blob, and then grepping for the outputted hash in the `bitcoind` debug.log was unsuccessful.

#### Solution

* Change the version computation from double to single SHA256
  *Note: This invalidates serialized AddrMan data which forces re-bucketing.*
* Avoid reversing byte order when logging the version

Inspired by https://github.com/bitcoin/bitcoin/pull/36201#issuecomment-5605080265 + https://github.com/bitcoin/bitcoin/pull/36201#pullrequestreview-5158109401
