### PR TITLE
util: avoid redundant rolling Bloom insertions

### DIFF
--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -15,6 +15,7 @@
 #include <util/overflow.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <compare>
 #include <vector>
@@ -194,7 +195,23 @@ static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, 
 
 void CRollingBloomFilter::insert(std::span<const unsigned char> vKey)
 {
-    if (nEntriesThisGeneration == nEntriesPerGeneration) {
+    std::array<uint32_t, MAX_HASH_FUNCS> hashes;
+    bool in_current_generation{true};
+    for (int n = 0; n < nHashFuncs; n++) {
+        const uint32_t h{RollingBloomHash(n, nTweak, vKey)};
+        hashes[n] = h;
+        if (in_current_generation) {
+            const int bit{static_cast<int>(h & 0x3F)};
+            const uint32_t pos{FastRange32(h, data.size())};
+            const uint64_t generation{
+                ((data[pos & ~1U] >> bit) & 1) |
+                (((data[pos | 1] >> bit) & 1) << 1),
+            };
+            in_current_generation = generation == static_cast<uint64_t>(nGeneration);
+        }
+    }
+
+    if (!in_current_generation && nEntriesThisGeneration == nEntriesPerGeneration) {
         nEntriesThisGeneration = 0;
         nGeneration++;
         if (nGeneration == 4) {
@@ -210,10 +227,10 @@ void CRollingBloomFilter::insert(std::span<const unsigned char> vKey)
             data[p + 1] = p2 & mask;
         }
     }
-    nEntriesThisGeneration++;
+    if (!in_current_generation) nEntriesThisGeneration++;
 
     for (int n = 0; n < nHashFuncs; n++) {
-        uint32_t h = RollingBloomHash(n, nTweak, vKey);
+        const uint32_t h{hashes[n]};
         int bit = h & 0x3F;
         /* FastMod works with the upper bits of h, so it is safe to ignore that the lower bits of h are already used for bit. */
         uint32_t pos = FastRange32(h, data.size());

--- a/src/common/bloom.h
+++ b/src/common/bloom.h
@@ -91,6 +91,8 @@ public:
  *
  * contains(item) will always return true if item was one of the last N to 1.5*N
  * insert()'ed ... but may also return true for items that were not inserted.
+ * Re-inserting an item reported present in the current generation does not
+ * consume additional capacity.
  *
  * It needs around 1.8 bytes per element per factor 0.1 of false positive rate.
  * For example, if we want 1000 elements, we'd need:

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -532,4 +532,56 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
     }
 }
 
+BOOST_AUTO_TEST_CASE(rolling_bloom_repeated_insert)
+{
+    SeedRandomForTest(SeedRand::ZEROS);
+
+    CRollingBloomFilter filter(100, 0.000001);
+    const std::vector protected_items{
+        RandomData(),
+        RandomData(),
+        RandomData(),
+    };
+    const auto repeated_item{RandomData()};
+    for (const auto& item : protected_items) {
+        filter.insert(item);
+    }
+    // Repeating one item across three nominal generations must not expire
+    // unrelated entries.
+    for (int i = 0; i < 150; ++i) {
+        filter.insert(repeated_item);
+    }
+    for (const auto& item : protected_items) {
+        BOOST_CHECK(filter.contains(item));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(rolling_bloom_reinsert_refreshes)
+{
+    SeedRandomForTest(SeedRand::ZEROS);
+
+    CRollingBloomFilter filter(100, 0.000001);
+    std::vector<std::vector<unsigned char>> old_items;
+    for (int i = 0; i < 50; ++i) {
+        old_items.push_back(RandomData());
+        filter.insert(old_items.back());
+    }
+
+    // Start generation two, then move all but one old item into it.
+    filter.insert(RandomData());
+    for (auto it = old_items.begin(); it != old_items.end() - 1; ++it) {
+        filter.insert(*it);
+    }
+
+    // Filling generation three must rotate back to generation one and expire
+    // the old item that was not refreshed.
+    for (int i = 0; i < 51; ++i) {
+        filter.insert(RandomData());
+    }
+    BOOST_CHECK(!filter.contains(old_items.back()));
+    for (auto it = old_items.begin(); it != old_items.end() - 1; ++it) {
+        BOOST_CHECK(filter.contains(*it));
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Re-inserting a value already represented by the current generation advances its entry counter without adding membership information. Repeating one value can therefore expire unrelated entries sooner than the configured capacity implies.

Detect current-generation membership before rotating. Only repeats already represented by that generation are free; refreshing an older entry consumes capacity normally. Retain the computed hashes so insertion does not hash the value twice.

One trade off is how insert into current generation when present in past generation. For this patch, the intended behavior is to count this as a fresh insert, so that the entry expires with the current insert generation.