### PR TITLE
rpc: report background validation progress in getchainstates

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3567,7 +3567,7 @@ const std::vector<RPCResult> RPCHelpForChainstate{
     {RPCResult::Type::STR_HEX, "bits", "nBits: compact representation of the block difficulty target"},
     {RPCResult::Type::STR_HEX, "target", "The difficulty target"},
     {RPCResult::Type::NUM, "difficulty", "difficulty of the tip"},
-    {RPCResult::Type::NUM, "verificationprogress", "progress towards the network tip"},
+    {RPCResult::Type::NUM, "verificationprogress", "progress towards the network tip, or towards the snapshot base block for a chainstate validating the chain underneath a snapshot"},
     {RPCResult::Type::STR_HEX, "snapshot_blockhash", /*optional=*/true, "the base block of the snapshot this chainstate is based on, if any"},
     {RPCResult::Type::NUM, "coins_db_cache_bytes", "size of the coinsdb cache"},
     {RPCResult::Type::NUM, "coins_tip_cache_bytes", "size of the coinstip cache"},
@@ -3611,7 +3611,8 @@ return RPCMethod{
         data.pushKV("bits", strprintf("%08x", tip->nBits));
         data.pushKV("target", GetTarget(*tip, chainman.GetConsensus().powLimit).GetHex());
         data.pushKV("difficulty", GetDifficulty(*tip));
-        data.pushKV("verificationprogress", chainman.GuessVerificationProgress(tip));
+        data.pushKV("verificationprogress", cs.TargetBlock() ? chainman.GetBackgroundVerificationProgress(*tip)
+                                                             : chainman.GuessVerificationProgress(tip));
         data.pushKV("coins_db_cache_bytes",  cs.m_coinsdb_cache_size_bytes);
         data.pushKV("coins_tip_cache_bytes", cs.m_coinstip_cache_size_bytes);
         if (cs.m_from_snapshot_blockhash) {

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -565,6 +565,10 @@ class AssumeutxoTest(BitcoinTestFramework):
         expected_verification_progress = background_tx_count / snapshot_tx_count
         assert_approx(bv_res["verificationprogress"], expected_verification_progress, vspan=0.01)
 
+        self.log.info("Check that getchainstates returns the background validation progress")
+        cs_res = n1.getchainstates()["chainstates"][0]
+        assert_approx(cs_res["verificationprogress"], expected_verification_progress, vspan=0.01)
+
         # find coinbase output at snapshot height on node0 and scan for it on node1,
         # where the block is not available, but the snapshot was loaded successfully
         coinbase_tx = n0.getblock(snapshot_hash, verbosity=2)['tx'][0]


### PR DESCRIPTION
After #33259, `getblockchaininfo` reports the progress of the background chainstate relative to the snapshot base block, but `getchainstates` still computes `verificationprogress` against the network tip for every chainstate, so the same node reports two different numbers for the same chainstate.

This PR modifies `verificationprogress` value to report the correct value, relative to the block the chainstate actually stops at.
