### PR TITLE
rpc: report background validation progress in getchainstates

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3568,6 +3568,7 @@ const std::vector<RPCResult> RPCHelpForChainstate{
     {RPCResult::Type::STR_HEX, "target", "The difficulty target"},
     {RPCResult::Type::NUM, "difficulty", "difficulty of the tip"},
     {RPCResult::Type::NUM, "verificationprogress", "progress towards the network tip"},
+    {RPCResult::Type::NUM, "background_verificationprogress", /*optional=*/true, "progress towards the block this chainstate stops at, if it is validating the chain underneath a snapshot"},
     {RPCResult::Type::STR_HEX, "snapshot_blockhash", /*optional=*/true, "the base block of the snapshot this chainstate is based on, if any"},
     {RPCResult::Type::NUM, "coins_db_cache_bytes", "size of the coinsdb cache"},
     {RPCResult::Type::NUM, "coins_tip_cache_bytes", "size of the coinstip cache"},
@@ -3612,6 +3613,9 @@ return RPCMethod{
         data.pushKV("target", GetTarget(*tip, chainman.GetConsensus().powLimit).GetHex());
         data.pushKV("difficulty", GetDifficulty(*tip));
         data.pushKV("verificationprogress", chainman.GuessVerificationProgress(tip));
+        if (cs.TargetBlock()) {
+            data.pushKV("background_verificationprogress", chainman.GetBackgroundVerificationProgress(*tip));
+        }
         data.pushKV("coins_db_cache_bytes",  cs.m_coinsdb_cache_size_bytes);
         data.pushKV("coins_tip_cache_bytes", cs.m_coinstip_cache_size_bytes);
         if (cs.m_from_snapshot_blockhash) {

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -565,6 +565,11 @@ class AssumeutxoTest(BitcoinTestFramework):
         expected_verification_progress = background_tx_count / snapshot_tx_count
         assert_approx(bv_res["verificationprogress"], expected_verification_progress, vspan=0.01)
 
+        self.log.info("Check that getchainstates reports the background validation progress")
+        background, snapshot_chainstate = n1.getchainstates()["chainstates"]
+        assert_approx(background["background_verificationprogress"], expected_verification_progress, vspan=0.01)
+        assert "background_verificationprogress" not in snapshot_chainstate
+
         # find coinbase output at snapshot height on node0 and scan for it on node1,
         # where the block is not available, but the snapshot was loaded successfully
         coinbase_tx = n0.getblock(snapshot_hash, verbosity=2)['tx'][0]


### PR DESCRIPTION
Follow-up to #33259, which added `GetBackgroundVerificationProgress()` and exposed it in `getblockchaininfo`.

`getchainstates` still reports `verificationprogress` relative to the network tip for every chainstate. This modifies `verificationprogress` to report the correct value, relative to 



