### PR TITLE
Refactor CoinGrinder tests

### DIFF
--- a/src/wallet/test/coinselection_tests.cpp
+++ b/src/wallet/test/coinselection_tests.cpp
@@ -60,7 +60,7 @@ static CoinSelectionParams init_cs_params(int eff_feerate = 5000)
 static const CoinSelectionParams default_cs_params = init_cs_params();
 
 /** Make one OutputGroup with a single UTXO that either has a given effective value (default) or a given amount (`is_eff_value = false`). */
-static OutputGroup MakeCoin(const CAmount& amount, bool is_eff_value = true, CoinSelectionParams cs_params = default_cs_params, int custom_spending_vsize = P2WPKH_INPUT_VSIZE)
+static OutputGroup MakeCoin(const CAmount& amount, CoinSelectionParams cs_params = default_cs_params, int custom_spending_vsize = P2WPKH_INPUT_VSIZE, bool is_eff_value = true)
 {
     // Always assume that we only have one input
     CMutableTransaction tx;
@@ -77,14 +77,14 @@ static OutputGroup MakeCoin(const CAmount& amount, bool is_eff_value = true, Coi
 static void AddCoins(std::vector<OutputGroup>& utxo_pool, std::vector<CAmount> coins, CoinSelectionParams cs_params = default_cs_params)
 {
     for (CAmount c : coins) {
-        utxo_pool.push_back(MakeCoin(c, true, cs_params));
+        utxo_pool.push_back(MakeCoin(c, cs_params));
     }
 }
 
 /** Make multiple coins that share the same effective value */
 static void AddDuplicateCoins(std::vector<OutputGroup>& utxo_pool, int count, int amount, CoinSelectionParams cs_params = default_cs_params) {
     for (int i = 0 ; i < count; ++i) {
-        utxo_pool.push_back(MakeCoin(amount, true, cs_params));
+        utxo_pool.push_back(MakeCoin(amount, cs_params));
     }
 }
 
@@ -117,7 +117,7 @@ static void TestBnBSuccess(std::string test_title, std::vector<OutputGroup>& utx
     SelectionResult expected_result(CAmount(0), SelectionAlgorithm::BNB);
     CAmount expected_amount = 0;
     for (CAmount input_amount : expected_input_amounts) {
-        OutputGroup group = MakeCoin(input_amount, true, cs_params, custom_spending_vsize);
+        OutputGroup group = MakeCoin(input_amount, cs_params, custom_spending_vsize);
         expected_amount += group.m_value;
         expected_result.AddInput(group);
     }
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(bnb_exhaustion_with_solution_test)
     // A hard case with no exact-match solution: BnB must still report that the algorithm did not complete once the
     // search is pushed into the attempt limit, even though it finds a solution within cost_of_change of the target.
     for (size_t i = 0; i < 19; ++i) {
-        utxo_pool.push_back(MakeCoin(100'000 + i, /*is_eff_value=*/true, default_cs_params));
+        utxo_pool.push_back(MakeCoin(100'000 + i, default_cs_params));
     }
 
     const auto result{SelectCoinsBnB(utxo_pool, selection_target, /*cost_of_change=*/default_cs_params.m_cost_of_change, MAX_STANDARD_TX_WEIGHT)};
@@ -253,12 +253,12 @@ BOOST_AUTO_TEST_CASE(bnb_feerate_sensitivity_test)
     TestBnBSuccess("Select one input at high feerates", high_feerate_pool, /*selection_target=*/10 * CENT, /*expected_input_amounts=*/{10 * CENT}, /*expected_attempts=*/5, high_feerate_params);
 
     // Add heavy inputs {6, 7} to existing {2, 3, 5, 10}
-    low_feerate_pool.push_back(MakeCoin(6 * CENT, true, default_cs_params, /*custom_spending_vsize=*/500));
-    low_feerate_pool.push_back(MakeCoin(7 * CENT, true, default_cs_params, /*custom_spending_vsize=*/500));
+    low_feerate_pool.push_back(MakeCoin(6 * CENT, default_cs_params, /*custom_spending_vsize=*/500));
+    low_feerate_pool.push_back(MakeCoin(7 * CENT, default_cs_params, /*custom_spending_vsize=*/500));
     TestBnBSuccess("Prefer two heavy inputs over two light inputs at low feerates", low_feerate_pool, /*selection_target=*/13 * CENT, /*expected_input_amounts=*/{6 * CENT, 7 * CENT}, /*expected_attempts=*/18, default_cs_params, /*custom_spending_vsize=*/500);
 
-    high_feerate_pool.push_back(MakeCoin(6 * CENT, true, high_feerate_params, /*custom_spending_vsize=*/500));
-    high_feerate_pool.push_back(MakeCoin(7 * CENT, true, high_feerate_params, /*custom_spending_vsize=*/500));
+    high_feerate_pool.push_back(MakeCoin(6 * CENT, high_feerate_params, /*custom_spending_vsize=*/500));
+    high_feerate_pool.push_back(MakeCoin(7 * CENT, high_feerate_params, /*custom_spending_vsize=*/500));
     TestBnBSuccess("Prefer two light inputs over two heavy inputs at high feerates", high_feerate_pool, /*selection_target=*/13 * CENT, /*expected_input_amounts=*/{3 * CENT, 10 * CENT}, /*expected_attempts=*/9, high_feerate_params);
 }
 
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(srd_test)
         // Create UTXO pool with UTXOs of same effective value but different weights
         std::vector<OutputGroup> mixed_weight_pool;
         AddDuplicateCoins(mixed_weight_pool, /*count=*/100, /*amount=*/5 * CENT, cs_params);
-        mixed_weight_pool.push_back(MakeCoin(5 * CENT, true, cs_params, /*custom_spending_vsize=*/P2WPKH_INPUT_VSIZE - 1));
+        mixed_weight_pool.push_back(MakeCoin(5 * CENT, cs_params, /*custom_spending_vsize=*/P2WPKH_INPUT_VSIZE - 1));
         TestSRDSuccess("Tie-break same effective value with lower weight", utxo_pool, /*selection_target=*/9 * CENT, cs_params,
         /*max_selection_weight=*/4 * 3 * (P2WPKH_INPUT_VSIZE - 1));
     }

--- a/src/wallet/test/coinselection_tests.cpp
+++ b/src/wallet/test/coinselection_tests.cpp
@@ -89,22 +89,21 @@ static void AddDuplicateCoins(std::vector<OutputGroup>& utxo_pool, int count, in
 }
 
 /** Check if SelectionResult a is equivalent to SelectionResult b.
- * Two results are equivalent if they are composed of the same input values, even if they have different inputs (i.e., same value, different prevout) */
-static bool HaveEquivalentValues(const SelectionResult& a, const SelectionResult& b)
+ * Two results are equivalent if they are composed of inputs with the same amounts and sizes, even if they have different inputs (i.e., different prevouts). */
+static bool HaveEquivalentInputs(const SelectionResult& a, const SelectionResult& b)
 {
-    std::vector<CAmount> a_amts;
-    std::vector<CAmount> b_amts;
+    std::vector<std::pair<CAmount, int>> a_inputs;
+    std::vector<std::pair<CAmount, int>> b_inputs;
     for (const auto& coin : a.GetInputSet()) {
-        a_amts.push_back(coin->txout.nValue);
+        a_inputs.emplace_back(coin->txout.nValue, coin->input_bytes);
     }
     for (const auto& coin : b.GetInputSet()) {
-        b_amts.push_back(coin->txout.nValue);
+        b_inputs.emplace_back(coin->txout.nValue, coin->input_bytes);
     }
-    std::sort(a_amts.begin(), a_amts.end());
-    std::sort(b_amts.begin(), b_amts.end());
+    std::sort(a_inputs.begin(), a_inputs.end());
+    std::sort(b_inputs.begin(), b_inputs.end());
 
-    auto ret = std::mismatch(a_amts.begin(), a_amts.end(), b_amts.begin());
-    return ret.first == a_amts.end() && ret.second == b_amts.end();
+    return a_inputs == b_inputs;
 }
 
 static std::string InputAmountsToString(const SelectionResult& selection)
@@ -124,7 +123,7 @@ static void TestBnBSuccess(std::string test_title, std::vector<OutputGroup>& utx
 
     const auto result = SelectCoinsBnB(utxo_pool, selection_target, /*cost_of_change=*/cs_params.m_cost_of_change, max_selection_weight);
     BOOST_CHECK_MESSAGE(result, "Falsy result in BnB-Success: " + test_title);
-    BOOST_CHECK_MESSAGE(HaveEquivalentValues(expected_result, *result), strprintf("Result mismatch in BnB-Success: %s. Expected %s, but got %s", test_title, InputAmountsToString(expected_result), InputAmountsToString(*result)));
+    BOOST_CHECK_MESSAGE(HaveEquivalentInputs(expected_result, *result), strprintf("Result mismatch in BnB-Success: %s. Expected %s, but got %s", test_title, InputAmountsToString(expected_result), InputAmountsToString(*result)));
     BOOST_CHECK_MESSAGE(result->GetSelectedValue() == expected_amount, strprintf("Selected amount mismatch in BnB-Success: %s. Expected %d, but got %d", test_title, expected_amount, result->GetSelectedValue()));
     BOOST_CHECK_MESSAGE(result->GetWeight() <= max_selection_weight, strprintf("Selected weight is higher than permitted in BnB-Success: %s. Expected %d, but got %d", test_title, max_selection_weight, result->GetWeight()));
     BOOST_CHECK_MESSAGE(result->GetSelectionsEvaluated() == expected_attempts, strprintf("Unexpected number of attempts in BnB-Success: %s. Expected %i attempts, but got %i", test_title, expected_attempts, result->GetSelectionsEvaluated()));


### PR DESCRIPTION
This PR migrates the CoinGrinder tests from `coinselector_tests.cpp` to the new coin selection test suite `coinselection_tests.cpp` where we use effective values, actual feerates, and avoid setting coin selection parameters that never appear in production.

Most of the tests are exact replications of the originals in the new framework, just the CoinGrinder exhaustion test was slightly refactored to simplify: it was using different weights for every single UTXO, but just two different weights are sufficient to replicate the relevant behavior for the test.

Each commit migrates one test to simplify review.