### PR TITLE
policy: fix format specifier in SingleTRUCChecks

### DIFF
--- a/src/policy/truc_policy.cpp
+++ b/src/policy/truc_policy.cpp
@@ -251,7 +251,7 @@ std::optional<std::pair<std::string, CTransactionRef>> SingleTRUCChecks(const CT
 
             // Return the sibling if its eviction can be considered. Provide the "descendant count
             // limit" string either way, as the caller may decide not to do sibling eviction.
-            return std::make_pair(strprintf("tx %u (wtxid=%s) would exceed descendant count limit",
+            return std::make_pair(strprintf("tx %s (wtxid=%s) would exceed descendant count limit",
                                             parent_entry.GetSharedTx()->GetHash().ToString(),
                                             parent_entry.GetSharedTx()->GetWitnessHash().ToString()),
                                   consider_sibling_eviction ? (*descendants.begin())->GetSharedTx() : nullptr);


### PR DESCRIPTION
### Motivation & Context
In `SingleTRUCChecks` (`src/policy/truc_policy.cpp:254`), the format string:
```cpp
return std::make_pair(strprintf("tx %u (wtxid=%s) would exceed descendant count limit",
                                parent_entry.GetSharedTx()->GetHash().ToString(),
                                parent_entry.GetSharedTx()->GetWitnessHash().ToString()),
                      consider_sibling_eviction ? (*descendants.begin())->GetSharedTx() : nullptr);
```
incorrectly specifies `%u` instead of `%s` for `parent_entry.GetSharedTx()->GetHash().ToString()`.

While `tinyformat` falls back to `operator<<` for `std::string` and therefore formats the string without crashing at runtime, this is an unintended type specifier mismatch. All other error and debug strings in `src/policy/truc_policy.cpp` (lines 77, 83, 131, 145, 208, 218) use `%s`. Furthermore, unit test expectations in `src/test/txvalidation_tests.cpp` (lines 517 and 556) already expect `tx %s (wtxid=%s)`.

### Description of Changes
Replace `%u` with `%s` in the `strprintf` format string in `SingleTRUCChecks` to maintain type-safety consistency and uniform formatting across `truc_policy.cpp`.
