### PR TITLE
test: Add test coverage for `PartiallySignedTransaction::Merge()`

### DIFF
--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -360,4 +360,43 @@ BOOST_AUTO_TEST_CASE(psbt_merge_fallback_locktime)
     BOOST_CHECK_EQUAL(*psbt1.fallback_locktime, 21);
 }
 
+BOOST_AUTO_TEST_CASE(psbt_merge_modifiable)
+{
+    CMutableTransaction mtx;
+    PartiallySignedTransaction psbt1(mtx, /*version*/2);
+    PartiallySignedTransaction psbt2(mtx, /*version*/2);
+
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_CHECK(!psbt1.m_tx_modifiable.has_value());
+
+    psbt1.m_tx_modifiable.emplace();
+    psbt1.m_tx_modifiable->set(0, true);
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_REQUIRE(psbt1.m_tx_modifiable.has_value());
+    BOOST_CHECK(!psbt1.m_tx_modifiable->test(0));
+
+    psbt1.m_tx_modifiable.reset();
+    psbt2.m_tx_modifiable.emplace();
+    psbt2.m_tx_modifiable->set(0, true);
+    psbt2.m_tx_modifiable->set(2, true);
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_REQUIRE(psbt1.m_tx_modifiable.has_value());
+    BOOST_CHECK(!psbt1.m_tx_modifiable->test(0));
+    BOOST_CHECK(psbt1.m_tx_modifiable->test(2));
+
+    psbt1.m_tx_modifiable.emplace();
+    psbt1.m_tx_modifiable->set(2, true);
+    psbt2.m_tx_modifiable.reset();
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_REQUIRE(psbt1.m_tx_modifiable.has_value());
+    BOOST_CHECK(psbt1.m_tx_modifiable->test(2));
+
+    psbt1.m_tx_modifiable.reset();
+    psbt2.m_tx_modifiable.emplace();
+    psbt2.m_tx_modifiable->set(2, true);
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_REQUIRE(psbt1.m_tx_modifiable.has_value());
+    BOOST_CHECK(psbt1.m_tx_modifiable->test(2));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -313,4 +313,14 @@ BOOST_AUTO_TEST_CASE(update_psbt_output_taproot)
     }
 }
 
+BOOST_AUTO_TEST_CASE(psbt_merge_only_same_version)
+{
+    CMutableTransaction mtx;
+    PartiallySignedTransaction psbt_v0(mtx, /*version*/0);
+    PartiallySignedTransaction psbt_v2(mtx, /*version*/2);
+    BOOST_REQUIRE(*psbt_v0.GetUniqueID() == *psbt_v2.GetUniqueID());
+    BOOST_CHECK(!psbt_v0.Merge(psbt_v2));
+    BOOST_CHECK(!psbt_v2.Merge(psbt_v0));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/psbt_tests.cpp
+++ b/src/test/psbt_tests.cpp
@@ -323,4 +323,41 @@ BOOST_AUTO_TEST_CASE(psbt_merge_only_same_version)
     BOOST_CHECK(!psbt_v2.Merge(psbt_v0));
 }
 
+BOOST_AUTO_TEST_CASE(psbt_merge_fallback_locktime)
+{
+    CMutableTransaction mtx;
+    PartiallySignedTransaction psbt1(mtx, /*version*/2);
+    PartiallySignedTransaction psbt2(mtx, /*version*/2);
+    psbt1.m_tx_modifiable.emplace();
+    psbt1.m_tx_modifiable->set(0, true);
+    BOOST_REQUIRE_EQUAL(psbt1.inputs.size(), 0);
+    psbt2.m_tx_modifiable.emplace();
+    psbt2.m_tx_modifiable->set(0, true);
+    BOOST_REQUIRE_EQUAL(psbt2.inputs.size(), 0);
+
+
+    PSBTInput psbtin(/*psbt_version=*/2, Txid::FromUint256(uint256::ONE), /*prev_out=*/0);
+    psbtin.height_locktime = 100;
+    BOOST_REQUIRE(psbt1.AddInput(psbtin));
+    BOOST_REQUIRE(psbt2.AddInput(psbtin));
+
+    psbt1.fallback_locktime = std::nullopt;
+    psbt2.fallback_locktime = 21;
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_REQUIRE(psbt1.fallback_locktime.has_value());
+    BOOST_CHECK_EQUAL(*psbt1.fallback_locktime, 21);
+
+    psbt1.fallback_locktime = 5;
+    psbt2.fallback_locktime = 19;
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_REQUIRE(psbt1.fallback_locktime.has_value());
+    BOOST_CHECK_EQUAL(*psbt1.fallback_locktime, 5);
+
+    psbt1.fallback_locktime = 21;
+    psbt2.fallback_locktime = std::nullopt;
+    BOOST_CHECK(psbt1.Merge(psbt2));
+    BOOST_REQUIRE(psbt1.fallback_locktime.has_value());
+    BOOST_CHECK_EQUAL(*psbt1.fallback_locktime, 21);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds test coverage for `PartiallySignedTransaction::Merge()` divided into 3 tests:

**1.Commit 0d21098e27dff9dc930a1d1ce9f72d82f37aef89 only merge PSBTs with same version**: Lines (46-47) have no coverage prior to this PR. The test can be triggered with this mutant as an example:
<details>
<summary>Diff</summary>

```diff
diff --git a/src/psbt.cpp b/src/psbt.cpp
index 51fb19591a..cf5eef0089 100644
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -43,7 +43,7 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
         return false;
     }
     if (GetVersion() != psbt.GetVersion()) {
-        return false;
+        return true;
     }

     for (unsigned int i = 0; i < inputs.size(); ++i) {
```
</details>

**2.Commit 0aedfc5a5918fae10f26efccdbfc2e332c8ad458 merge PSBT `fallback_locktime` coverage**: Line 56 checks if the psbt has a fallback locktime, if not, it adopts the one from the psbt is merging. Prior to this PR no coverage was provided. The test can be triggered with this mutant as an example:
<details>
<summary>Diff</summary>

```diff
diff --git a/src/psbt.cpp b/src/psbt.cpp
index 51fb19591a..ce909eb062 100644
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -53,7 +53,7 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
         outputs[i].Merge(psbt.outputs[i]);
     }
     MergeGlobalXPubs(psbt);
-    if (fallback_locktime == std::nullopt && psbt.fallback_locktime != std::nullopt) fallback_locktime = psbt.fallback_locktime;
+    if (fallback_locktime == std::nullopt || psbt.fallback_locktime != std::nullopt) fallback_locktime = psbt.fallback_locktime;
 
     // Set m_tx_modifiable only if either PSBT had it set
     if (m_tx_modifiable.has_value() || psbt.m_tx_modifiable.has_value()) {
```
</details>

**While writing this test I had a question**:  If both PSBTs have a `fallback_locktime` value, the "this" (receiving side) wins silently. Is this the expected behavior? Why not keep the max or directly fail merging if we have two conflicting fallback_locktimes?

**3.Commit 4a5a082d306d9b4eab4ea9db6643efc307a9e961 merge PSBT `m_tx_modifiable` coverage**: Added missing coverage for all the mutants. The test can be triggered with this mutant as one of the various examples:
<details>
<summary>Diff</summary>

```diff
diff --git a/src/psbt.cpp b/src/psbt.cpp
index 51fb19591a..29eb910014 100644
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -56,7 +56,7 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
     if (fallback_locktime == std::nullopt && psbt.fallback_locktime != std::nullopt) fallback_locktime = psbt.fallback_locktime;
 
     // Set m_tx_modifiable only if either PSBT had it set
-    if (m_tx_modifiable.has_value() || psbt.m_tx_modifiable.has_value()) {
+    if (m_tx_modifiable.has_value() && psbt.m_tx_modifiable.has_value()) {
         // In general, we AND the modifiable flags
         std::bitset<8> this_modifiable = m_tx_modifiable.value_or(0);
         std::bitset<8> psbt_modifiable = psbt.m_tx_modifiable.value_or(0);
```
</details>